### PR TITLE
Tracking valid states in host

### DIFF
--- a/examples/2d_camera.roc
+++ b/examples/2d_camera.roc
@@ -56,12 +56,7 @@ init =
 render : Model, PlatformState -> Task Model []
 render = \model, { mouse, keys } ->
 
-    # RENDER WORLD
-    RocRay.drawMode2D! model.cameraID (drawWorld model)
-
-    # RENDER SCREEN UI
-    drawScreenUI!
-
+    # UPDATE CAMERA
     rotation =
         (
             if Keys.down keys KeyA then
@@ -87,6 +82,7 @@ render = \model, { mouse, keys } ->
 
     RocRay.updateCamera! model.cameraID cameraSettings
 
+    # UPDATE PLAYER
     player =
         if Keys.down keys KeyLeft then
             { x: model.player.x - 10, y: model.player.y }
@@ -94,6 +90,17 @@ render = \model, { mouse, keys } ->
             { x: model.player.x + 10, y: model.player.y }
         else
             model.player
+
+    # RENDER FRAMEBUFFER
+    RocRay.beginDrawing! White
+
+    # RENDER WORLD
+    RocRay.drawMode2D! model.cameraID (drawWorld model)
+
+    # RENDER SCREEN UI
+    drawScreenUI!
+
+    RocRay.endDrawing!
 
     Task.ok { model & cameraSettings, player }
 

--- a/examples/audio.roc
+++ b/examples/audio.roc
@@ -17,8 +17,6 @@ Model : {
 init =
 
     RocRay.setTargetFPS! 60
-
-    RocRay.setBackgroundColor! White
     RocRay.setWindowSize! { width: 800, height: 450 }
     RocRay.setWindowTitle! "Making Sounds"
 
@@ -34,6 +32,8 @@ init =
 
 render : Model, RocRay.PlatformState -> Task Model []
 render = \model, { keys } ->
+
+    RocRay.beginDrawing! White
 
     RocRay.drawText! {
         text: "Press SPACE to PLAY the WAV sound",
@@ -56,6 +56,8 @@ render = \model, { keys } ->
             Play model.ogg
         else
             None
+
+    RocRay.endDrawing!
 
     when chosenSound is
         Play sound ->

--- a/examples/basic-shapes.roc
+++ b/examples/basic-shapes.roc
@@ -19,6 +19,8 @@ init =
 
 render = \_, _ ->
 
+    RocRay.beginDrawing! White
+
     RocRay.drawText! { pos: { x: 300, y: 50 }, text: "Hello World", size: 40, color: Navy }
     RocRay.drawRectangle! { rect: { x: 100, y: 150, width: 250, height: 100 }, color: Aqua }
     RocRay.drawRectangleGradientH! { rect: { x: 400, y: 150, width: 250, height: 100 }, top: Lime, bottom: Navy }
@@ -26,5 +28,7 @@ render = \_, _ ->
     RocRay.drawCircle! { center: { x: 200, y: 400 }, radius: 75, color: Fuchsia }
     RocRay.drawCircleGradient! { center: { x: 600, y: 400 }, radius: 75, inner: Yellow, outer: Maroon }
     RocRay.drawLine! { start: { x: 100, y: 500 }, end: { x: 500, y: 500 }, color: Red }
+
+    RocRay.endDrawing!
 
     Task.ok {}

--- a/examples/pong.roc
+++ b/examples/pong.roc
@@ -2,9 +2,8 @@ app [main, Model] {
     ray: platform "../platform/main.roc",
 }
 
-import ray.RocRay exposing [Vector2]
+import ray.RocRay exposing [Vector2, PlatformState]
 import ray.RocRay.Mouse as Mouse
-import ray.RocRay.Keys as Keys
 
 main = { init, render }
 
@@ -31,7 +30,6 @@ init : Task Model []
 init =
     RocRay.setTargetFPS! 60
     RocRay.setDrawFPS! { fps: Visible }
-    RocRay.setBackgroundColor! Navy
     RocRay.setWindowSize! { width, height }
     RocRay.setWindowTitle! "Pong"
 
@@ -67,57 +65,66 @@ bounce = \ball, pos ->
 
     { pos: { x: x2, y: y2 }, vel: { x: vx2, y: vy3 } }
 
-render : Model, RocRay.PlatformState -> Task Model []
-render = \model, { frameCount, keys, mouse } ->
-
-    screenTask =
-        if Keys.down keys KeyLeftControl && Keys.down keys KeyK then
-            RocRay.takeScreenshot "saved-$(Num.toStr frameCount).png"
-        else
-            Task.ok {}
+render : Model, PlatformState -> Task Model []
+render = \model, state ->
 
     if !model.playing then
-        RocRay.drawText! { pos: { x: 50, y: 120 }, text: "Click to start", size: 20, color: White }
+        # DRAW START MENU
+        drawGameStartMenu! model
 
-        maxScore = model.maxScore |> Num.toStr
-
-        RocRay.drawText! { pos: { x: 50, y: 50 }, text: "Max Score: $(maxScore)", size: 20, color: White }
-
-        score = model.score |> Num.toStr
-
-        RocRay.drawText! { pos: { x: 50, y: 80 }, text: "Last Score: $(score)", size: 20, color: White }
-
-        RocRay.drawText! { pos: { x: 50, y: 150 }, text: "Ctrl-K to Screenshot to 'saved.png'", size: 20, color: White }
-
-        screenTask!
-
-        if Mouse.pressed mouse.buttons.left then
+        if Mouse.pressed state.mouse.buttons.left then
             Task.ok { model & playing: Bool.true, score: 0 }
         else
             Task.ok model
     else
         # Increase the speed of the ball, starts getting crazy after a minute... just for a bit of fun
-        RocRay.setTargetFPS! (60 + ((Num.toFrac frameCount) / 60 |> Num.floor |> Num.toI32))
+        RocRay.setTargetFPS! (60 + ((Num.toFrac state.frameCount) / 60 |> Num.floor |> Num.toI32))
 
-        score = model.score |> Num.toStr
-
-        RocRay.drawText! { pos: { x: 50, y: 50 }, text: "Score: $(score)", size: 20, color: White }
-
-        newY = model.pos + (Num.toF32 mouse.position.y - model.pos) / 5
-
-        RocRay.drawRectangle! { rect: { x: 0, y: newY, width: pw, height: paddle }, color: Aqua }
-        RocRay.drawRectangle! { rect: { x: model.ball.pos.x, y: model.ball.pos.y, width: ballSize, height: ballSize }, color: Green }
-
-        drawCrossHair! mouse.position
+        # DRAW GAME
+        drawGamePlaying! model state
 
         ball = bounce (moveBall model.ball) model.pos
-
-        screenTask!
+        newY = model.pos + (Num.toF32 state.mouse.position.y - model.pos) / 5
 
         if ball.pos.x <= 0 then
             Task.ok { model & pos: newY, ball: newBall, maxScore: Num.max model.score model.maxScore, playing: Bool.false }
         else
             Task.ok { model & pos: newY, ball: ball, score: model.score + 1 }
+
+drawGameStartMenu : Model -> Task {} _
+drawGameStartMenu = \model ->
+
+    RocRay.beginDrawing! Navy
+
+    RocRay.drawText! { pos: { x: 50, y: 120 }, text: "Click to start", size: 20, color: White }
+
+    maxScore = model.maxScore |> Num.toStr
+
+    RocRay.drawText! { pos: { x: 50, y: 50 }, text: "Max Score: $(maxScore)", size: 20, color: White }
+
+    score = model.score |> Num.toStr
+
+    RocRay.drawText! { pos: { x: 50, y: 80 }, text: "Last Score: $(score)", size: 20, color: White }
+
+    RocRay.endDrawing!
+
+drawGamePlaying : Model, PlatformState -> Task {} _
+drawGamePlaying = \model, { mouse } ->
+
+    RocRay.beginDrawing! Navy
+
+    score = model.score |> Num.toStr
+
+    RocRay.drawText! { pos: { x: 50, y: 50 }, text: "Score: $(score)", size: 20, color: White }
+
+    newY = model.pos + (Num.toF32 mouse.position.y - model.pos) / 5
+
+    RocRay.drawRectangle! { rect: { x: 0, y: newY, width: pw, height: paddle }, color: Aqua }
+    RocRay.drawRectangle! { rect: { x: model.ball.pos.x, y: model.ball.pos.y, width: ballSize, height: ballSize }, color: Green }
+
+    drawCrossHair! mouse.position
+
+    RocRay.endDrawing!
 
 drawCrossHair : Vector2 -> Task {} []
 drawCrossHair = \mousePos ->

--- a/examples/random.roc
+++ b/examples/random.roc
@@ -42,6 +42,8 @@ init =
 render : Model, PlatformState -> Task Model {}
 render = \model, { keys, timestampMillis } ->
 
+    RocRay.beginDrawing! Black
+
     nowStr = DateTime.fromNanosSinceEpoch (timestampMillis * 1000) |> DateTime.toIsoStr
 
     RocRay.drawText! { pos: { x: 10, y: 50 }, text: "DateTime $(nowStr)", size: 20, color: White }
@@ -53,6 +55,8 @@ render = \model, { keys, timestampMillis } ->
     Task.forEach! lines RocRay.drawRectangle
 
     RocRay.drawText! { pos: { x: 10, y: model.height - 25 }, text: "Up-Down to change number of random dots, current value is $(Num.toStr model.number)", size: 20, color: White }
+
+    RocRay.endDrawing!
 
     if Keys.down keys KeyUp then
         Task.ok { model & seed, number: Num.addSaturated model.number 10 }

--- a/examples/sprites.roc
+++ b/examples/sprites.roc
@@ -21,7 +21,6 @@ init =
     RocRay.setTargetFPS! 60
     RocRay.setWindowSize! { width, height }
     RocRay.setWindowTitle! "Animated Sprite Example"
-    RocRay.setBackgroundColor! White
 
     dude = RocRay.loadTexture! "examples/assets/sprite-dude/sheet.png"
 
@@ -39,6 +38,8 @@ init =
 render : Model, PlatformState -> Task Model _
 render = \model, { timestampMillis, keys } ->
 
+    RocRay.beginDrawing! White
+
     dudeAnimation = updateAnimation model.dudeAnimation timestampMillis
 
     RocRay.drawText! { pos: { x: 10, y: 10 }, text: "Rocci the Cool Dude", size: 40, color: Navy }
@@ -50,6 +51,8 @@ render = \model, { timestampMillis, keys } ->
         pos: model.player,
         tint: White,
     }
+
+    RocRay.endDrawing!
 
     (player, direction) =
         if Keys.down keys KeyUp then

--- a/examples/squares.roc
+++ b/examples/squares.roc
@@ -11,12 +11,13 @@ Program : {
 }
 
 Model : {
-    width : F32,
-    height : F32,
     squares : List Rectangle,
     status : [Ready, AfterClick RocRay.Vector2],
     circlePos : RocRay.Vector2,
 }
+
+width = 900
+height = 400
 
 main : Program
 main = { init, render }
@@ -24,15 +25,10 @@ main = { init, render }
 init : Task Model {}
 init =
 
-    width = 900f32
-    height = 400f32
-
     RocRay.setWindowSize! { width, height }
     RocRay.setWindowTitle! "Squares Demo"
 
     Task.ok {
-        width,
-        height,
         circlePos: { x: width / 2, y: height / 2 },
         squares: [],
         status: Ready,
@@ -41,14 +37,16 @@ init =
 render : Model, PlatformState -> Task Model {}
 render = \model, { keys, mouse } ->
 
-    RocRay.drawText! { pos: { x: model.width - 400, y: model.height - 25 }, text: "Click on the screen ...", size: 20, color: White }
+    RocRay.beginDrawing! Black
+
+    RocRay.drawText! { pos: { x: width - 400, y: height - 25 }, text: "Click on the screen ...", size: 20, color: White }
 
     mousePos = mouse.position
 
     RocRay.drawText! {
         pos: {
             x: 10,
-            y: model.height - 25,
+            y: height - 25,
         },
         text: "Mouse $(Num.toStr mousePos.x),$(Num.toStr mousePos.y), $(Inspect.toStr keys), $(Inspect.toStr mouse.buttons)",
         size: 20,
@@ -58,6 +56,8 @@ render = \model, { keys, mouse } ->
     RocRay.drawRectangle! { rect: { x: Num.toF32 mousePos.x - 10, y: Num.toF32 mousePos.y - 10, width: 20, height: 20 }, color: Red }
 
     RocRay.drawRectangle! { rect: { x: model.circlePos.x, y: model.circlePos.y, width: 50, height: 50 }, color: Aqua }
+
+    RocRay.endDrawing!
 
     newCirclePos =
         if Keys.down keys KeyUp then

--- a/examples/squares.roc
+++ b/examples/squares.roc
@@ -48,14 +48,14 @@ render = \model, { keys, mouse } ->
             x: 10,
             y: height - 25,
         },
-        text: "Mouse $(Num.toStr mousePos.x),$(Num.toStr mousePos.y), $(Inspect.toStr keys), $(Inspect.toStr mouse.buttons)",
+        text: "Mouse $(Num.toStr mousePos.x),$(Num.toStr mousePos.y)",
         size: 20,
         color: White,
     }
 
     RocRay.drawRectangle! { rect: { x: Num.toF32 mousePos.x - 10, y: Num.toF32 mousePos.y - 10, width: 20, height: 20 }, color: Red }
 
-    RocRay.drawRectangle! { rect: { x: model.circlePos.x, y: model.circlePos.y, width: 50, height: 50 }, color: Aqua }
+    RocRay.drawCircle! { center: model.circlePos, radius: 50, color: Aqua }
 
     RocRay.endDrawing!
 

--- a/platform/Effect.roc
+++ b/platform/Effect.roc
@@ -8,7 +8,6 @@ hosted Effect
         drawText,
         measureText,
         setWindowTitle,
-        setBackgroundColor,
         drawLine,
         drawRectangle,
         drawRectangleGradientV,
@@ -20,6 +19,8 @@ hosted Effect
         takeScreenshot,
         createCamera,
         updateCamera,
+        beginDrawing,
+        endDrawing,
         beginMode2D,
         endMode2D,
         log,
@@ -58,7 +59,6 @@ drawText : RocVector2, I32, Str, RocColor -> Task {} {}
 measureText : Str, I32 -> Task I64 {}
 
 setWindowTitle : Str -> Task {} {}
-setBackgroundColor : RocColor -> Task {} {}
 
 drawLine : RocVector2, RocVector2, RocColor -> Task {} {}
 
@@ -76,6 +76,8 @@ takeScreenshot : Str -> Task {} {}
 createCamera : RocVector2, RocVector2, F32, F32 -> Task U64 {}
 updateCamera : U64, RocVector2, RocVector2, F32, F32 -> Task {} {}
 
+beginDrawing : RocColor -> Task {} {}
+endDrawing : Task {} {}
 beginMode2D : U64 -> Task {} {}
 endMode2D : U64 -> Task {} {}
 

--- a/platform/RocRay.roc
+++ b/platform/RocRay.roc
@@ -10,7 +10,6 @@ module [
     Sound,
     setWindowSize,
     getScreenSize,
-    setBackgroundColor,
     exit,
     setWindowTitle,
     setTargetFPS,
@@ -33,6 +32,8 @@ module [
     drawTextureRec,
     loadSound,
     playSound,
+    beginDrawing,
+    endDrawing,
 ]
 
 import RocRay.Keys as Keys
@@ -144,6 +145,14 @@ log = \message, level ->
     Effect.log message (Effect.toLogLevel level)
     |> Task.mapErr \{} -> crash "unreachable log"
 
+beginDrawing : Color -> Task {} *
+beginDrawing = \color ->
+    Effect.beginDrawing (rgba color)
+    |> Task.mapErr \{} -> crash "unreachable beginDrawing"
+
+endDrawing : Task {} *
+endDrawing = Effect.endDrawing |> Task.mapErr \{} -> crash "unreachable endDrawing"
+
 ## Set the window title.
 setWindowTitle : Str -> Task {} *
 setWindowTitle = \title ->
@@ -182,12 +191,6 @@ setDrawFPS = \{ fps, posX ? 10, posY ? 10 } ->
 
     Effect.setDrawFPS showFps posX posY
     |> Task.mapErr \{} -> crash "unreachable setDrawFPS"
-
-## Set the background color to clear the window between each frame.
-setBackgroundColor : Color -> Task {} *
-setBackgroundColor = \color ->
-    Effect.setBackgroundColor (rgba color)
-    |> Task.mapErr \{} -> crash "unreachable setBackgroundColor"
 
 ## Measure the width of a text string using the default font.
 measureText : { text : Str, size : I32 } -> Task I64 *


### PR DESCRIPTION
We keep track of what "mode" the platform is in... and make a check whenever each effect is run. We provide a helpful runtime error and gracefully exit if an application attempts to run an effect that is not permitted.

The reason we do this is to keep the effects simple (and not introducing Tasks that return result/errors) while still providing a level of "safety" for the app author. We can ensure the author doesn't accidentally do something bad, and also encourage good separation of concerns in the code.

Below is a simple illustration to describe this process... it shows how the host tracks the platform "mode" under the hood.

<img width="876" alt="Screenshot 2024-10-21 at 11 53 37" src="https://github.com/user-attachments/assets/0a19371a-4a8d-4594-8850-a35ae1f76e99">
