### PR TITLE
Add 2d split-screen example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,15 @@ roc_std_heap = { git = "https://github.com/roc-lang/roc.git" }
 libc = "0.2"
 
 [build-dependencies]
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "rustls-tls"] }
+reqwest = { version = "0.11", default-features = false, features = [
+    "blocking",
+    "rustls-tls",
+] }
 flate2 = "1.0"
 tar = "0.4"
 zip = "0.5"
 bytes = "1"
+
+[features]
+default = []
+trace-debug = []

--- a/examples/2d_camera_split_screen.roc
+++ b/examples/2d_camera_split_screen.roc
@@ -1,0 +1,142 @@
+app [Model, init, render] {
+    rr: platform "../platform/main.roc",
+    rand: "https://github.com/lukewilliamboswell/roc-random/releases/download/0.3.0/hPlOciYUhWMU7BefqNzL89g84-30fTE6l2_6Y3cxIcE.tar.br",
+    time: "https://github.com/imclerran/roc-isodate/releases/download/v0.5.0/ptg0ElRLlIqsxMDZTTvQHgUSkNrUSymQaGwTfv0UEmk.tar.br",
+}
+
+import rr.RocRay exposing [Rectangle]
+#import rr.Keys
+import rr.Draw
+import rr.Camera
+import rr.RenderTexture
+#import rand.Random
+
+screenWidth = 800
+screenHeight = 440
+playerSize = 40
+
+Model : {
+    playerOne : Rectangle,
+    playerTwo : Rectangle,
+    settingsLeft : Camera.Settings,
+    settingsRight : Camera.Settings,
+    cameraLeft : RocRay.Camera,
+    cameraRight : RocRay.Camera,
+    screenLeft : RocRay.RenderTexture,
+    screenRight : RocRay.RenderTexture,
+}
+
+init : Task Model []
+init =
+
+    RocRay.setTargetFPS! 60
+    RocRay.setDrawFPS! { fps: Visible }
+    RocRay.setWindowSize! { width: screenWidth, height: screenHeight }
+    RocRay.setWindowTitle! "2D camera split-screen"
+
+    playerOne = { x : 200, y : 200, width : playerSize, height : playerSize }
+    playerTwo = { x : 250, y : 200, width : playerSize, height : playerSize }
+
+    settingsLeft = {
+        target: {x:playerOne.x, y:playerOne.y},
+        offset: { x: 200, y: 200 },
+        rotation: 0,
+        zoom: 1,
+    }
+
+    settingsRight = {
+        target: {x:playerTwo.x, y:playerTwo.y},
+        offset: { x: 200, y: 200 },
+        rotation: 0,
+        zoom: 1,
+    }
+
+    cameraLeft = Camera.create! settingsLeft
+    cameraRight = Camera.create! settingsRight
+
+    screenLeft = RenderTexture.create! { width: screenWidth / 2, height: screenHeight / 2}
+    screenRight = RenderTexture.create! { width: screenWidth / 2, height: screenHeight / 2}
+
+    # WHAT IS THIS?
+    #splitScreenRect = { x: 0, y: 0, width: screenWidth / 2, height: screenHeight }
+
+    Task.ok {
+        playerOne,
+        playerTwo,
+        settingsLeft,
+        settingsRight,
+        cameraLeft,
+        cameraRight,
+        screenLeft,
+        screenRight,
+    }
+
+render : Model, RocRay.PlatformState -> Task Model []
+render = \model, {  } ->
+
+    ## UPDATE CAMERA
+    #rotation =
+    #    (
+    #        if Keys.down keys KeyA then
+    #            model.cameraSettings.rotation - 1
+    #        else if Keys.down keys KeyS then
+    #            model.cameraSettings.rotation + 1
+    #        else
+    #            model.cameraSettings.rotation
+    #    )
+    #    |> limit { upper: 40, lower: -40 }
+    #    |> \r -> if Keys.pressed keys KeyR then 0 else r
+
+    #zoom =
+    #    (model.cameraSettings.zoom + (mouse.wheel * 0.05))
+    #    |> limit { upper: 3, lower: 0.1 }
+    #    |> \z -> if Keys.pressed keys KeyR then 1 else z
+
+    #cameraSettings =
+    #    model.cameraSettings
+    #    |> &target model.player
+    #    |> &rotation rotation
+    #    |> &zoom zoom
+
+    #Camera.update! model.camera cameraSettings
+
+    ## UPDATE PLAYER
+    #player =
+    #    if Keys.down keys KeyLeft then
+    #        { x: model.player.x - 10, y: model.player.y }
+    #    else if Keys.down keys KeyRight then
+    #        { x: model.player.x + 10, y: model.player.y }
+    #    else
+    #        model.player
+    #
+
+    # RENDER THE SCENE INTO THE LEFT SCREEN TEXTURE
+    Draw.withTexture! model.screenLeft Aqua \{} ->
+
+        Draw.withMode2D! model.cameraLeft \{} ->
+
+            Draw.rectangle! { rect: model.playerOne, color: Red }
+
+            drawScene!
+
+    # RENDER FRAMEBUFFER
+    Draw.draw! White \{} ->
+
+        # DRAW THE LEFT SCREEN TEXTURE INTO THE FRAMEBUFFER
+        Draw.renderTextureRec! {
+            texture : model.screenLeft,
+            source : { x : 0, y : 0, width : screenWidth / 2, height: screenHeight / 2 },
+            pos : { x: 0, y: 0},
+            tint : White,
+        }
+
+    Task.ok model
+
+drawScene : Task {} []
+drawScene =
+
+    List.range { start: At 0, end: Before ((screenWidth/playerSize) + 1)}
+    |> List.map \i -> { start: { x: playerSize*i, y: 0 }, end: { x: playerSize*i, y: screenHeight }, color: lightGray }
+    |> Task.forEach! Draw.line
+
+lightGray = RGBA 200 200 200 255

--- a/examples/2d_camera_split_screen.roc
+++ b/examples/2d_camera_split_screen.roc
@@ -1,15 +1,11 @@
 app [Model, init, render] {
     rr: platform "../platform/main.roc",
-    rand: "https://github.com/lukewilliamboswell/roc-random/releases/download/0.3.0/hPlOciYUhWMU7BefqNzL89g84-30fTE6l2_6Y3cxIcE.tar.br",
-    time: "https://github.com/imclerran/roc-isodate/releases/download/v0.5.0/ptg0ElRLlIqsxMDZTTvQHgUSkNrUSymQaGwTfv0UEmk.tar.br",
 }
 
 import rr.RocRay exposing [Rectangle]
-#import rr.Keys
 import rr.Draw
 import rr.Camera
 import rr.RenderTexture
-#import rand.Random
 
 screenWidth = 800
 screenHeight = 440
@@ -57,9 +53,6 @@ init =
     screenLeft = RenderTexture.create! { width: screenWidth / 2, height: screenHeight / 2}
     screenRight = RenderTexture.create! { width: screenWidth / 2, height: screenHeight / 2}
 
-    # WHAT IS THIS?
-    #splitScreenRect = { x: 0, y: 0, width: screenWidth / 2, height: screenHeight }
-
     Task.ok {
         playerOne,
         playerTwo,
@@ -74,48 +67,13 @@ init =
 render : Model, RocRay.PlatformState -> Task Model []
 render = \model, {  } ->
 
-    ## UPDATE CAMERA
-    #rotation =
-    #    (
-    #        if Keys.down keys KeyA then
-    #            model.cameraSettings.rotation - 1
-    #        else if Keys.down keys KeyS then
-    #            model.cameraSettings.rotation + 1
-    #        else
-    #            model.cameraSettings.rotation
-    #    )
-    #    |> limit { upper: 40, lower: -40 }
-    #    |> \r -> if Keys.pressed keys KeyR then 0 else r
-
-    #zoom =
-    #    (model.cameraSettings.zoom + (mouse.wheel * 0.05))
-    #    |> limit { upper: 3, lower: 0.1 }
-    #    |> \z -> if Keys.pressed keys KeyR then 1 else z
-
-    #cameraSettings =
-    #    model.cameraSettings
-    #    |> &target model.player
-    #    |> &rotation rotation
-    #    |> &zoom zoom
-
-    #Camera.update! model.camera cameraSettings
-
-    ## UPDATE PLAYER
-    #player =
-    #    if Keys.down keys KeyLeft then
-    #        { x: model.player.x - 10, y: model.player.y }
-    #    else if Keys.down keys KeyRight then
-    #        { x: model.player.x + 10, y: model.player.y }
-    #    else
-    #        model.player
-    #
-
     # RENDER THE SCENE INTO THE LEFT SCREEN TEXTURE
     Draw.withTexture! model.screenLeft Aqua \{} ->
 
         Draw.withMode2D! model.cameraLeft \{} ->
 
             Draw.rectangle! { rect: model.playerOne, color: Red }
+            Draw.rectangle! { rect: { x : -1000, y : -1000, width : screenWidth*100, height: screenHeight*100 }, color: Blue}
 
             drawScene!
 
@@ -125,8 +83,8 @@ render = \model, {  } ->
         # DRAW THE LEFT SCREEN TEXTURE INTO THE FRAMEBUFFER
         Draw.renderTextureRec! {
             texture : model.screenLeft,
-            source : { x : 0, y : 0, width : screenWidth / 2, height: screenHeight / 2 },
-            pos : { x: 0, y: 0},
+            source : { x : 50, y : 50, width : screenWidth / 2, height: screenHeight / 2 },
+            pos : { x: 100, y: 100},
             tint : White,
         }
 

--- a/examples/2d_camera_split_screen.roc
+++ b/examples/2d_camera_split_screen.roc
@@ -68,7 +68,7 @@ render : Model, RocRay.PlatformState -> Task Model []
 render = \model, {  } ->
 
     # RENDER THE SCENE INTO THE LEFT SCREEN TEXTURE
-    Draw.withTexture! model.screenLeft Aqua \{} ->
+    Draw.withTexture! model.screenLeft White \{} ->
 
         Draw.withMode2D! model.cameraLeft \{} ->
 

--- a/justfile
+++ b/justfile
@@ -19,10 +19,10 @@ setup:
 
 # build and run an executable
 [unix]
-dev app="examples/basic-shapes.roc":
+dev app="examples/basic-shapes.roc" features="default":
     roc check {{app}}
     roc build --no-link --emit-llvm-ir --output app.o {{app}}
-    cargo run
+    cargo run --features {{features}}
 
 # build and run an executable
 [windows]

--- a/platform/Camera.roc
+++ b/platform/Camera.roc
@@ -1,8 +1,15 @@
-module [create, update]
+module [Settings, create, update]
 
 import Effect
 import InternalVector
 import RocRay exposing [Camera, Vector2]
+
+Settings : {
+    target : Vector2,
+    offset : Vector2,
+    rotation : F32,
+    zoom : F32,
+}
 
 ## Create a new camera. The camera can be used to render a 2D and 3D perspective of the world.
 ## ```
@@ -15,7 +22,7 @@ import RocRay exposing [Camera, Vector2]
 ##
 ## cameraID = Camera.create! cameraSettings
 ## ```
-create : { target : Vector2, offset : Vector2, rotation : F32, zoom : F32 } -> Task Camera *
+create : Settings -> Task Camera *
 create = \{ target, offset, rotation, zoom } ->
     Effect.createCamera (InternalVector.fromVector2 target) (InternalVector.fromVector2 offset) rotation zoom
     |> Task.map \camera -> camera
@@ -31,7 +38,7 @@ create = \{ target, offset, rotation, zoom } ->
 ##
 ## Camera.update! model.cameraID cameraSettings
 ## ```
-update : Camera, { target : Vector2, offset : Vector2, rotation : F32, zoom : F32 } -> Task {} *
+update : Camera, Settings -> Task {} *
 update = \camera, { target, offset, rotation, zoom } ->
     Effect.updateCamera camera (InternalVector.fromVector2 target) (InternalVector.fromVector2 offset) rotation zoom
     |> Task.mapErr \{} -> crash "unreachable updateCamera"

--- a/platform/Draw.roc
+++ b/platform/Draw.roc
@@ -10,6 +10,7 @@ module [
     circle,
     circleGradient,
     textureRec,
+    renderTextureRec,
 ]
 
 import Effect
@@ -154,4 +155,19 @@ circleGradient = \{ center, radius, inner, outer } ->
 textureRec : { texture : Texture, source : Rectangle, pos : Vector2, tint : Color } -> Task {} *
 textureRec = \{ texture, source, pos, tint } ->
     Effect.drawTextureRec texture (InternalRectangle.fromRect source) (InternalVector.fromVector2 pos) (rgba tint)
+    |> Task.mapErr \{} -> crash "unreachable drawTextureRec"
+
+## Draw part of a texture.
+## ```
+## # Draw the sprite at the player's position.
+## Draw.renderTextureRec! {
+##     texture: model.dude,
+##     source: dudeSprite model.direction dudeAnimation.frame,
+##     pos: model.player,
+##     tint: White,
+## }
+## ```
+renderTextureRec : { texture : RenderTexture, source : Rectangle, pos : Vector2, tint : Color } -> Task {} *
+renderTextureRec = \{ texture, source, pos, tint } ->
+    Effect.drawRenderTextureRec texture (InternalRectangle.fromRect source) (InternalVector.fromVector2 pos) (rgba tint)
     |> Task.mapErr \{} -> crash "unreachable drawTextureRec"

--- a/platform/Effect.roc
+++ b/platform/Effect.roc
@@ -34,6 +34,7 @@ hosted Effect
         loadSound,
         playSound,
         createRenderTexture,
+        drawRenderTextureRec,
     ]
     imports []
 
@@ -91,6 +92,7 @@ endMode2D : Camera -> Task {} {}
 Texture := Box {}
 loadTexture : Str -> Task Texture {}
 drawTextureRec : Texture, RocRectangle, RocVector2, RocColor -> Task {} {}
+drawRenderTextureRec : RenderTexture, RocRectangle, RocVector2, RocColor -> Task {} {}
 
 Sound := Box {}
 loadSound : Str -> Task Sound {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -812,6 +812,34 @@ unsafe extern "C" fn roc_fx_drawTextureRec(
     RocResult::ok(())
 }
 
+#[no_mangle]
+unsafe extern "C" fn roc_fx_drawRenderTextureRec(
+    boxed_texture: RocBox<()>,
+    source: &glue::RocRectangle,
+    position: &glue::RocVector2,
+    color: glue::RocColor,
+) -> RocResult<(), ()> {
+    if !is_effect_permitted(PlatformEffect::DrawTextureRectangle) {
+        let mode = platform_mode_str();
+        exit_with_msg(
+            format!("Cannot draw a texture rectangle while in {mode}"),
+            ExitErrCode::ExitEffectNotPermitted,
+        );
+    }
+
+    let texture: &mut bindings::RenderTexture =
+        ThreadSafeRefcountedResourceHeap::box_to_resource(boxed_texture);
+
+    bindings::DrawTextureRec(
+        texture.texture,
+        source.into(),
+        position.into(),
+        color.into(),
+    );
+
+    RocResult::ok(())
+}
+
 #[cfg(test)]
 mod test_platform_mode_transitions {
     use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,11 +174,14 @@ fn main() {
             panic!("Attempting to create window failed!");
         }
 
+        let mut frame_count = 0;
+
+        #[cfg(feature = "trace-debug")]
+        bindings::SetTraceLogLevel(bindings::TraceLogLevel_LOG_DEBUG as i32);
+
         bindings::InitAudioDevice();
 
         let mut model = roc::call_roc_init();
-
-        let mut frame_count = 0;
 
         while !bindings::WindowShouldClose() && !SHOULD_EXIT.get() {
             let duration_since_epoch = SystemTime::now()
@@ -186,6 +189,12 @@ fn main() {
                 .unwrap();
 
             let timestamp = duration_since_epoch.as_millis() as u64; // we are casting to u64 and losing precision
+
+            #[cfg(feature = "trace-debug")]
+            trace_log(&format!(
+                "------ RENDER frame: {}, millis: {} ------",
+                frame_count, timestamp
+            ));
 
             let platform_state = roc::PlatformState {
                 frame_count,
@@ -573,6 +582,9 @@ extern "C" fn roc_fx_beginDrawing(clear_color: glue::RocColor) -> RocResult<(), 
 
     #[cfg(not(test))]
     unsafe {
+        #[cfg(feature = "trace-debug")]
+        trace_log("BeginDrawing");
+
         bindings::BeginDrawing();
         bindings::ClearBackground(clear_color.into());
     }
@@ -594,6 +606,9 @@ extern "C" fn roc_fx_endDrawing() -> RocResult<(), ()> {
 
     #[cfg(not(test))]
     unsafe {
+        #[cfg(feature = "trace-debug")]
+        trace_log("EndDrawing");
+
         bindings::EndMode2D();
     }
 
@@ -615,6 +630,9 @@ extern "C" fn roc_fx_beginMode2D(boxed_camera: RocBox<()>) -> RocResult<(), ()> 
 
     #[cfg(not(test))]
     unsafe {
+        #[cfg(feature = "trace-debug")]
+        trace_log("BeginMode2D");
+
         let camera: &mut bindings::Camera2D =
             ThreadSafeRefcountedResourceHeap::box_to_resource(boxed_camera);
 
@@ -638,6 +656,9 @@ extern "C" fn roc_fx_endMode2D(_boxed_camera: RocBox<()>) -> RocResult<(), ()> {
 
     #[cfg(not(test))]
     unsafe {
+        #[cfg(feature = "trace-debug")]
+        trace_log("EndMode2D");
+
         bindings::EndMode2D();
     }
 
@@ -662,6 +683,9 @@ extern "C" fn roc_fx_beginTexture(
 
     #[cfg(not(test))]
     unsafe {
+        #[cfg(feature = "trace-debug")]
+        trace_log("BeginTexture");
+
         let render_texture: &mut bindings::RenderTexture =
             ThreadSafeRefcountedResourceHeap::box_to_resource(boxed_render_texture);
 
@@ -686,7 +710,10 @@ extern "C" fn roc_fx_endTexture(_boxed_render_texture: RocBox<()>) -> RocResult<
 
     #[cfg(not(test))]
     unsafe {
-        bindings::EndMode2D();
+        #[cfg(feature = "trace-debug")]
+        trace_log("EndTexture");
+
+        bindings::EndTextureMode();
     }
 
     RocResult::ok(())
@@ -830,8 +857,6 @@ unsafe extern "C" fn roc_fx_drawRenderTextureRec(
     let texture: &mut bindings::RenderTexture =
         ThreadSafeRefcountedResourceHeap::box_to_resource(boxed_texture);
 
-    dbg!(&texture, &source, &position, &color);
-
     bindings::DrawTextureRec(
         texture.texture,
         source.into(),
@@ -840,6 +865,13 @@ unsafe extern "C" fn roc_fx_drawRenderTextureRec(
     );
 
     RocResult::ok(())
+}
+
+#[cfg(feature = "trace-debug")]
+unsafe fn trace_log(msg: &str) {
+    let level = bindings::TraceLogLevel_LOG_DEBUG;
+    let text = CString::new(msg).unwrap();
+    bindings::TraceLog(level as i32, text.as_ptr());
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -830,6 +830,8 @@ unsafe extern "C" fn roc_fx_drawRenderTextureRec(
     let texture: &mut bindings::RenderTexture =
         ThreadSafeRefcountedResourceHeap::box_to_resource(boxed_texture);
 
+    dbg!(&texture, &source, &position, &color);
+
     bindings::DrawTextureRec(
         texture.texture,
         source.into(),


### PR DESCRIPTION
Inspired by the [raylib core core_2d_camera_split_screen](https://github.com/raysan5/raylib/blob/master/examples/core/core_2d_camera_split_screen.c) this example will ensure we have the RenderTexture functionality working correctly, and provide a good example for users in future. 

![roc-ray-10](https://github.com/user-attachments/assets/f4c80c68-020c-4e99-9ea2-fbdbd612f78c)
