### PR TITLE
Complete 2d_camera example, add MouseWheel

### DIFF
--- a/examples/2d_camera.roc
+++ b/examples/2d_camera.roc
@@ -5,14 +5,16 @@ app [main, Model] {
 }
 
 import ray.RocRay exposing [PlatformState, Vector2, Rectangle, Color, Camera]
+import ray.RocRay.Keys as Keys
 import rand.Random
 
 main = { init, render }
 
-screenWidth = 800f32
-screenHeight = 800f32
+screenWidth = 800
+screenHeight = 450
 
 Model : {
+    player : { x : F32, y : F32 },
     buildings : List { rect : Rectangle, color : Color },
     cameraSettings : {
         target : Vector2,
@@ -26,12 +28,15 @@ Model : {
 init : Task Model []
 init =
 
+    RocRay.setTargetFPS! 60
     RocRay.setDrawFPS! { fps: Visible }
     RocRay.setWindowSize! { width: screenWidth, height: screenHeight }
     RocRay.setWindowTitle! "2D Camera Example"
 
+    player = { x: 400, y: 280 }
+
     cameraSettings = {
-        target: { x: 20, y: 20 },
+        target: player,
         offset: { x: screenWidth / 2, y: screenHeight / 2 },
         rotation: 0,
         zoom: 1,
@@ -41,23 +46,106 @@ init =
 
     buildings = generateBuildings
 
-    Task.ok { buildings, cameraID, cameraSettings }
+    Task.ok {
+        player,
+        buildings,
+        cameraID,
+        cameraSettings,
+    }
 
 render : Model, PlatformState -> Task Model []
-render = \model, { mouse } ->
+render = \model, { mouse, keys } ->
 
-    RocRay.drawMode2D! model.cameraID (Task.forEach model.buildings RocRay.drawRectangle)
+    # RENDER WORLD
+    RocRay.drawMode2D! model.cameraID (drawWorld model)
 
-    cameraSettings = model.cameraSettings |> &target mouse.position
+    # RENDER SCREEN UI
+    drawScreenUI!
+
+    rotation =
+        (
+            if Keys.down keys KeyA then
+                model.cameraSettings.rotation - 1
+            else if Keys.down keys KeyS then
+                model.cameraSettings.rotation + 1
+            else
+                model.cameraSettings.rotation
+        )
+        |> limit { upper: 40, lower: -40 }
+        |> \r -> if Keys.pressed keys KeyR then 0 else r
+
+    zoom =
+        (model.cameraSettings.zoom + (mouse.wheel * 0.05))
+        |> limit { upper: 3, lower: 0.1 }
+        |> \z -> if Keys.pressed keys KeyR then 1 else z
+
+    cameraSettings =
+        model.cameraSettings
+        |> &target model.player
+        |> &rotation rotation
+        |> &zoom zoom
 
     RocRay.updateCamera! model.cameraID cameraSettings
 
-    Task.ok { model & cameraSettings }
+    player =
+        if Keys.down keys KeyLeft then
+            { x: model.player.x - 10, y: model.player.y }
+        else if Keys.down keys KeyRight then
+            { x: model.player.x + 10, y: model.player.y }
+        else
+            model.player
+
+    Task.ok { model & cameraSettings, player }
+
+drawWorld : Model -> Task {} _
+drawWorld = \model ->
+
+    # BACKGROUND
+    RocRay.drawRectangle! { rect: { x: -6000, y: 320, width: 13000, height: 8000 }, color: Gray }
+
+    # BUILDINGS
+    Task.forEach! model.buildings RocRay.drawRectangle
+
+    # PLAYER
+    playerWidth = 40
+    playerHeight = 80
+
+    RocRay.drawRectangle! {
+        rect: {
+            x: model.player.x - (playerWidth / 2),
+            y: model.player.y - (playerHeight / 2),
+            width: playerWidth,
+            height: playerHeight,
+        },
+        color: Red,
+    }
+
+    # PLAYER CROSSHAIR
+    RocRay.drawLine! { start: { x: model.player.x, y: -screenHeight * 10 }, end: { x: model.player.x, y: screenHeight * 10 }, color: Yellow }
+    RocRay.drawLine! { start: { x: -screenWidth * 10, y: model.player.y }, end: { x: screenWidth * 10, y: model.player.y }, color: Yellow }
+
+drawScreenUI : Task {} _
+drawScreenUI =
+
+    RocRay.drawText! { pos: { x: 640, y: 10 }, text: "SCREEN AREA", size: 20, color: Red }
+
+    RocRay.drawRectangle! { rect: { x: 0, y: 0, width: screenWidth, height: 5 }, color: Red }
+    RocRay.drawRectangle! { rect: { x: 0, y: 5, width: 5, height: screenHeight - 10 }, color: Red }
+    RocRay.drawRectangle! { rect: { x: screenWidth - 5, y: 5, width: 5, height: screenHeight - 10 }, color: Red }
+    RocRay.drawRectangle! { rect: { x: 0, y: screenHeight - 5, width: screenWidth, height: 5 }, color: Red }
+
+    RocRay.drawRectangle! { rect: { x: 10, y: 20, width: 250, height: 113 }, color: RGBA 116 255 255 128 }
+
+    RocRay.drawText! { pos: { x: 20, y: 30 }, text: "Free 2d camera controls:", size: 10, color: Black }
+    RocRay.drawText! { pos: { x: 40, y: 50 }, text: "- Right/Left to move Offset", size: 10, color: Black }
+    RocRay.drawText! { pos: { x: 40, y: 70 }, text: "- Mouse Wheel to Zoom in-out", size: 10, color: Black }
+    RocRay.drawText! { pos: { x: 40, y: 90 }, text: "- A / S to Rotate", size: 10, color: Black }
+    RocRay.drawText! { pos: { x: 40, y: 110 }, text: "- R to reset Zoom and Rotation", size: 10, color: Black }
 
 generateBuildings : List { rect : Rectangle, color : Color }
 generateBuildings =
     List.range { start: At 0, end: Before 100 }
-    |> List.walk { seed: Random.seed 1234u32, rects: [], nextX: -6000f32 } \state, _ ->
+    |> List.walk { seed: Random.seed 1234, rects: [], nextX: -6000 } \state, _ ->
 
         bldgGen = Random.step state.seed randomBuilding
 
@@ -65,7 +153,7 @@ generateBuildings =
 
         rect = {
             x: state.nextX,
-            y: screenHeight - 130f32 - bldg.rect.height,
+            y: screenHeight - 130 - bldg.rect.height,
             width: bldg.rect.width,
             height: bldg.rect.height,
         }
@@ -79,8 +167,8 @@ randomBuilding : Random.Generator { rect : Rectangle, color : Color }
 randomBuilding =
     { Random.chain <-
         rect: { Random.chain <-
-            x: Random.static 0f32,
-            y: Random.static 0f32,
+            x: Random.static 0,
+            y: Random.static 0,
             width: Random.boundedU16 50 200 |> Random.map Num.toF32,
             height: Random.boundedU16 100 800 |> Random.map Num.toF32,
         }
@@ -92,3 +180,12 @@ randomBuilding =
         }
         |> Random.map \{ red, green, blue } -> RGBA red green blue 255,
     }
+
+limit : F32, { upper : F32, lower : F32 } -> F32
+limit = \value, { upper, lower } ->
+    if value > upper then
+        upper
+    else if value < lower then
+        lower
+    else
+        value

--- a/platform/Effect.roc
+++ b/platform/Effect.roc
@@ -73,8 +73,8 @@ setDrawFPS : Bool, I32, I32 -> Task {} {}
 
 takeScreenshot : Str -> Task {} {}
 
-createCamera : F32, F32, F32, F32, F32, F32 -> Task U64 {}
-updateCamera : U64, F32, F32, F32, F32, F32, F32 -> Task {} {}
+createCamera : RocVector2, RocVector2, F32, F32 -> Task U64 {}
+updateCamera : U64, RocVector2, RocVector2, F32, F32 -> Task {} {}
 
 beginMode2D : U64 -> Task {} {}
 endMode2D : U64 -> Task {} {}

--- a/platform/RocRay.roc
+++ b/platform/RocRay.roc
@@ -62,6 +62,7 @@ PlatformState : {
     mouse : {
         position : Vector2,
         buttons : Mouse.Buttons,
+        wheel : F32,
     },
 }
 
@@ -261,13 +262,13 @@ Camera := U64
 
 createCamera : { target : Vector2, offset : Vector2, rotation : F32, zoom : F32 } -> Task Camera *
 createCamera = \{ target, offset, rotation, zoom } ->
-    Effect.createCamera target.x target.y offset.x offset.y rotation zoom
+    Effect.createCamera (InternalVector.fromVector2 target) (InternalVector.fromVector2 offset) rotation zoom
     |> Task.map \camera -> @Camera camera
     |> Task.mapErr \{} -> crash "unreachable createCamera"
 
 updateCamera : Camera, { target : Vector2, offset : Vector2, rotation : F32, zoom : F32 } -> Task {} *
 updateCamera = \@Camera camera, { target, offset, rotation, zoom } ->
-    Effect.updateCamera camera target.x target.y offset.x offset.y rotation zoom
+    Effect.updateCamera camera (InternalVector.fromVector2 target) (InternalVector.fromVector2 offset) rotation zoom
     |> Task.mapErr \{} -> crash "unreachable updateCamera"
 
 drawMode2D : Camera, Task {} err -> Task {} err

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -19,6 +19,7 @@ PlatformStateFromHost : {
     timestampMillis : U64,
     mousePosX : F32,
     mousePosY : F32,
+    mouseWheel : F32,
 }
 
 ProgramForHost model : {
@@ -43,7 +44,7 @@ render : Box Model, PlatformStateFromHost -> Task (Box Model) {}
 render = \boxedModel, platformState ->
     model = Box.unbox boxedModel
 
-    { timestampMillis, frameCount, keys, mouseButtons, mousePosX, mousePosY } = platformState
+    { timestampMillis, frameCount, keys, mouseButtons, mousePosX, mousePosY, mouseWheel } = platformState
 
     state : RocRay.PlatformState
     state = {
@@ -53,6 +54,7 @@ render = \boxedModel, platformState ->
         mouse: {
             position: { x: mousePosX, y: mousePosY },
             buttons: mouseButtonsForApp { mouseButtons },
+            wheel: mouseWheel,
         },
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ fn main() {
                 timestamp_millis: timestamp,
                 mouse_pos_x: bindings::GetMouseX() as f32,
                 mouse_pos_y: bindings::GetMouseY() as f32,
+                mouse_wheel: bindings::GetMouseWheelMove(),
             };
 
             model = roc::call_roc_render(platform_state, &model);
@@ -234,22 +235,14 @@ unsafe extern "C" fn roc_fx_setDrawFPS(show: bool, pos_x: i32, pos_y: i32) -> Ro
 
 #[no_mangle]
 unsafe extern "C" fn roc_fx_createCamera(
-    target_x: f32,
-    target_y: f32,
-    offset_x: f32,
-    offset_y: f32,
+    target: &glue::RocVector2,
+    offset: &glue::RocVector2,
     rotation: f32,
     zoom: f32,
 ) -> RocResult<RocBox<()>, ()> {
     let camera = bindings::Camera2D {
-        target: bindings::Vector2 {
-            x: target_x,
-            y: target_y,
-        },
-        offset: bindings::Vector2 {
-            x: offset_x,
-            y: offset_y,
-        },
+        target: target.into(),
+        offset: offset.into(),
         rotation,
         zoom,
     };
@@ -267,24 +260,16 @@ unsafe extern "C" fn roc_fx_createCamera(
 #[no_mangle]
 unsafe extern "C" fn roc_fx_updateCamera(
     boxed_camera: RocBox<()>,
-    target_x: f32,
-    target_y: f32,
-    offset_x: f32,
-    offset_y: f32,
+    target: &glue::RocVector2,
+    offset: &glue::RocVector2,
     rotation: f32,
     zoom: f32,
 ) -> RocResult<(), ()> {
     let camera: &mut bindings::Camera2D =
         ThreadSafeRefcountedResourceHeap::box_to_resource(boxed_camera);
 
-    camera.target = bindings::Vector2 {
-        x: target_x,
-        y: target_y,
-    };
-    camera.offset = bindings::Vector2 {
-        x: offset_x,
-        y: offset_y,
-    };
+    camera.target = target.into();
+    camera.offset = offset.into();
     camera.rotation = rotation;
     camera.zoom = zoom;
 

--- a/src/roc.rs
+++ b/src/roc.rs
@@ -162,6 +162,7 @@ pub struct PlatformState {
     pub timestamp_millis: u64,
     pub mouse_pos_x: f32,
     pub mouse_pos_y: f32,
+    pub mouse_wheel: f32,
 }
 
 impl roc_std::RocRefcounted for PlatformState {


### PR DESCRIPTION
This PR completes the raylib 2d camera core example, and adds support for `mouse.wheel` movement 

![roc-ray-9](https://github.com/user-attachments/assets/ac434443-f202-47a6-a4b6-de173f1583af)
