### PR TITLE
New mouse API

### DIFF
--- a/examples/2d_camera.roc
+++ b/examples/2d_camera.roc
@@ -44,11 +44,11 @@ init =
     Task.ok { buildings, cameraID, cameraSettings }
 
 render : Model, PlatformState -> Task Model []
-render = \model, { mousePos } ->
+render = \model, { mouse } ->
 
     RocRay.drawMode2D! model.cameraID (Task.forEach model.buildings RocRay.drawRectangle)
 
-    cameraSettings = model.cameraSettings |> &target mousePos
+    cameraSettings = model.cameraSettings |> &target mouse.position
 
     RocRay.updateCamera! model.cameraID cameraSettings
 

--- a/examples/pong.roc
+++ b/examples/pong.roc
@@ -3,6 +3,7 @@ app [main, Model] {
 }
 
 import ray.RocRay exposing [Vector2]
+import ray.RocRay.Mouse as Mouse
 
 main = { init, render }
 
@@ -27,9 +28,9 @@ newBall = { pos: { x: width / 2, y: height / 2 }, vel: { x: 5, y: 2 } }
 
 init : Task Model []
 init =
-
-    RocRay.setBackgroundColor! Navy
+    RocRay.setTargetFPS! 60
     RocRay.setDrawFPS! { fps: Visible }
+    RocRay.setBackgroundColor! Navy
     RocRay.setWindowSize! { width, height }
     RocRay.setWindowTitle! "Pong"
 
@@ -66,7 +67,7 @@ bounce = \ball, pos ->
     { pos: { x: x2, y: y2 }, vel: { x: vx2, y: vy3 } }
 
 render : Model, RocRay.PlatformState -> Task Model []
-render = \model, { frameCount, keyboardButtons, mouseButtons, mousePos } ->
+render = \model, { frameCount, keyboardButtons, mouse } ->
 
     screenTask =
         if Set.contains keyboardButtons KeyLeftControl && Set.contains keyboardButtons KeyK then
@@ -89,7 +90,7 @@ render = \model, { frameCount, keyboardButtons, mouseButtons, mousePos } ->
 
         screenTask!
 
-        if Set.contains mouseButtons MouseButtonLeft then
+        if Mouse.pressed mouse.buttons.left then
             Task.ok { model & playing: Bool.true, score: 0 }
         else
             Task.ok model
@@ -101,12 +102,12 @@ render = \model, { frameCount, keyboardButtons, mouseButtons, mousePos } ->
 
         RocRay.drawText! { text: "Score: $(score)", x: 50, y: 50, size: 20, color: White }
 
-        pos = model.pos + (mousePos.y - model.pos) / 5
+        pos = model.pos + (mouse.position.y - model.pos) / 5
 
         RocRay.drawRectangle! { x: 0, y: pos, width: pw, height: paddle, color: Aqua }
         RocRay.drawRectangle! { x: model.ball.pos.x, y: model.ball.pos.y, width: ballSize, height: ballSize, color: Green }
 
-        drawCrossHair! mousePos
+        drawCrossHair! mouse.position
 
         ball = bounce (moveBall model.ball) model.pos
 

--- a/examples/squares.roc
+++ b/examples/squares.roc
@@ -38,12 +38,14 @@ init =
     }
 
 render : Model, PlatformState -> Task Model {}
-render = \model, { keyboardButtons, mouseButtons, mousePos } ->
+render = \model, { keyboardButtons, mouse } ->
 
     RocRay.drawText! { text: "Click on the screen ...", x: model.width - 400, y: model.height - 25, size: 20, color: White }
 
+    mousePos = mouse.position
+
     RocRay.drawText! {
-        text: "Mouse $(Num.toStr (Num.round mousePos.x)),$(Num.toStr (Num.round mousePos.y)), $(Inspect.toStr keyboardButtons), $(Inspect.toStr mouseButtons)",
+        text: "Mouse $(Num.toStr (Num.round mousePos.x)),$(Num.toStr (Num.round mousePos.y)), $(Inspect.toStr keyboardButtons), $(Inspect.toStr mouse.buttons)",
         x: 10,
         y: model.height - 25,
         size: 20,

--- a/platform/RocRay.roc
+++ b/platform/RocRay.roc
@@ -2,7 +2,6 @@ module [
     Program,
     PlatformState,
     KeyboardKey,
-    MouseButton,
     Color,
     Rectangle,
     Vector2,
@@ -30,9 +29,9 @@ module [
     log,
 ]
 
+import RocRay.Mouse as Mouse
 import Effect
 import InternalKeyboard
-import InternalMouse
 
 ## Provide an initial state and a render function to the platform.
 ## ```
@@ -50,13 +49,13 @@ PlatformState : {
     timestampMillis : U64,
     frameCount : U64,
     keyboardButtons : Set KeyboardKey,
-    mouseButtons : Set MouseButton,
-    mousePos : Vector2,
+    mouse : {
+        position : Vector2,
+        buttons : Mouse.Buttons,
+    },
 }
 
 KeyboardKey : InternalKeyboard.KeyboardKey
-
-MouseButton : InternalMouse.MouseButton
 
 ## Represents a rectangle.
 ## ```

--- a/platform/RocRay/Mouse.roc
+++ b/platform/RocRay/Mouse.roc
@@ -1,0 +1,43 @@
+module [Buttons, ButtonState, down, pressed, released, up]
+
+import Bool exposing [true, false]
+
+ButtonState : [Up, Down, Pressed, Released]
+
+Buttons : {
+    left : ButtonState,
+    right : ButtonState,
+    middle : ButtonState,
+    side : ButtonState,
+    extra : ButtonState,
+    forward : ButtonState,
+    back : ButtonState,
+}
+
+up : ButtonState -> Bool
+up = \state ->
+    when state is
+        Up -> true
+        Released -> true
+        Down -> false
+        Pressed -> false
+
+down : ButtonState -> Bool
+down = \state ->
+    when state is
+        Down -> true
+        Pressed -> true
+        Up -> false
+        Released -> false
+
+pressed : ButtonState -> Bool
+pressed = \state ->
+    when state is
+        Pressed -> true
+        _ -> false
+
+released : ButtonState -> Bool
+released = \state ->
+    when state is
+        Released -> true
+        _ -> false

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -6,6 +6,7 @@ platform "roc-ray"
     provides [forHost]
 
 import RocRay exposing [Program]
+import RocRay.Mouse as Mouse
 import InternalKeyboard
 import InternalMouse
 import Effect
@@ -14,7 +15,10 @@ PlatformStateFromHost : {
     timestampMillis : U64,
     frameCount : U64,
     keysDownU64 : List U64,
-    mouseDownU64 : List U64,
+    mouseDownBool : List Bool,
+    mousePressedBool : List Bool,
+    mouseReleasedBool : List Bool,
+    mouseUpBool : List Bool,
     mousePosX : F32,
     mousePosY : F32,
 }
@@ -42,20 +46,56 @@ render = \boxedModel, platformState ->
 
     model = Box.unbox boxedModel
 
-    { timestampMillis, frameCount, keysDownU64, mouseDownU64, mousePosX, mousePosY } = platformState
+    { timestampMillis, frameCount, keysDownU64, mouseDownBool, mousePressedBool, mouseUpBool, mouseReleasedBool, mousePosX, mousePosY } = platformState
 
-    keyboardButtons = keysDownU64 |> List.map InternalKeyboard.keyFromU64 |> Set.fromList
-    mouseButtons = mouseDownU64 |> List.map InternalMouse.mouseButtonFromU64 |> Set.fromList
+    mouseFlagsToSet : List Bool -> Set InternalMouse.MouseButton
+    mouseFlagsToSet = \flags ->
+        flags
+        |> List.mapWithIndex \flagged, i -> (flagged, i)
+        |> List.keepOks \(flagged, i) ->
+            if flagged then Ok (InternalMouse.mouseButtonFromU64 i) else Err Other
+        |> Set.fromList
+
+    mouseButtonSets = {
+        down: mouseFlagsToSet mouseDownBool,
+        up: mouseFlagsToSet mouseUpBool,
+        pressed: mouseFlagsToSet mousePressedBool,
+        released: mouseFlagsToSet mouseReleasedBool,
+    }
+
+    mouseButtons : Mouse.Buttons
+    mouseButtons =
+        stateOf = \button ->
+            if Set.contains mouseButtonSets.pressed button then
+                Pressed
+            else if Set.contains mouseButtonSets.released button then
+                Released
+            else if Set.contains mouseButtonSets.down button then
+                Down
+            else
+                Up
+
+        {
+            left: stateOf MouseButtonLeft,
+            right: stateOf MouseButtonRight,
+            middle: stateOf MouseButtonMiddle,
+            side: stateOf MouseButtonSide,
+            extra: stateOf MouseButtonExtra,
+            forward: stateOf MouseButtonForward,
+            back: stateOf MouseButtonBack,
+        }
+
+    keyboardButtons =
+        keysDownU64 |> List.map InternalKeyboard.keyFromU64 |> Set.fromList
 
     state : RocRay.PlatformState
     state = {
         timestampMillis,
         frameCount,
         keyboardButtons,
-        mouseButtons,
-        mousePos: {
-            x: mousePosX,
-            y: mousePosY,
+        mouse: {
+            position: { x: mousePosX, y: mousePosY },
+            buttons: mouseButtons,
         },
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use roc_std::{RocBox, RocList, RocResult, RocStr};
 use roc_std_heap::ThreadSafeRefcountedResourceHeap;
+use std::array;
 use std::cell::Cell;
 use std::ffi::{c_int, CString};
 use std::time::SystemTime;
@@ -43,7 +44,10 @@ fn main() {
                 timestamp_millis: timestamp,
                 frame_count,
                 keys_down: RocList::empty(),
-                mouse_down: RocList::empty(),
+                mouse_down: get_mouse_down(),
+                mouse_pressed: get_mouse_pressed(),
+                mouse_released: get_mouse_released(),
+                mouse_up: get_mouse_up(),
                 mouse_pos_x: bindings::GetMouseX() as f32,
                 mouse_pos_y: bindings::GetMouseY() as f32,
             };
@@ -371,81 +375,22 @@ unsafe extern "C" fn roc_fx_endMode2D(_boxed_camera: RocBox<()>) -> RocResult<()
     RocResult::ok(())
 }
 
-// fn update_keys_down() !void {
-//     var key = rl.getKeyPressed();
+unsafe fn get_mouse_down() -> RocList<bool> {
+    let mouse_buttons: [bool; 7] = array::from_fn(|i| bindings::IsMouseButtonDown(i as c_int));
+    RocList::from_slice(&mouse_buttons)
+}
 
-//     // insert newly pressed keys
-//     while (key != rl.KeyboardKey.key_null) {
-//         try keys_down.put(key, true);
-//         key = rl.getKeyPressed();
-//     }
+unsafe fn get_mouse_pressed() -> RocList<bool> {
+    let mouse_buttons: [bool; 7] = array::from_fn(|i| bindings::IsMouseButtonPressed(i as c_int));
+    RocList::from_slice(&mouse_buttons)
+}
 
-//     // check all keys that are marked "down" and update if they have been released
-//     var iter = keys_down.iterator();
-//     while (iter.next()) |kv| {
-//         if (kv.value_ptr.*) {
-//             const k = kv.key_ptr.*;
-//             if (!rl.isKeyDown(k)) {
-//                 try keys_down.put(k, false);
-//             }
-//         } else {
-//             // key hasn't been pressed, ignore it
-//         }
-//     }
-// }
+unsafe fn get_mouse_up() -> RocList<bool> {
+    let mouse_buttons: [bool; 7] = array::from_fn(|i| bindings::IsMouseButtonUp(i as c_int));
+    RocList::from_slice(&mouse_buttons)
+}
 
-// fn get_keys_down() RocList {
-
-//     // store the keys pressed as we read from the queue... assume max 1000 queued
-//     var key_queue: [1000]u64 = undefined;
-//     var count: u64 = 0;
-
-//     var iter = keys_down.iterator();
-//     while (iter.next()) |kv| {
-//         if (kv.value_ptr.*) {
-//             key_queue[count] = @intCast(@intFromEnum(kv.key_ptr.*));
-//             count = count + 1;
-//         } else {
-//             // key hasn't been pressed, ignore it
-//         }
-//     }
-
-//     return RocList.fromSlice(u64, key_queue[0..count], false);
-// }
-
-// fn get_mouse_down() RocList {
-//     var mouse_down: [6]u64 = undefined;
-//     var count: u64 = 0;
-
-//     if (rl.isMouseButtonDown(rl.MouseButton.mouse_button_left)) {
-//         mouse_down[count] = @intCast(@intFromEnum(rl.MouseButton.mouse_button_left));
-//         count += 1;
-//     }
-
-//     if (rl.isMouseButtonDown(rl.MouseButton.mouse_button_right)) {
-//         mouse_down[count] = @intCast(@intFromEnum(rl.MouseButton.mouse_button_right));
-//         count += 1;
-//     }
-//     if (rl.isMouseButtonDown(rl.MouseButton.mouse_button_middle)) {
-//         mouse_down[count] = @intCast(@intFromEnum(rl.MouseButton.mouse_button_middle));
-//         count += 1;
-//     }
-//     if (rl.isMouseButtonDown(rl.MouseButton.mouse_button_side)) {
-//         mouse_down[count] = @intCast(@intFromEnum(rl.MouseButton.mouse_button_side));
-//         count += 1;
-//     }
-//     if (rl.isMouseButtonDown(rl.MouseButton.mouse_button_extra)) {
-//         mouse_down[count] = @intCast(@intFromEnum(rl.MouseButton.mouse_button_extra));
-//         count += 1;
-//     }
-//     if (rl.isMouseButtonDown(rl.MouseButton.mouse_button_forward)) {
-//         mouse_down[count] = @intCast(@intFromEnum(rl.MouseButton.mouse_button_forward));
-//         count += 1;
-//     }
-//     if (rl.isMouseButtonDown(rl.MouseButton.mouse_button_back)) {
-//         mouse_down[count] = @intCast(@intFromEnum(rl.MouseButton.mouse_button_back));
-//         count += 1;
-//     }
-
-//     return RocList.fromSlice(u64, mouse_down[0..count], false);
-// }
+unsafe fn get_mouse_released() -> RocList<bool> {
+    let mouse_buttons: [bool; 7] = array::from_fn(|i| bindings::IsMouseButtonReleased(i as c_int));
+    RocList::from_slice(&mouse_buttons)
+}

--- a/src/roc.rs
+++ b/src/roc.rs
@@ -116,7 +116,10 @@ unsafe impl Sync for Model {}
 pub struct PlatformState {
     pub frame_count: u64,
     pub keys_down: roc_std::RocList<u64>,
-    pub mouse_down: roc_std::RocList<u64>,
+    pub mouse_down: roc_std::RocList<bool>,
+    pub mouse_pressed: roc_std::RocList<bool>,
+    pub mouse_released: roc_std::RocList<bool>,
+    pub mouse_up: roc_std::RocList<bool>,
     pub timestamp_millis: u64,
     pub mouse_pos_x: f32,
     pub mouse_pos_y: f32,


### PR DESCRIPTION
This adds mouse state passed as an (ordered) list of bools, where the index represents the Raylib enum. We could replace that platform-internal type with a bitset down the line. The Raylib.Mouse module is intended to be the public user-friendly one.