### PR TITLE
bring back setDrawFPS

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,29 @@
+use std::process::Command;
+
 fn main() {
     println!("cargo:rustc-link-search=native=.");
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "macos")]
     {
         println!("cargo:rerun-if-changed=app.o");
         println!("cargo:rustc-link-lib=static=app.o");
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        println!("cargo:rerun-if-changed=app.o");
+
+        // Run the `ar rcs libapp.a app.o` command
+        let output = Command::new("ar")
+            .args(&["rcs", "libapp.a", "app.o"])
+            .output()
+            .expect("Failed to execute ar command");
+
+        if !output.status.success() {
+            panic!("ar command failed with status: {}", output.status);
+        }
+
+        println!("cargo:rustc-link-lib=static=app");
     }
 
     #[cfg(target_os = "windows")]

--- a/platform/Effect.roc
+++ b/platform/Effect.roc
@@ -78,7 +78,7 @@ MouseButtons : {
 mouseButtons : Task MouseButtons {}
 
 setTargetFPS : I32 -> Task {} {}
-setDrawFPS : Bool, F32, F32 -> Task {} {}
+setDrawFPS : Bool, I32, I32 -> Task {} {}
 
 takeScreenshot : Str -> Task {} {}
 

--- a/platform/Raylib.roc
+++ b/platform/Raylib.roc
@@ -167,7 +167,7 @@ setTargetFPS = \fps -> Effect.setTargetFPS fps |> Task.mapErr \{} -> crash "unre
 ## ```
 ## Raylib.setDrawFPS! { fps: Visible, posX: 10, posY: 10 }
 ## ```
-setDrawFPS : { fps : [Visible, Hidden], posX ? F32, posY ? F32 } -> Task {} *
+setDrawFPS : { fps : [Visible, Hidden], posX ? I32, posY ? I32 } -> Task {} *
 setDrawFPS = \{ fps, posX ? 10, posY ? 10 } ->
 
     showFps =


### PR DESCRIPTION
We get to do rust easy mode with mutable globals since everything is stuck on the UI thread anyway.
Also includes your statically linked linux build script.