### PR TITLE
better implementation of key lookup

### DIFF
--- a/platform/InternalKeyboard.roc
+++ b/platform/InternalKeyboard.roc
@@ -1,4 +1,21 @@
-module [KeyboardKey, KeyState, keyFromU64, keyStateFromU8]
+module [
+    Keys,
+    KeyState,
+    KeyboardKey,
+    pack,
+    readKey,
+]
+
+Keys := List U8
+
+pack : List U8 -> Keys
+pack = \bytes -> @Keys bytes
+
+readKey : Keys, KeyboardKey -> KeyState
+readKey = \@Keys bytes, requestedKey ->
+    when List.get bytes (keyToU64 requestedKey) is
+        Ok byte -> keyStateFromU8 byte
+        Err OutOfBounds -> crash "bug in key bytes encoding"
 
 KeyboardKey : [
     KeyApostrophe, # = 39,
@@ -129,6 +146,118 @@ keyStateFromU8 = \n ->
         4 -> PressedRepeat
         _ -> crash "unreachable key state from host"
 
+keyToU64 : KeyboardKey -> U64
+keyToU64 = \key ->
+    when key is
+        KeyApostrophe -> 39
+        KeyComma -> 44
+        KeyMinus -> 45
+        KeyPeriod -> 46
+        KeySlash -> 47
+        KeyZero -> 48
+        KeyOne -> 49
+        KeyTwo -> 50
+        KeyThree -> 51
+        KeyFour -> 52
+        KeyFive -> 53
+        KeySix -> 54
+        KeySeven -> 55
+        KeyEight -> 56
+        KeyNine -> 57
+        KeySemicolon -> 59
+        KeyEqual -> 61
+        KeyA -> 65
+        KeyB -> 66
+        KeyC -> 67
+        KeyD -> 68
+        KeyE -> 69
+        KeyF -> 70
+        KeyG -> 71
+        KeyH -> 72
+        KeyI -> 73
+        KeyJ -> 74
+        KeyK -> 75
+        KeyL -> 76
+        KeyM -> 77
+        KeyN -> 78
+        KeyO -> 79
+        KeyP -> 80
+        KeyQ -> 81
+        KeyR -> 82
+        KeyS -> 83
+        KeyT -> 84
+        KeyU -> 85
+        KeyV -> 86
+        KeyW -> 87
+        KeyX -> 88
+        KeyY -> 89
+        KeyZ -> 90
+        KeySpace -> 32
+        KeyEscape -> 256
+        KeyEnter -> 257
+        KeyTab -> 258
+        KeyBackspace -> 259
+        KeyInsert -> 260
+        KeyDelete -> 261
+        KeyRight -> 262
+        KeyLeft -> 263
+        KeyDown -> 264
+        KeyUp -> 265
+        KeyPageUp -> 266
+        KeyPageDown -> 267
+        KeyHome -> 268
+        KeyEnd -> 269
+        KeyCapsLock -> 280
+        KeyScrollLock -> 281
+        KeyNumLock -> 282
+        KeyPrintScreen -> 283
+        KeyPause -> 284
+        KeyF1 -> 290
+        KeyF2 -> 291
+        KeyF3 -> 292
+        KeyF4 -> 293
+        KeyF5 -> 294
+        KeyF6 -> 295
+        KeyF7 -> 296
+        KeyF8 -> 297
+        KeyF9 -> 298
+        KeyF10 -> 299
+        KeyF11 -> 300
+        KeyF12 -> 301
+        KeyLeftShift -> 340
+        KeyLeftControl -> 341
+        KeyLeftAlt -> 342
+        KeyLeftSuper -> 343
+        KeyRightShift -> 344
+        KeyRightControl -> 345
+        KeyRightAlt -> 346
+        KeyRightSuper -> 347
+        KeyKBMenu -> 348
+        KeyLeftBracket -> 91
+        KeyBackslash -> 92
+        KeyRightBracket -> 93
+        KeyGrave -> 96
+        KeyKP0 -> 320
+        KeyKP1 -> 321
+        KeyKP2 -> 322
+        KeyKP3 -> 323
+        KeyKP4 -> 324
+        KeyKP5 -> 325
+        KeyKP6 -> 326
+        KeyKP7 -> 327
+        KeyKP8 -> 328
+        KeyKP9 -> 329
+        KeyKPDecimal -> 330
+        KeyKPDivide -> 331
+        KeyKPMultiply -> 332
+        KeyKPSubtract -> 333
+        KeyKPAdd -> 334
+        KeyKPEnter -> 335
+        KeyKPEqual -> 336
+        KeyBack -> 4
+        KeyVolumeUp -> 24
+        KeyVolumeDown -> 25
+
 keyFromU64 : U64 -> Result KeyboardKey [Ignored]
 keyFromU64 = \key ->
     when key is
@@ -241,3 +370,18 @@ keyFromU64 = \key ->
         24 -> Ok KeyVolumeUp
         25 -> Ok KeyVolumeDown
         _ -> Err Ignored
+
+expect
+    bytes = List.repeat 2u8 350
+    keys = pack bytes
+    state = readKey keys KeyLeft
+    state == Down
+
+expect
+    range = List.range { start: At 0, end: At 350 }
+    allKeys = List.keepOks range \i ->
+        when keyFromU64 i is
+            Ok key -> Ok (key, i)
+            Err Ignored -> Err Ignored
+    List.all allKeys \(key, i) ->
+        keyToU64 key == i

--- a/platform/Keys.roc
+++ b/platform/Keys.roc
@@ -16,32 +16,38 @@ import InternalKeyboard
 
 KeyboardKey : InternalKeyboard.KeyboardKey
 
-Keys : Dict InternalKeyboard.KeyboardKey InternalKeyboard.KeyState
+Keys : InternalKeyboard.Keys
 
 down : Keys, KeyboardKey -> Bool
 down = \keys, key ->
-    state = Dict.get keys key
-    state == Ok Down || state == Ok PressedRepeat
+    when InternalKeyboard.readKey keys key is
+        Down -> Bool.true
+        PressedRepeat -> Bool.true
+        _ -> Bool.false
 
 up : Keys, KeyboardKey -> Bool
 up = \keys, key ->
-    state = Dict.get keys key
-    state == Ok Up
+    when InternalKeyboard.readKey keys key is
+        Up -> Bool.true
+        _ -> Bool.false
 
 pressed : Keys, KeyboardKey -> Bool
 pressed = \keys, key ->
-    state = Dict.get keys key
-    state == Ok Pressed
+    when InternalKeyboard.readKey keys key is
+        Pressed -> Bool.true
+        _ -> Bool.false
 
 released : Keys, KeyboardKey -> Bool
 released = \keys, key ->
-    state = Dict.get keys key
-    state == Ok Down
+    when InternalKeyboard.readKey keys key is
+        Released -> Bool.true
+        _ -> Bool.false
 
 pressedRepeat : Keys, KeyboardKey -> Bool
 pressedRepeat = \keys, key ->
-    state = Dict.get keys key
-    state == Ok PressedRepeat
+    when InternalKeyboard.readKey keys key is
+        PressedRepeat -> Bool.true
+        _ -> Bool.false
 
 anyDown : Keys, List KeyboardKey -> Bool
 anyDown = \keys, selection -> any keys selection down
@@ -59,3 +65,8 @@ any : Keys, List KeyboardKey, (Keys, KeyboardKey -> Bool) -> Bool
 any = \keys, selection, predicate ->
     List.any selection \k ->
         predicate keys k
+
+expect
+    bytes = List.repeat 2u8 350
+    keys = InternalKeyboard.pack bytes
+    down keys KeyLeft == Bool.true

--- a/platform/RocRay.roc
+++ b/platform/RocRay.roc
@@ -37,7 +37,6 @@ module [
     endDrawing,
 ]
 
-import Keys
 import Mouse
 import Effect
 import InternalKeyboard
@@ -73,7 +72,7 @@ Program state err : {
 PlatformState : {
     timestampMillis : U64,
     frameCount : U64,
-    keys : Keys.Keys,
+    keys : InternalKeyboard.Keys,
     mouse : {
         position : Vector2,
         buttons : Mouse.Buttons,
@@ -379,7 +378,7 @@ beginMode2D = \camera ->
 endMode2D : Camera -> Task {} *
 endMode2D = \camera ->
     Effect.endMode2D camera
-    |> Task.mapErr! \{} -> crash "unreachable endMode2D"
+        |> Task.mapErr! \{} -> crash "unreachable endMode2D"
 
 ## Load a texture from a file.
 ## ```
@@ -412,7 +411,7 @@ drawTextureRec = \{ texture, source, pos, tint } ->
 loadSound : Str -> Task Sound *
 loadSound = \path ->
     Effect.loadSound path
-    |> Task.mapErr \{} -> crash "unreachable Sound.load"
+    |> Task.mapErr \{} -> crash "unreachable loadSound"
 
 ## Play a loaded sound.
 ## ```
@@ -421,4 +420,4 @@ loadSound = \path ->
 playSound : Sound -> Task {} *
 playSound = \sound ->
     Effect.playSound sound
-    |> Task.mapErr \{} -> crash "unreachable Sound.play"
+    |> Task.mapErr \{} -> crash "unreachable playSound"

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -7,7 +7,6 @@ platform "roc-ray"
 
 import RocRay exposing [Program]
 import Mouse
-import Keys
 import InternalKeyboard
 import InternalMouse
 import Effect
@@ -50,7 +49,7 @@ render = \boxedModel, platformState ->
     state = {
         timestampMillis,
         frameCount,
-        keys: keysForApp { keys },
+        keys: InternalKeyboard.pack keys,
         mouse: {
             position: { x: mousePosX, y: mousePosY },
             buttons: mouseButtonsForApp { mouseButtons },
@@ -65,15 +64,6 @@ render = \boxedModel, platformState ->
                 Effect.log! (Inspect.toStr err) (Effect.toLogLevel LogError)
                 Effect.exit!
                 Task.err {}
-
-keysForApp : { keys : List U8 } -> Keys.Keys
-keysForApp = \{ keys } ->
-    keys
-    |> List.map InternalKeyboard.keyStateFromU8
-    |> List.mapWithIndex \s, i -> (InternalKeyboard.keyFromU64 i, s)
-    |> List.keepOks \(recognized, s) ->
-        Result.map recognized \key -> (key, s)
-    |> Dict.fromList
 
 mouseButtonsForApp : { mouseButtons : List U8 } -> Mouse.Buttons
 mouseButtonsForApp = \{ mouseButtons } ->


### PR DESCRIPTION
samply made it look like keysForApp was one of the things we spent the most time in (that we control, in a dev build), so now it just stays bytes internally instead of allocating a dict and a list or two every frame