### PR TITLE
Add support for `RenderTexture`'s

### DIFF
--- a/examples/basic-shapes.roc
+++ b/examples/basic-shapes.roc
@@ -16,8 +16,6 @@ init =
     RocRay.setWindowSize!  { width, height }
     RocRay.setWindowTitle! "Basic Shapes"
 
-    _ = RocRay.createRenderTexture! { width: width/2, height: height/2 }
-
     Task.ok {}
 
 render : Model, PlatformState -> Task Model []

--- a/examples/basic-shapes.roc
+++ b/examples/basic-shapes.roc
@@ -13,8 +13,10 @@ main = { init, render }
 init : Task Model []
 init =
 
-    RocRay.setWindowSize! { width, height }
+    RocRay.setWindowSize!  { width, height }
     RocRay.setWindowTitle! "Basic Shapes"
+
+    _ = RocRay.createRenderTexture! { width: width/2, height: height/2 }
 
     Task.ok {}
 

--- a/flake.lock
+++ b/flake.lock
@@ -61,11 +61,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729403505,
-        "narHash": "sha256-1ILT9fxCbNQuToPWBhxC3N+hblIWW3WlEHnwcdoCBHE=",
+        "lastModified": 1729643269,
+        "narHash": "sha256-jh9t+NAFJGUDThjWiMuxz+rGz+O7sctLBIgJBfm1xQk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "88d3f02d308cb29a07942d24539f960721a20fe0",
+        "rev": "1c9fee8711a88d5b09e2072caf331efaec6501d3",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1729014666,
-        "narHash": "sha256-8nzl/uQWbmtYGYReQNHhyu2A3kMRRoQcixWoQr7exZ8=",
+        "lastModified": 1729598205,
+        "narHash": "sha256-SdVW9q8AHDx2ETcwATA32kPA3IP1C4CHZxAH844iWvo=",
         "owner": "roc-lang",
         "repo": "roc",
-        "rev": "573d4337e7c864439ac775849c83a03e8517e892",
+        "rev": "71e68f972510c5d0258ae622bce861ebfaa9485f",
         "type": "github"
       },
       "original": {

--- a/platform/Effect.roc
+++ b/platform/Effect.roc
@@ -1,6 +1,7 @@
 hosted Effect
     exposes [
         Texture,
+        RenderTexture,
         Sound,
         Camera,
         setWindowSize,
@@ -22,6 +23,8 @@ hosted Effect
         updateCamera,
         beginDrawing,
         endDrawing,
+        beginTexture,
+        endTexture,
         beginMode2D,
         endMode2D,
         log,
@@ -30,6 +33,7 @@ hosted Effect
         drawTextureRec,
         loadSound,
         playSound,
+        createRenderTexture,
     ]
     imports []
 
@@ -91,3 +95,8 @@ drawTextureRec : Texture, RocRectangle, RocVector2, RocColor -> Task {} {}
 Sound := Box {}
 loadSound : Str -> Task Sound {}
 playSound : Sound -> Task {} {}
+
+RenderTexture := Box {}
+createRenderTexture : RocVector2 -> Task RenderTexture {}
+beginTexture : RenderTexture, RocColor -> Task {} {}
+endTexture : RenderTexture -> Task {} {}

--- a/platform/RocRay.roc
+++ b/platform/RocRay.roc
@@ -274,7 +274,7 @@ drawRectangle = \{ rect, color } ->
 
 ## Draw a rectangle with a vertical-gradient fill on the screen.
 ## ```
-### RocRay.drawRectangleGradientV! { rect: { x: 300, y: 250, width: 250, height: 100 }, top: Maroon, bottom: Green }
+## RocRay.drawRectangleGradientV! { rect: { x: 300, y: 250, width: 250, height: 100 }, top: Maroon, bottom: Green }
 ## ```
 drawRectangleGradientV : { rect : Rectangle, top : Color, bottom : Color } -> Task {} *
 drawRectangleGradientV = \{ rect, top, bottom } ->

--- a/platform/RocRay.roc
+++ b/platform/RocRay.roc
@@ -35,6 +35,9 @@ module [
     playSound,
     beginDrawing,
     endDrawing,
+    createRenderTexture,
+    beginTexture,
+    endTexture,
 ]
 
 import Keys
@@ -129,8 +132,15 @@ Color : [
     Purple,
 ]
 
-## A loaded texture resource, used to draw images.
+## A static image loaded into GPU memory, typically from a file. Once loaded, it can be used
+## multiple times for efficient rendering. Cannot be modified after creation - for dynamic
+## textures that can be drawn to, see [RenderTexture] instead.
 Texture : Effect.Texture
+
+## A special texture that can be used as a render target. Allows drawing operations to be
+## performed to it (like a canvas), making it useful for effects, buffering, or off-screen
+## rendering. The result can then be used like a regular texture.
+RenderTexture : Effect.RenderTexture
 
 ## A loaded sound resource, used to play audio.
 Sound : Effect.Sound
@@ -422,3 +432,18 @@ playSound : Sound -> Task {} *
 playSound = \sound ->
     Effect.playSound sound
     |> Task.mapErr \{} -> crash "unreachable Sound.play"
+
+createRenderTexture : { width : F32, height : F32 } -> Task RenderTexture *
+createRenderTexture = \{ width, height } ->
+    Effect.createRenderTexture (InternalVector.fromXY width height)
+    |> Task.mapErr \{} -> crash "unreachable createRenderTexture"
+
+beginTexture : RenderTexture, Color -> Task {} *
+beginTexture = \texture, color ->
+    Effect.beginTexture texture (rgba color)
+    |> Task.mapErr \{} -> crash "unreachable beginTexture"
+
+endTexture : RenderTexture -> Task {} *
+endTexture = \texture ->
+    Effect.endTexture texture
+    |> Task.mapErr \{} -> crash "unreachable endTexture"

--- a/src/main.rs
+++ b/src/main.rs
@@ -519,36 +519,10 @@ unsafe extern "C" fn roc_fx_createRenderTexture(
 
     let (width, height) = size.to_components_c_int();
 
-    // [src/main.rs:521:5] width = 400
-    // [src/main.rs:521:5] height = 300
-    dbg!(width, height);
-
     let render_texture: bindings::RenderTexture = bindings::LoadRenderTexture(width, height);
-
-    // [src/main.rs:524:5] &render_texture = RenderTexture {
-    //     id: 1,
-    //     texture: Texture {
-    //         id: 3,
-    //         width: 400,
-    //         height: 300,
-    //         mipmaps: 1,
-    //         format: 7,
-    //     },
-    //     depth: Texture {
-    //         id: 1,
-    //         width: 400,
-    //         height: 300,
-    //         mipmaps: 1,
-    //         format: 19,
-    //     },
-    // }
-    dbg!(&render_texture);
 
     let heap = roc::render_texture_heap();
 
-    // WHY IS THIS FAILING??
-    // roc-ray(54393,0x2015c0f40) malloc: *** error for object 0x10ba68000: pointer being freed was not allocated
-    // roc-ray(54393,0x2015c0f40) malloc: *** set a breakpoint in malloc_error_break to debug
     let alloc_result = heap.alloc_for(render_texture);
     match alloc_result {
         Ok(roc_box) => RocResult::ok(roc_box),

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,6 @@ fn update_platform_mode_draw_2d() {
         } else if mode.matches(TextureModeDraw2D) {
             *mode = TextureMode;
         } else {
-            // TODO HANDLE GOING THE OTHER WAY TOO
             panic!("unreachable, invalid mode should have been caught by is_effect_permitted")
         }
     });

--- a/src/roc.rs
+++ b/src/roc.rs
@@ -50,6 +50,24 @@ pub fn sound_heap() -> &'static ThreadSafeRefcountedResourceHeap<bindings::Sound
     })
 }
 
+// note this is checked and deallocated in the roc_dealloc function
+pub fn render_texture_heap() -> &'static ThreadSafeRefcountedResourceHeap<bindings::RenderTexture> {
+    static RENDER_TEXTURE_HEAP: OnceLock<
+        ThreadSafeRefcountedResourceHeap<bindings::RenderTexture>,
+    > = OnceLock::new();
+    const DEFAULT_ROC_RAY_MAX_RENDER_TEXTURE_HEAP_SIZE: usize = 1000;
+    let max_heap_size = std::env::var("ROC_RAY_MAX_RENDER_TEXTURE_HEAP_SIZE")
+        .map(|v| {
+            v.parse()
+                .unwrap_or(DEFAULT_ROC_RAY_MAX_RENDER_TEXTURE_HEAP_SIZE)
+        })
+        .unwrap_or(DEFAULT_ROC_RAY_MAX_RENDER_TEXTURE_HEAP_SIZE);
+    RENDER_TEXTURE_HEAP.get_or_init(|| {
+        ThreadSafeRefcountedResourceHeap::new(max_heap_size)
+            .expect("Failed to allocate mmap for heap references.")
+    })
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn roc_alloc(size: usize, _alignment: u32) -> *mut c_void {
     libc::malloc(size)

--- a/src/roc.rs
+++ b/src/roc.rs
@@ -93,6 +93,12 @@ pub unsafe extern "C" fn roc_dealloc(c_ptr: *mut c_void, _alignment: u32) {
         return;
     }
 
+    let render_texture_heap = render_texture_heap();
+    if render_texture_heap.in_range(c_ptr) {
+        render_texture_heap.dealloc(c_ptr);
+        return;
+    }
+
     libc::free(c_ptr);
 }
 


### PR DESCRIPTION
RenderTexture is used for dynamic rendering, allowing you to draw onto the texture using the CPU and then using a single draw to load that into the GPU frame buffer.