### PR TITLE
Refactor host to prepare for networking

### DIFF
--- a/examples/2d_camera.roc
+++ b/examples/2d_camera.roc
@@ -30,8 +30,8 @@ init =
 
     RocRay.setTargetFPS! 60
     RocRay.setDrawFPS! { fps: Visible }
-    RocRay.setWindowSize! { width: screenWidth, height: screenHeight }
-    RocRay.setWindowTitle! "2D Camera Example"
+
+    RocRay.initWindow! { title: "2D Camera Example", width: screenWidth, height: screenHeight }
 
     player = { x: 400, y: 280 }
 

--- a/examples/2d_camera_split_screen.roc
+++ b/examples/2d_camera_split_screen.roc
@@ -26,8 +26,11 @@ Model : {
 init : Task Model []
 init =
 
-    RocRay.setWindowSize! { width: screenWidth, height: screenHeight }
-    RocRay.setWindowTitle! "2D camera split-screen"
+    RocRay.initWindow! {
+        title: "2D camera split-screen",
+        width: screenWidth,
+        height: screenHeight,
+    }
 
     playerOne = { x: 200, y: 200, width: playerSize, height: playerSize }
     playerTwo = { x: 250, y: 200, width: playerSize, height: playerSize }
@@ -114,25 +117,25 @@ render = \model, { keys } ->
 
     playerOne =
         if Keys.down keys KeyUp then
-            model.playerOne |> &y (model.playerOne.y - 1)
+            model.playerOne |> &y (model.playerOne.y - 10)
         else if Keys.down keys KeyDown then
-            model.playerOne |> &y (model.playerOne.y + 1)
+            model.playerOne |> &y (model.playerOne.y + 10)
         else if Keys.down keys KeyLeft then
-            model.playerOne |> &x (model.playerOne.x - 1)
+            model.playerOne |> &x (model.playerOne.x - 10)
         else if Keys.down keys KeyRight then
-            model.playerOne |> &x (model.playerOne.x + 1)
+            model.playerOne |> &x (model.playerOne.x + 10)
         else
             model.playerOne
 
     playerTwo =
         if Keys.down keys KeyW then
-            model.playerTwo |> &y (model.playerTwo.y - 1)
+            model.playerTwo |> &y (model.playerTwo.y - 10)
         else if Keys.down keys KeyS then
-            model.playerTwo |> &y (model.playerTwo.y + 1)
+            model.playerTwo |> &y (model.playerTwo.y + 10)
         else if Keys.down keys KeyA then
-            model.playerTwo |> &x (model.playerTwo.x - 1)
+            model.playerTwo |> &x (model.playerTwo.x - 10)
         else if Keys.down keys KeyD then
-            model.playerTwo |> &x (model.playerTwo.x + 1)
+            model.playerTwo |> &x (model.playerTwo.x + 10)
         else
             model.playerTwo
 

--- a/examples/audio.roc
+++ b/examples/audio.roc
@@ -15,9 +15,11 @@ Model : {
 init : Task Model []
 init =
 
-    RocRay.setTargetFPS! 60
-    RocRay.setWindowSize! { width: 800, height: 450 }
-    RocRay.setWindowTitle! "Making Sounds"
+    RocRay.initWindow! {
+        title: "Making Sounds",
+        width: 800,
+        height: 450,
+    }
 
     wav = Sound.load! "resources/sound.wav"
     ogg = Sound.load! "resources/target.ogg"

--- a/examples/basic-shapes.roc
+++ b/examples/basic-shapes.roc
@@ -11,8 +11,7 @@ Model : {}
 init : Task Model []
 init =
 
-    RocRay.setWindowSize! { width, height }
-    RocRay.setWindowTitle! "Basic Shapes"
+    RocRay.initWindow! { title: "Basic Shapes", width, height }
 
     Task.ok {}
 

--- a/examples/pong.roc
+++ b/examples/pong.roc
@@ -28,10 +28,10 @@ newBall = {
 
 init : Task Model []
 init =
-    RocRay.setTargetFPS! 60
+
+    RocRay.setTargetFPS! 120
     RocRay.setDrawFPS! { fps: Visible }
-    RocRay.setWindowSize! { width, height }
-    RocRay.setWindowTitle! "Pong"
+    RocRay.initWindow! { title: "Pong", width, height }
 
     Task.ok {
         screen: StartMenu,

--- a/examples/random.roc
+++ b/examples/random.roc
@@ -11,31 +11,23 @@ import rand.Random
 import time.DateTime
 
 Model : {
-    width : F32,
-    height : F32,
     seed : Random.State U32,
     number : U64,
 }
 
+width = 800
+height = 800
+
 init : Task Model []
 init =
 
-    width = 800f32
-    height = 800f32
-    number = 1000
-
-    seed = Random.seed 1234
-
     RocRay.setTargetFPS! 500
     RocRay.setDrawFPS! { fps: Visible }
-    RocRay.setWindowSize! { width, height }
-    RocRay.setWindowTitle! "Random Dots"
+    RocRay.initWindow! { title: "Random Dots", width, height }
 
     Task.ok {
-        number,
-        seed,
-        width,
-        height,
+        number: 10000,
+        seed: Random.seed 1234,
     }
 
 render : Model, RocRay.PlatformState -> Task Model []
@@ -59,7 +51,7 @@ render = \model, { keys, timestampMillis } ->
 
         Task.forEach! lines Draw.rectangle
 
-        Draw.text! { pos: { x: 10, y: model.height - 25 }, text: "Up-Down to change number of random dots, current value is $(Num.toStr model.number)", size: 20, color: White }
+        Draw.text! { pos: { x: 10, y: height - 25 }, text: "Up-Down to change number of random dots, current value is $(Num.toStr model.number)", size: 20, color: White }
 
     Task.ok { model & seed, number }
 

--- a/examples/reload-text.roc
+++ b/examples/reload-text.roc
@@ -10,16 +10,15 @@ Model : {
 
 init : Task Model []
 init =
-    message = RocRay.loadFileToStr! "examples/assets/reload-text/message.txt"
 
-    RocRay.setWindowSize! { width: 800, height: 600 }
-    RocRay.setWindowTitle! "Reload Text"
+    RocRay.initWindow! { title: "Reload Text" }
+
+    message = RocRay.loadFileToStr! "examples/assets/reload-text/message.txt"
 
     Task.ok { message }
 
 render : Model, RocRay.PlatformState -> Task Model []
 render = \model, { mouse } ->
-    dbg mouse
 
     buttonRect = {
         x: 100,

--- a/examples/sprites.roc
+++ b/examples/sprites.roc
@@ -19,8 +19,7 @@ init : Task Model []
 init =
 
     RocRay.setTargetFPS! 60
-    RocRay.setWindowSize! { width, height }
-    RocRay.setWindowTitle! "Animated Sprite Example"
+    RocRay.initWindow! { title: "Animated Sprite Example" }
 
     dude = Texture.load! "examples/assets/sprite-dude/sheet.png"
 

--- a/examples/squares.roc
+++ b/examples/squares.roc
@@ -16,8 +16,7 @@ height = 400
 init : Task Model []
 init =
 
-    RocRay.setWindowSize! { width, height }
-    RocRay.setWindowTitle! "Squares Demo"
+    RocRay.initWindow! { title: "Squares Demo", width, height }
 
     Task.ok {
         circlePos: { x: width / 2, y: height / 2 },

--- a/platform/Effect.roc
+++ b/platform/Effect.roc
@@ -4,12 +4,10 @@ hosted Effect
         RenderTexture,
         Sound,
         Camera,
-        setWindowSize,
         getScreenSize,
         exit,
         drawText,
         measureText,
-        setWindowTitle,
         drawLine,
         drawRectangle,
         drawRectangleGradientV,
@@ -44,7 +42,6 @@ import InternalColor exposing [RocColor]
 import InternalVector exposing [RocVector2]
 import InternalRectangle exposing [RocRectangle]
 
-setWindowSize : I32, I32 -> Task {} {}
 getScreenSize : Task { height : I32, width : I32, z : I64 } {}
 
 exit : Task {} {}
@@ -62,12 +59,11 @@ toLogLevel = \level ->
         LogNone -> 7
 
 log : Str, I32 -> Task {} {}
-initWindow : Task {} {}
+
+initWindow : Str, F32, F32 -> Task {} {}
 
 drawText : RocVector2, I32, Str, RocColor -> Task {} {}
 measureText : Str, I32 -> Task I64 {}
-
-setWindowTitle : Str -> Task {} {}
 
 drawLine : RocVector2, RocVector2, RocColor -> Task {} {}
 

--- a/platform/Effect.roc
+++ b/platform/Effect.roc
@@ -21,6 +21,7 @@ hosted Effect
         takeScreenshot,
         createCamera,
         updateCamera,
+        initWindow,
         beginDrawing,
         endDrawing,
         beginTexture,
@@ -61,6 +62,7 @@ toLogLevel = \level ->
         LogNone -> 7
 
 log : Str, I32 -> Task {} {}
+initWindow : Task {} {}
 
 drawText : RocVector2, I32, Str, RocColor -> Task {} {}
 measureText : Str, I32 -> Task I64 {}

--- a/platform/RocRay.roc
+++ b/platform/RocRay.roc
@@ -9,11 +9,9 @@ module [
     RenderTexture,
     Sound,
     rgba,
-    setWindowSize,
     getScreenSize,
     initWindow,
     exit,
-    setWindowTitle,
     setTargetFPS,
     setDrawFPS,
     measureText,
@@ -154,27 +152,16 @@ log = \message, level ->
     Effect.log message (Effect.toLogLevel level)
     |> Task.mapErr \{} -> crash "unreachable log"
 
-initWindow : Task {} *
-initWindow = Effect.initWindow |> Task.mapErr \{} -> crash "unreachable initWindow"
-
-## Set the window title.
-##
-## ```
-## RocRay.setWindowTitle! "My Roc Game"
-## ```
-setWindowTitle : Str -> Task {} *
-setWindowTitle = \title ->
-    Effect.setWindowTitle title
-    |> Task.mapErr \{} -> crash "unreachable setWindowTitle"
-
-## Set the window size.
-## ```
-## RocRay.setWindowSize! { width: 800, height: 600 }
-## ```
-setWindowSize : { width : F32, height : F32 } -> Task {} *
-setWindowSize = \{ width, height } ->
-    Effect.setWindowSize (Num.round width) (Num.round height)
-    |> Task.mapErr \{} -> crash "unreachable setWindowSize"
+initWindow :
+    {
+        title ? Str,
+        width ? F32,
+        height ? F32,
+    }
+    -> Task {} *
+initWindow = \{ title ? "RocRay", width ? 800, height ? 600 } ->
+    Effect.initWindow title width height
+    |> Task.mapErr \{} -> crash "unreachable initWindow"
 
 ## Get the window size.
 getScreenSize : Task { height : F32, width : F32 } *

--- a/platform/RocRay.roc
+++ b/platform/RocRay.roc
@@ -11,6 +11,7 @@ module [
     rgba,
     setWindowSize,
     getScreenSize,
+    initWindow,
     exit,
     setWindowTitle,
     setTargetFPS,
@@ -152,6 +153,9 @@ log : Str, [LogAll, LogTrace, LogDebug, LogInfo, LogWarning, LogError, LogFatal,
 log = \message, level ->
     Effect.log message (Effect.toLogLevel level)
     |> Task.mapErr \{} -> crash "unreachable log"
+
+initWindow : Task {} *
+initWindow = Effect.initWindow |> Task.mapErr \{} -> crash "unreachable initWindow"
 
 ## Set the window title.
 ##

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,68 @@
+use std::cell::RefCell;
+use std::ffi::{c_int, CString};
+
+thread_local! {
+    static CONFIG: RefCell<Config> = RefCell::new(Config {
+        title: CString::new("Loading roc-ray app...").unwrap(),
+        width: 200,
+        height: 50,
+        should_exit: false,
+        fps_show: false,
+        fps_target: 60,
+        fps_target_dirty: false,
+        fps_position: (10, 10),
+        trace_log_level: TraceLevel::Info,
+    });
+}
+
+pub fn with<F, R>(f: F) -> R
+where
+    F: FnOnce(&Config) -> R,
+{
+    CONFIG.with(|config| f(&*config.borrow()))
+}
+
+pub fn update<F>(f: F)
+where
+    F: FnOnce(&mut Config),
+{
+    CONFIG.with(|config| f(&mut *config.borrow_mut()));
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum TraceLevel {
+    None,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+    All,
+}
+
+impl From<TraceLevel> for c_int {
+    fn from(value: TraceLevel) -> Self {
+        match value {
+            TraceLevel::None => crate::bindings::TraceLogLevel_LOG_NONE as c_int,
+            TraceLevel::Error => crate::bindings::TraceLogLevel_LOG_ERROR as c_int,
+            TraceLevel::Warn => crate::bindings::TraceLogLevel_LOG_WARNING as c_int,
+            TraceLevel::Info => crate::bindings::TraceLogLevel_LOG_INFO as c_int,
+            TraceLevel::Debug => crate::bindings::TraceLogLevel_LOG_DEBUG as c_int,
+            TraceLevel::Trace => crate::bindings::TraceLogLevel_LOG_TRACE as c_int,
+            TraceLevel::All => crate::bindings::TraceLogLevel_LOG_ALL as c_int,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Config {
+    pub title: CString,
+    pub width: c_int,
+    pub height: c_int,
+    pub should_exit: bool,
+    pub fps_show: bool,
+    pub fps_target: c_int,
+    pub fps_target_dirty: bool,
+    pub fps_position: (c_int, c_int),
+    pub trace_log_level: TraceLevel,
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::ffi::{c_int, CString};
 
 thread_local! {
+    // DEFAULT VALUES
     static CONFIG: RefCell<Config> = RefCell::new(Config {
         title: CString::new("Loading roc-ray app...").unwrap(),
         width: 200,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,15 @@
+use platform_mode::PlatformEffect;
 use roc_std::{RocBox, RocList, RocResult, RocStr};
 use roc_std_heap::ThreadSafeRefcountedResourceHeap;
 use std::array;
-use std::cell::{Cell, RefCell};
 use std::ffi::{c_int, CString};
 use std::time::SystemTime;
 
 mod bindings;
+mod config;
 mod glue;
+mod platform_mode;
 mod roc;
-
-thread_local! {
-    static DRAW_FPS: Cell<Option<(i32, i32)>> = const { Cell::new(None) };
-    static SHOULD_EXIT: Cell<bool> = const { Cell::new(false) };
-    static PLATFORM_MODE: RefCell<PlatformMode> = const { RefCell::new(PlatformMode::None) };
-}
 
 /// use different error codes when the app exits
 #[derive(Debug)]
@@ -22,171 +18,25 @@ enum ExitErrCode {
     ExitHeapFull = 2,
 }
 
-/// we check at runtime which mode the platform is in and if the effect is permitted
-///
-/// is an app author tries to call an effect that is not permitted in the current mode
-/// the app will exit with an error code and provide a message to the user
-///
-/// this is used to keep the API very simple instead of having each effect return a result
-/// or taking an argument which "locks" which effects are permitted.
-///
-/// if this is expensive for performance, we can only include this in dev builds and remove
-/// it in release builds
-#[derive(Debug, Clone, Copy, PartialEq)]
-enum PlatformMode {
-    None,
-    TextureMode,
-    TextureModeDraw2D,
-    FramebufferMode,
-    FramebufferModeDraw2D,
-}
-
-/// effects that are only permitted in certain modes
-///
-/// not all effects need to be listed here
-enum PlatformEffect {
-    BeginDrawingFramebuffer,
-    EndDrawingFramebuffer,
-    BeginMode2D,
-    EndMode2D,
-    BeginDrawingTexture,
-    EndDrawingTexture,
-    CreateCamera,
-    UpdateCamera,
-    LoadTexture,
-    CreateRenderTexture,
-    SetWindowSize,
-    SetWindowTitle,
-    SetTargetFPS,
-    GetScreenSize,
-    LoadSound,
-    DrawCircle,
-    DrawCircleGradient,
-    DrawRectangleGradientV,
-    DrawRectangleGradientH,
-    DrawText,
-    DrawRectangle,
-    DrawLine,
-    DrawTextureRectangle,
-}
-
-impl PlatformMode {
-    /// only these modes are permitted to "draw" as raylib has a framebuffer and texture ready
-    #[inline]
-    fn is_draw_mode(&self) -> bool {
-        use PlatformMode::*;
-        matches!(
-            self,
-            FramebufferMode | FramebufferModeDraw2D | TextureMode | TextureModeDraw2D
-        )
-    }
-
-    fn matches(&self, other: PlatformMode) -> bool {
-        *self == other
-    }
-
-    #[inline]
-    fn is_effect_permitted(&self, e: PlatformEffect) -> bool {
-        use PlatformEffect::*;
-        use PlatformMode::*;
-
-        // we only need to track the "permitted" effects, everything else is "not permitted"
-        match (self, e) {
-            (None, CreateCamera)
-            | (None, UpdateCamera)
-            | (None, SetWindowSize)
-            | (None, SetWindowTitle)
-            | (None, SetTargetFPS)
-            | (None, GetScreenSize)
-            | (None, LoadSound)
-            | (None, LoadTexture)
-            | (None, CreateRenderTexture)
-            | (None, BeginDrawingFramebuffer)
-            | (None, BeginDrawingTexture)
-            | (FramebufferMode, BeginMode2D)
-            | (FramebufferMode, EndDrawingFramebuffer)
-            | (FramebufferModeDraw2D, EndMode2D)
-            | (TextureMode, EndDrawingTexture)
-            | (TextureMode, BeginMode2D)
-            | (TextureModeDraw2D, EndMode2D) => true,
-            (mode, DrawCircle) if mode.is_draw_mode() => true,
-            (mode, DrawCircleGradient) if mode.is_draw_mode() => true,
-            (mode, DrawRectangleGradientV) if mode.is_draw_mode() => true,
-            (mode, DrawRectangleGradientH) if mode.is_draw_mode() => true,
-            (mode, DrawText) if mode.is_draw_mode() => true,
-            (mode, DrawRectangle) if mode.is_draw_mode() => true,
-            (mode, DrawLine) if mode.is_draw_mode() => true,
-            (mode, DrawTextureRectangle) if mode.is_draw_mode() => true,
-            (_, _) => false,
-        }
-    }
-
-    #[inline]
-    fn as_str(&self) -> &'static str {
-        use PlatformMode::*;
-        match self {
-            None => "None",
-            FramebufferMode => "FramebufferMode",
-            FramebufferModeDraw2D => "FramebufferModeDraw2D",
-            TextureMode => "TextureMode",
-            TextureModeDraw2D => "TextureModeDraw2D",
-        }
-    }
-}
-
-fn is_effect_permitted(e: PlatformEffect) -> bool {
-    PLATFORM_MODE.with(|mode| mode.borrow().is_effect_permitted(e))
-}
-
-fn platform_mode_str() -> &'static str {
-    PLATFORM_MODE.with(|m| m.borrow().as_str())
-}
-
-fn update_platform_mode(mode: PlatformMode) {
-    PLATFORM_MODE.with(|m| *m.borrow_mut() = mode);
-}
-
-/// check if in framebuffer or texture mode before moving to the next mode
-fn update_platform_mode_draw_2d() {
-    PLATFORM_MODE.with(|m| {
-        use PlatformMode::*;
-        let mut mode = m.borrow_mut();
-        if mode.matches(FramebufferMode) {
-            *mode = FramebufferModeDraw2D;
-        } else if mode.matches(FramebufferModeDraw2D) {
-            *mode = FramebufferMode;
-        } else if mode.matches(TextureMode) {
-            *mode = TextureModeDraw2D;
-        } else if mode.matches(TextureModeDraw2D) {
-            *mode = TextureMode;
-        } else {
-            panic!("unreachable, invalid mode should have been caught by is_effect_permitted")
-        }
-    });
-}
-
 fn main() {
+    // CALL INTO ROC FOR INITALIZATION
+    let mut model = roc::call_roc_init();
+
+    // MANUALLY TRANSITION TO RENDER MODE
+    platform_mode::update(PlatformEffect::EndInitWindow).unwrap();
+
+    let mut frame_count = 0;
+
     unsafe {
-        let c_title = CString::new("Loading...").unwrap();
-
-        bindings::InitWindow(100, 50, c_title.as_ptr());
-        if !bindings::IsWindowReady() {
-            panic!("Attempting to create window failed!");
-        }
-
-        let mut frame_count = 0;
-
-        #[cfg(feature = "trace-debug")]
-        bindings::SetTraceLogLevel(bindings::TraceLogLevel_LOG_DEBUG as i32);
-
-        bindings::InitAudioDevice();
-
-        let mut model = roc::call_roc_init();
-
-        while !bindings::WindowShouldClose() && !SHOULD_EXIT.get() {
+        while !bindings::WindowShouldClose() && !(config::with(|c| c.should_exit)) {
             let duration_since_epoch = SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .unwrap();
+
+            if config::with(|c| c.fps_target_dirty) {
+                bindings::SetTargetFPS(config::with(|c| c.fps_target));
+                config::update(|c| c.fps_target_dirty = false);
+            }
 
             let timestamp = duration_since_epoch.as_millis() as u64; // we are casting to u64 and losing precision
 
@@ -208,8 +58,8 @@ fn main() {
 
             model = roc::call_roc_render(platform_state, &model);
 
-            if let Some((x, y)) = DRAW_FPS.get() {
-                bindings::DrawFPS(x, y);
+            if config::with(|c| c.fps_show) {
+                config::with(|c| bindings::DrawFPS(c.fps_position.0, c.fps_position.1));
             }
 
             frame_count += 1;
@@ -231,12 +81,16 @@ fn exit_with_msg(msg: String, code: ExitErrCode) -> ! {
 
 #[no_mangle]
 pub extern "C" fn roc_fx_exit() -> RocResult<(), ()> {
-    SHOULD_EXIT.set(true);
+    config::update(|c| c.should_exit = true);
     RocResult::ok(())
 }
 
 #[no_mangle]
 unsafe extern "C" fn roc_fx_log(msg: &RocStr, level: i32) -> RocResult<(), ()> {
+    if let Err(msg) = platform_mode::update(PlatformEffect::LogMsg) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
+    }
+
     let text = CString::new(msg.as_str()).unwrap();
     if level >= 0 && level <= 7 {
         bindings::TraceLog(level, text.as_ptr())
@@ -247,37 +101,56 @@ unsafe extern "C" fn roc_fx_log(msg: &RocStr, level: i32) -> RocResult<(), ()> {
     RocResult::ok(())
 }
 
-#[allow(unused_variables)]
 #[no_mangle]
-extern "C" fn roc_fx_setWindowSize(width: i32, height: i32) -> RocResult<(), ()> {
-    if !is_effect_permitted(PlatformEffect::SetWindowSize) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot set the window size while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+pub extern "C" fn roc_fx_initWindow() -> RocResult<(), ()> {
+    if let Err(msg) = platform_mode::update(PlatformEffect::InitWindow) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
-    #[cfg(not(test))]
+    let title = config::with(|c| c.title.as_ptr());
+    let width = config::with(|c| c.width);
+    let height = config::with(|c| c.height);
+
     unsafe {
-        bindings::SetWindowSize(width, height);
+        bindings::InitWindow(width, height, title);
+
+        // wait for the window to be ready (blocking)
+        if !bindings::IsWindowReady() {
+            panic!("Attempting to create window failed!");
+        }
+
+        bindings::SetTraceLogLevel(config::with(|c| c.trace_log_level.into()));
+        bindings::SetTargetFPS(config::with(|c| c.fps_target));
+
+        bindings::InitAudioDevice();
     }
 
     RocResult::ok(())
 }
 
 #[no_mangle]
-unsafe extern "C" fn roc_fx_setWindowTitle(text: &RocStr) -> RocResult<(), ()> {
-    if !is_effect_permitted(PlatformEffect::SetWindowTitle) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot set the window title while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+extern "C" fn roc_fx_setWindowSize(width: i32, height: i32) -> RocResult<(), ()> {
+    if let Err(msg) = platform_mode::update(PlatformEffect::SetWindowSize) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
-    let text = CString::new(text.as_str()).unwrap();
-    bindings::SetWindowTitle(text.as_ptr());
+    config::update(|c| {
+        c.width = width;
+        c.height = height;
+    });
+
+    RocResult::ok(())
+}
+
+#[no_mangle]
+extern "C" fn roc_fx_setWindowTitle(text: &RocStr) -> RocResult<(), ()> {
+    if let Err(msg) = platform_mode::update(PlatformEffect::SetWindowTitle) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
+    }
+
+    config::update(|c| {
+        c.title = CString::new(text.as_str()).unwrap();
+    });
 
     RocResult::ok(())
 }
@@ -288,53 +161,53 @@ unsafe extern "C" fn roc_fx_drawCircle(
     radius: f32,
     color: glue::RocColor,
 ) -> RocResult<(), ()> {
-    if !is_effect_permitted(PlatformEffect::DrawCircle) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot draw a circle while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+    if let Err(msg) = platform_mode::update(PlatformEffect::DrawCircle) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
-    bindings::DrawCircleV(center.into(), radius, color.into());
+
+    unsafe {
+        bindings::DrawCircleV(center.into(), radius, color.into());
+    }
+
     RocResult::ok(())
 }
 
 #[no_mangle]
-unsafe extern "C" fn roc_fx_drawCircleGradient(
+extern "C" fn roc_fx_drawCircleGradient(
     center: &glue::RocVector2,
     radius: f32,
     inner: glue::RocColor,
     outer: glue::RocColor,
 ) -> RocResult<(), ()> {
-    if !is_effect_permitted(PlatformEffect::DrawCircleGradient) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot draw a circle with gradient while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+    if let Err(msg) = platform_mode::update(PlatformEffect::DrawCircleGradient) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
     let (x, y) = center.to_components_c_int();
-    bindings::DrawCircleGradient(x, y, radius, inner.into(), outer.into());
+
+    unsafe {
+        bindings::DrawCircleGradient(x, y, radius, inner.into(), outer.into());
+    }
+
     RocResult::ok(())
 }
 
 #[no_mangle]
-unsafe extern "C" fn roc_fx_drawRectangleGradientV(
+extern "C" fn roc_fx_drawRectangleGradientV(
     rect: &glue::RocRectangle,
     top: glue::RocColor,
     bottom: glue::RocColor,
 ) -> RocResult<(), ()> {
-    if !is_effect_permitted(PlatformEffect::DrawRectangleGradientV) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot draw a rectangle with verticle gradient while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+    if let Err(msg) = platform_mode::update(PlatformEffect::DrawRectangleGradientV) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
     let (x, y, w, h) = rect.to_components_c_int();
-    bindings::DrawRectangleGradientV(x, y, w, h, top.into(), bottom.into());
+
+    unsafe {
+        bindings::DrawRectangleGradientV(x, y, w, h, top.into(), bottom.into());
+    }
+
     RocResult::ok(())
 }
 
@@ -344,16 +217,16 @@ unsafe extern "C" fn roc_fx_drawRectangleGradientH(
     top: glue::RocColor,
     bottom: glue::RocColor,
 ) -> RocResult<(), ()> {
-    if !is_effect_permitted(PlatformEffect::DrawRectangleGradientH) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot draw a rectangle with verticle gradient while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+    if let Err(msg) = platform_mode::update(PlatformEffect::DrawRectangleGradientH) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
     let (x, y, w, h) = rect.to_components_c_int();
-    bindings::DrawRectangleGradientV(x, y, w, h, top.into(), bottom.into());
+
+    unsafe {
+        bindings::DrawRectangleGradientV(x, y, w, h, top.into(), bottom.into());
+    }
+
     RocResult::ok(())
 }
 
@@ -364,52 +237,50 @@ unsafe extern "C" fn roc_fx_drawText(
     text: &RocStr,
     color: glue::RocColor,
 ) -> RocResult<(), ()> {
-    if !is_effect_permitted(PlatformEffect::DrawText) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot draw text while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+    if let Err(msg) = platform_mode::update(PlatformEffect::DrawText) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
     let text = CString::new(text.as_bytes()).unwrap();
     let (x, y) = pos.to_components_c_int();
-    bindings::DrawText(text.as_ptr(), x, y, size as c_int, color.into());
+
+    unsafe {
+        bindings::DrawText(text.as_ptr(), x, y, size as c_int, color.into());
+    }
+
     RocResult::ok(())
 }
 
 #[no_mangle]
-unsafe extern "C" fn roc_fx_drawRectangle(
+extern "C" fn roc_fx_drawRectangle(
     rect: &glue::RocRectangle,
     color: glue::RocColor,
 ) -> RocResult<(), ()> {
-    if !is_effect_permitted(PlatformEffect::DrawRectangle) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot draw rectangle while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+    if let Err(msg) = platform_mode::update(PlatformEffect::DrawRectangle) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
-    bindings::DrawRectangleRec(rect.into(), color.into());
+    unsafe {
+        bindings::DrawRectangleRec(rect.into(), color.into());
+    }
+
     RocResult::ok(())
 }
 
 #[no_mangle]
-unsafe extern "C" fn roc_fx_drawLine(
+extern "C" fn roc_fx_drawLine(
     start: &glue::RocVector2,
     end: &glue::RocVector2,
     color: glue::RocColor,
 ) -> RocResult<(), ()> {
-    if !is_effect_permitted(PlatformEffect::DrawLine) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot draw line while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+    if let Err(msg) = platform_mode::update(PlatformEffect::DrawLine) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
-    bindings::DrawLineV(start.into(), end.into(), color.into());
+    unsafe {
+        bindings::DrawLineV(start.into(), end.into(), color.into());
+    }
+
     RocResult::ok(())
 }
 
@@ -422,46 +293,52 @@ struct ScreenSize {
 
 #[no_mangle]
 unsafe extern "C" fn roc_fx_getScreenSize() -> RocResult<ScreenSize, ()> {
-    if !is_effect_permitted(PlatformEffect::GetScreenSize) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot get screen size while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+    if let Err(msg) = platform_mode::update(PlatformEffect::GetScreenSize) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
-    let height = bindings::GetScreenHeight();
-    let width = bindings::GetScreenWidth();
-    RocResult::ok(ScreenSize {
-        height,
-        width,
-        z: 0,
-    })
+    unsafe {
+        let height = bindings::GetScreenHeight();
+        let width = bindings::GetScreenWidth();
+        RocResult::ok(ScreenSize {
+            height,
+            width,
+            z: 0,
+        })
+    }
 }
 
 #[no_mangle]
-unsafe extern "C" fn roc_fx_measureText(text: &RocStr, size: i32) -> RocResult<i64, ()> {
-    // permitted in any mode
+extern "C" fn roc_fx_measureText(text: &RocStr, size: i32) -> RocResult<i64, ()> {
+    if let Err(msg) = platform_mode::update(PlatformEffect::MeasureText) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
+    }
+
     let text = CString::new(text.as_str()).unwrap();
-    let width = bindings::MeasureText(text.as_ptr(), size as c_int);
+    let width = unsafe { bindings::MeasureText(text.as_ptr(), size as c_int) };
     RocResult::ok(width as i64)
 }
 
 #[no_mangle]
 unsafe extern "C" fn roc_fx_setTargetFPS(rate: i32) -> RocResult<(), ()> {
-    if !is_effect_permitted(PlatformEffect::SetTargetFPS) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot set target FPS while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+    if let Err(msg) = platform_mode::update(PlatformEffect::SetTargetFPS) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
-    bindings::SetTargetFPS(rate as c_int);
+
+    config::update(|c| {
+        c.fps_target_dirty = true;
+        c.fps_target = rate as c_int
+    });
+
     RocResult::ok(())
 }
 
 #[no_mangle]
 unsafe extern "C" fn roc_fx_takeScreenshot(path: &RocStr) -> RocResult<(), ()> {
+    if let Err(msg) = platform_mode::update(PlatformEffect::TakeScreenshot) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
+    }
+
     // permitted in any mode
     let path = CString::new(path.as_str()).unwrap();
     bindings::TakeScreenshot(path.as_ptr());
@@ -470,29 +347,27 @@ unsafe extern "C" fn roc_fx_takeScreenshot(path: &RocStr) -> RocResult<(), ()> {
 
 #[no_mangle]
 unsafe extern "C" fn roc_fx_setDrawFPS(show: bool, pos_x: i32, pos_y: i32) -> RocResult<(), ()> {
-    // permitted in any mode
-    if show {
-        DRAW_FPS.set(Some((pos_x, pos_y)));
-    } else {
-        DRAW_FPS.set(None);
+    if let Err(msg) = platform_mode::update(PlatformEffect::SetDrawFPS) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
+
+    config::update(|c| {
+        c.fps_show = show;
+        c.fps_position = (pos_x, pos_y)
+    });
 
     RocResult::ok(())
 }
 
 #[no_mangle]
-unsafe extern "C" fn roc_fx_createCamera(
+extern "C" fn roc_fx_createCamera(
     target: &glue::RocVector2,
     offset: &glue::RocVector2,
     rotation: f32,
     zoom: f32,
 ) -> RocResult<RocBox<()>, ()> {
-    if !is_effect_permitted(PlatformEffect::CreateCamera) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot create a camera while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+    if let Err(msg) = platform_mode::update(PlatformEffect::CreateCamera) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
     let camera = bindings::Camera2D {
@@ -514,20 +389,14 @@ unsafe extern "C" fn roc_fx_createCamera(
 }
 
 #[no_mangle]
-unsafe extern "C" fn roc_fx_createRenderTexture(
-    size: &glue::RocVector2,
-) -> RocResult<RocBox<()>, ()> {
-    if !is_effect_permitted(PlatformEffect::CreateRenderTexture) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot create a render texture while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+extern "C" fn roc_fx_createRenderTexture(size: &glue::RocVector2) -> RocResult<RocBox<()>, ()> {
+    if let Err(msg) = platform_mode::update(PlatformEffect::CreateRenderTexture) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
     let (width, height) = size.to_components_c_int();
 
-    let render_texture: bindings::RenderTexture = bindings::LoadRenderTexture(width, height);
+    let render_texture = unsafe { bindings::LoadRenderTexture(width, height) };
 
     let heap = roc::render_texture_heap();
 
@@ -548,12 +417,8 @@ unsafe extern "C" fn roc_fx_updateCamera(
     rotation: f32,
     zoom: f32,
 ) -> RocResult<(), ()> {
-    if !is_effect_permitted(PlatformEffect::UpdateCamera) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot update camera while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+    if let Err(msg) = platform_mode::update(PlatformEffect::UpdateCamera) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
     let camera: &mut bindings::Camera2D =
@@ -567,22 +432,13 @@ unsafe extern "C" fn roc_fx_updateCamera(
     RocResult::ok(())
 }
 
-#[allow(unused_variables)]
 #[no_mangle]
 extern "C" fn roc_fx_beginDrawing(clear_color: glue::RocColor) -> RocResult<(), ()> {
-    if !is_effect_permitted(PlatformEffect::BeginDrawingFramebuffer) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot begin drawing while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+    if let Err(msg) = platform_mode::update(PlatformEffect::BeginDrawingFramebuffer) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
-    update_platform_mode(PlatformMode::FramebufferMode);
-
-    #[cfg(not(test))]
     unsafe {
-        #[cfg(feature = "trace-debug")]
         trace_log("BeginDrawing");
 
         bindings::BeginDrawing();
@@ -594,21 +450,12 @@ extern "C" fn roc_fx_beginDrawing(clear_color: glue::RocColor) -> RocResult<(), 
 
 #[no_mangle]
 extern "C" fn roc_fx_endDrawing() -> RocResult<(), ()> {
-    if !is_effect_permitted(PlatformEffect::EndDrawingFramebuffer) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot end drawing while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+    if let Err(msg) = platform_mode::update(PlatformEffect::EndDrawingFramebuffer) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
-    update_platform_mode(PlatformMode::None);
-
-    #[cfg(not(test))]
     unsafe {
-        #[cfg(feature = "trace-debug")]
         trace_log("EndDrawing");
-
         bindings::EndMode2D();
     }
 
@@ -618,19 +465,11 @@ extern "C" fn roc_fx_endDrawing() -> RocResult<(), ()> {
 #[allow(unused_variables)]
 #[no_mangle]
 extern "C" fn roc_fx_beginMode2D(boxed_camera: RocBox<()>) -> RocResult<(), ()> {
-    if !is_effect_permitted(PlatformEffect::BeginMode2D) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot begin drawing in 2D while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+    if let Err(msg) = platform_mode::update(PlatformEffect::BeginMode2D) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
-    update_platform_mode_draw_2d();
-
-    #[cfg(not(test))]
     unsafe {
-        #[cfg(feature = "trace-debug")]
         trace_log("BeginMode2D");
 
         let camera: &mut bindings::Camera2D =
@@ -644,21 +483,12 @@ extern "C" fn roc_fx_beginMode2D(boxed_camera: RocBox<()>) -> RocResult<(), ()> 
 
 #[no_mangle]
 extern "C" fn roc_fx_endMode2D(_boxed_camera: RocBox<()>) -> RocResult<(), ()> {
-    if !is_effect_permitted(PlatformEffect::EndMode2D) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot begin drawing in 2D while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+    if let Err(msg) = platform_mode::update(PlatformEffect::EndMode2D) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
-    update_platform_mode_draw_2d();
-
-    #[cfg(not(test))]
     unsafe {
-        #[cfg(feature = "trace-debug")]
         trace_log("EndMode2D");
-
         bindings::EndMode2D();
     }
 
@@ -671,21 +501,12 @@ extern "C" fn roc_fx_beginTexture(
     boxed_render_texture: RocBox<()>,
     clear_color: glue::RocColor,
 ) -> RocResult<(), ()> {
-    if !is_effect_permitted(PlatformEffect::BeginDrawingTexture) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot begin drawing to a render texture while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+    if let Err(msg) = platform_mode::update(PlatformEffect::BeginDrawingTexture) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
-    update_platform_mode(PlatformMode::TextureMode);
-
-    #[cfg(not(test))]
     unsafe {
-        #[cfg(feature = "trace-debug")]
         trace_log("BeginTexture");
-
         let render_texture: &mut bindings::RenderTexture =
             ThreadSafeRefcountedResourceHeap::box_to_resource(boxed_render_texture);
 
@@ -698,21 +519,12 @@ extern "C" fn roc_fx_beginTexture(
 
 #[no_mangle]
 extern "C" fn roc_fx_endTexture(_boxed_render_texture: RocBox<()>) -> RocResult<(), ()> {
-    if !is_effect_permitted(PlatformEffect::EndDrawingTexture) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot end drawing to a render texture while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+    if let Err(msg) = platform_mode::update(PlatformEffect::EndDrawingTexture) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
-    update_platform_mode(PlatformMode::None);
-
-    #[cfg(not(test))]
     unsafe {
-        #[cfg(feature = "trace-debug")]
         trace_log("EndTexture");
-
         bindings::EndTextureMode();
     }
 
@@ -756,18 +568,17 @@ unsafe fn get_keys_states() -> RocList<u8> {
 }
 
 #[no_mangle]
-unsafe extern "C" fn roc_fx_loadSound(path: &RocStr) -> RocResult<RocBox<()>, ()> {
-    if !is_effect_permitted(PlatformEffect::LoadSound) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot load a sound while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+extern "C" fn roc_fx_loadSound(path: &RocStr) -> RocResult<RocBox<()>, ()> {
+    if let Err(msg) = platform_mode::update(PlatformEffect::LoadSound) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
     let path = CString::new(path.as_str()).unwrap();
 
-    let sound = bindings::LoadSound(path.as_ptr());
+    let sound = unsafe {
+        trace_log("LoadSound");
+        bindings::LoadSound(path.as_ptr())
+    };
 
     let heap = roc::sound_heap();
 
@@ -781,29 +592,31 @@ unsafe extern "C" fn roc_fx_loadSound(path: &RocStr) -> RocResult<RocBox<()>, ()
 }
 
 #[no_mangle]
-unsafe extern "C" fn roc_fx_playSound(boxed_sound: RocBox<()>) -> RocResult<(), ()> {
-    // permitted in any mode
+extern "C" fn roc_fx_playSound(boxed_sound: RocBox<()>) -> RocResult<(), ()> {
+    if let Err(msg) = platform_mode::update(PlatformEffect::PlaySound) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
+    }
+
     let sound: &mut bindings::Sound =
         ThreadSafeRefcountedResourceHeap::box_to_resource(boxed_sound);
 
-    bindings::PlaySound(*sound);
+    unsafe {
+        bindings::PlaySound(*sound);
+    }
 
     RocResult::ok(())
 }
 
 #[no_mangle]
-unsafe extern "C" fn roc_fx_loadTexture(file_path: &RocStr) -> RocResult<RocBox<()>, ()> {
-    if !is_effect_permitted(PlatformEffect::LoadTexture) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot load a texture while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+extern "C" fn roc_fx_loadTexture(file_path: &RocStr) -> RocResult<RocBox<()>, ()> {
+    if let Err(msg) = platform_mode::update(PlatformEffect::LoadTexture) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
     // should have a valid utf8 string from roc, no need to check for null bytes
     let file_path = CString::new(file_path.as_str()).unwrap();
-    let texture: bindings::Texture = bindings::LoadTexture(file_path.as_ptr());
+
+    let texture: bindings::Texture = unsafe { bindings::LoadTexture(file_path.as_ptr()) };
 
     let heap = roc::texture_heap();
 
@@ -823,12 +636,8 @@ unsafe extern "C" fn roc_fx_drawTextureRec(
     position: &glue::RocVector2,
     color: glue::RocColor,
 ) -> RocResult<(), ()> {
-    if !is_effect_permitted(PlatformEffect::DrawTextureRectangle) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot draw a texture rectangle while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+    if let Err(msg) = platform_mode::update(PlatformEffect::DrawTextureRectangle) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
     let texture: &mut bindings::Texture =
@@ -846,12 +655,8 @@ unsafe extern "C" fn roc_fx_drawRenderTextureRec(
     position: &glue::RocVector2,
     color: glue::RocColor,
 ) -> RocResult<(), ()> {
-    if !is_effect_permitted(PlatformEffect::DrawTextureRectangle) {
-        let mode = platform_mode_str();
-        exit_with_msg(
-            format!("Cannot draw a texture rectangle while in {mode}"),
-            ExitErrCode::ExitEffectNotPermitted,
-        );
+    if let Err(msg) = platform_mode::update(PlatformEffect::DrawTextureRectangle) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
 
     let texture: &mut bindings::RenderTexture =
@@ -869,6 +674,10 @@ unsafe extern "C" fn roc_fx_drawRenderTextureRec(
 
 #[no_mangle]
 unsafe extern "C" fn roc_fx_loadFileToStr(path: &RocStr) -> RocResult<RocStr, ()> {
+    if let Err(msg) = platform_mode::update(PlatformEffect::LoadFileToStr) {
+        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
+    }
+
     let path = path.as_str();
     let Ok(contents) = std::fs::read_to_string(path) else {
         panic!("file not found: {path}");
@@ -880,83 +689,8 @@ unsafe extern "C" fn roc_fx_loadFileToStr(path: &RocStr) -> RocResult<RocStr, ()
     RocResult::ok(contents)
 }
 
-#[cfg(feature = "trace-debug")]
 unsafe fn trace_log(msg: &str) {
     let level = bindings::TraceLogLevel_LOG_DEBUG;
     let text = CString::new(msg).unwrap();
     bindings::TraceLog(level as i32, text.as_ptr());
-}
-
-#[cfg(test)]
-mod test_platform_mode_transitions {
-    use super::*;
-
-    fn set_platform_mode(mode: PlatformMode) {
-        PLATFORM_MODE.with(|m| *m.borrow_mut() = mode);
-    }
-
-    fn get_platform_mode() -> PlatformMode {
-        PLATFORM_MODE.with(|m| m.borrow().clone())
-    }
-
-    #[test]
-    fn test_initial_mode() {
-        assert_eq!(get_platform_mode(), PlatformMode::None);
-    }
-
-    #[test]
-    fn test_begin_drawing_framebuffer() {
-        set_platform_mode(PlatformMode::None);
-        roc_fx_beginDrawing(glue::RocColor::WHITE);
-        assert_eq!(get_platform_mode(), PlatformMode::FramebufferMode);
-    }
-
-    #[test]
-    fn test_end_drawing_framebuffer() {
-        set_platform_mode(PlatformMode::FramebufferMode);
-        roc_fx_endDrawing();
-        assert_eq!(get_platform_mode(), PlatformMode::None);
-    }
-
-    #[test]
-    fn test_begin_texture() {
-        set_platform_mode(PlatformMode::None);
-        roc_fx_beginTexture(RocBox::new(()), glue::RocColor::WHITE);
-        assert_eq!(get_platform_mode(), PlatformMode::TextureMode);
-    }
-
-    #[test]
-    fn test_end_texture() {
-        set_platform_mode(PlatformMode::TextureMode);
-        roc_fx_endTexture(RocBox::new(()));
-        assert_eq!(get_platform_mode(), PlatformMode::None);
-    }
-
-    #[test]
-    fn test_begin_mode_2d_from_framebuffer() {
-        set_platform_mode(PlatformMode::FramebufferMode);
-        roc_fx_beginMode2D(RocBox::new(()));
-        assert_eq!(get_platform_mode(), PlatformMode::FramebufferModeDraw2D);
-    }
-
-    #[test]
-    fn test_end_mode_2d_to_framebuffer() {
-        set_platform_mode(PlatformMode::FramebufferModeDraw2D);
-        roc_fx_endMode2D(RocBox::new(()));
-        assert_eq!(get_platform_mode(), PlatformMode::FramebufferMode);
-    }
-
-    #[test]
-    fn test_begin_mode_2d_from_texture() {
-        set_platform_mode(PlatformMode::TextureMode);
-        roc_fx_beginMode2D(RocBox::new(()));
-        assert_eq!(get_platform_mode(), PlatformMode::TextureModeDraw2D);
-    }
-
-    #[test]
-    fn test_end_mode_2d_to_texture() {
-        set_platform_mode(PlatformMode::TextureModeDraw2D);
-        roc_fx_endMode2D(RocBox::new(()));
-        assert_eq!(get_platform_mode(), PlatformMode::TextureMode);
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,13 @@ unsafe extern "C" fn roc_fx_log(msg: &RocStr, level: i32) -> RocResult<(), ()> {
 }
 
 #[no_mangle]
-pub extern "C" fn roc_fx_initWindow() -> RocResult<(), ()> {
+pub extern "C" fn roc_fx_initWindow(title: &RocStr, width: f32, height: f32) -> RocResult<(), ()> {
+    config::update(|c| {
+        c.title = CString::new(title.to_string()).unwrap();
+        c.width = width as i32;
+        c.height = height as i32;
+    });
+
     if let Err(msg) = platform_mode::update(PlatformEffect::InitWindow) {
         exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
     }
@@ -124,33 +130,6 @@ pub extern "C" fn roc_fx_initWindow() -> RocResult<(), ()> {
 
         bindings::InitAudioDevice();
     }
-
-    RocResult::ok(())
-}
-
-#[no_mangle]
-extern "C" fn roc_fx_setWindowSize(width: i32, height: i32) -> RocResult<(), ()> {
-    if let Err(msg) = platform_mode::update(PlatformEffect::SetWindowSize) {
-        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
-    }
-
-    config::update(|c| {
-        c.width = width;
-        c.height = height;
-    });
-
-    RocResult::ok(())
-}
-
-#[no_mangle]
-extern "C" fn roc_fx_setWindowTitle(text: &RocStr) -> RocResult<(), ()> {
-    if let Err(msg) = platform_mode::update(PlatformEffect::SetWindowTitle) {
-        exit_with_msg(msg, ExitErrCode::ExitEffectNotPermitted);
-    }
-
-    config::update(|c| {
-        c.title = CString::new(text.as_str()).unwrap();
-    });
 
     RocResult::ok(())
 }

--- a/src/platform_mode.rs
+++ b/src/platform_mode.rs
@@ -1,0 +1,275 @@
+use std::cell::RefCell;
+
+thread_local! {
+    static PLATFORM_MODE: RefCell<PlatformMode> = const { RefCell::new(PlatformMode::Init) };
+}
+
+/// we check at runtime which mode the platform is in and if the effect is permitted
+///
+/// is an app author tries to call an effect that is not permitted in the current mode
+/// the app will exit with an error code and provide a message to the user
+///
+/// this is used to keep the API very simple instead of having each effect return a result
+/// or taking an argument which "locks" which effects are permitted.
+///
+/// if this is expensive for performance, we can only include this in dev builds and remove
+/// it in release builds
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PlatformMode {
+    Init,
+    InitRaylib,
+    Render,
+    TextureMode,
+    TextureModeDraw2D,
+    FramebufferMode,
+    FramebufferModeDraw2D,
+}
+
+/// effects that are only permitted in certain modes
+///
+/// not all effects need to be listed here
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PlatformEffect {
+    BeginDrawingFramebuffer,
+    EndDrawingFramebuffer,
+    BeginMode2D,
+    EndMode2D,
+    BeginDrawingTexture,
+    EndDrawingTexture,
+    CreateCamera,
+    UpdateCamera,
+    LoadTexture,
+    CreateRenderTexture,
+    TakeScreenshot,
+    InitWindow,
+    EndInitWindow,
+    SetWindowSize,
+    LogMsg,
+    SetWindowTitle,
+    SetTargetFPS,
+    GetScreenSize,
+    LoadSound,
+    LoadFileToStr,
+    PlaySound,
+    DrawCircle,
+    DrawCircleGradient,
+    DrawRectangleGradientV,
+    DrawRectangleGradientH,
+    SetDrawFPS,
+    MeasureText,
+    DrawText,
+    DrawRectangle,
+    DrawLine,
+    DrawTextureRectangle,
+}
+
+impl PlatformMode {
+    /// only these modes are permitted to "draw" as raylib has a framebuffer and texture ready
+    fn is_draw_mode(&self) -> bool {
+        use PlatformMode::*;
+        matches!(
+            self,
+            FramebufferMode | FramebufferModeDraw2D | TextureMode | TextureModeDraw2D
+        )
+    }
+
+    fn not_init(&self) -> bool {
+        !matches!(self, PlatformMode::Init)
+    }
+
+    fn is_effect_permitted(&self, e: PlatformEffect) -> bool {
+        use PlatformEffect::*;
+        use PlatformMode::*;
+
+        // we only need to track the "permitted" effects, everything else is "not permitted"
+        match (self, e) {
+            // PERMITTED ONLY DURING INIT BEFORE RAYLIB INIT
+            (Init, SetWindowSize) | (Init, SetWindowTitle) => true,
+
+            // PERMITTED ONLY DURING INIT AFTER RAYLIB WINDOW INIT
+            (InitRaylib, CreateCamera)
+            | (InitRaylib, UpdateCamera)
+            | (InitRaylib, LoadSound)
+            | (InitRaylib, LoadTexture)
+            | (InitRaylib, CreateRenderTexture)
+            | (InitRaylib, LoadFileToStr)
+            | (InitRaylib, EndInitWindow) => true,
+
+            // MODE TRANISITIONS
+            (Init, InitWindow)
+            | (Render, BeginDrawingFramebuffer)
+            | (Render, BeginDrawingTexture)
+            | (FramebufferMode, BeginMode2D)
+            | (FramebufferMode, EndDrawingFramebuffer)
+            | (FramebufferModeDraw2D, EndMode2D)
+            | (TextureMode, EndDrawingTexture)
+            | (TextureMode, BeginMode2D)
+            | (TextureModeDraw2D, EndMode2D) => true,
+
+            // PERMITTED ONLY DURING DRAW MODES
+            (mode, DrawCircle) if mode.is_draw_mode() => true,
+            (mode, DrawCircleGradient) if mode.is_draw_mode() => true,
+            (mode, DrawRectangleGradientV) if mode.is_draw_mode() => true,
+            (mode, DrawRectangleGradientH) if mode.is_draw_mode() => true,
+            (mode, DrawText) if mode.is_draw_mode() => true,
+            (mode, DrawRectangle) if mode.is_draw_mode() => true,
+            (mode, DrawLine) if mode.is_draw_mode() => true,
+            (mode, DrawTextureRectangle) if mode.is_draw_mode() => true,
+
+            // PERMITTED ONLY IN RENDER
+            (mode, PlaySound) if mode.not_init() => true,
+            (mode, TakeScreenshot) if mode.not_init() => true,
+            (mode, GetScreenSize) if mode.not_init() => true,
+
+            // PERMITTED IN ANY MODE
+            (_, SetDrawFPS) | (_, SetTargetFPS) | (_, MeasureText) | (_, LogMsg) => true,
+
+            // NOT PERMITTED
+            (_, _) => false,
+        }
+    }
+}
+
+pub fn update(effect: PlatformEffect) -> Result<(), String> {
+    PLATFORM_MODE.with(|m| {
+        let mut mode = m.borrow_mut();
+
+        use PlatformEffect::*;
+        match *mode {
+            PlatformMode::Init if matches!(effect, InitWindow) => {
+                *mode = PlatformMode::InitRaylib;
+                Ok(())
+            }
+            PlatformMode::InitRaylib if matches!(effect, EndInitWindow) => {
+                *mode = PlatformMode::Render;
+                Ok(())
+            }
+            PlatformMode::Render if matches!(effect, BeginDrawingFramebuffer) => {
+                *mode = PlatformMode::FramebufferMode;
+                Ok(())
+            }
+            PlatformMode::Render if matches!(effect, BeginDrawingTexture) => {
+                *mode = PlatformMode::TextureMode;
+                Ok(())
+            }
+            PlatformMode::FramebufferMode if matches!(effect, EndDrawingFramebuffer) => {
+                *mode = PlatformMode::Render;
+                Ok(())
+            }
+            PlatformMode::FramebufferMode if matches!(effect, BeginMode2D) => {
+                *mode = PlatformMode::FramebufferModeDraw2D;
+                Ok(())
+            }
+            PlatformMode::FramebufferModeDraw2D if matches!(effect, EndMode2D) => {
+                *mode = PlatformMode::FramebufferMode;
+                Ok(())
+            }
+            PlatformMode::TextureMode if matches!(effect, EndDrawingTexture) => {
+                *mode = PlatformMode::Render;
+                Ok(())
+            }
+            PlatformMode::TextureMode if matches!(effect, BeginMode2D) => {
+                *mode = PlatformMode::TextureModeDraw2D;
+                Ok(())
+            }
+            PlatformMode::TextureModeDraw2D if matches!(effect, EndMode2D) => {
+                *mode = PlatformMode::TextureMode;
+                Ok(())
+            }
+            current_mode if current_mode.is_effect_permitted(effect) => Ok(()),
+            _ => Err(format!(
+                "Effect {:?} not permitted in mode {:?}",
+                effect, *mode
+            )),
+        }
+    })
+}
+
+#[cfg(test)]
+mod test_platform_mode_transitions {
+
+    use super::*;
+
+    fn set_platform_mode(mode: PlatformMode) {
+        PLATFORM_MODE.with(|m| *m.borrow_mut() = mode);
+    }
+
+    fn get_platform_mode() -> PlatformMode {
+        PLATFORM_MODE.with(|m| m.borrow().clone())
+    }
+
+    #[test]
+    fn test_initial_mode() {
+        assert_eq!(get_platform_mode(), PlatformMode::Init);
+    }
+
+    #[test]
+    fn test_begin_drawing_framebuffer() {
+        set_platform_mode(PlatformMode::Render);
+        update(PlatformEffect::BeginDrawingFramebuffer).unwrap();
+        assert_eq!(get_platform_mode(), PlatformMode::FramebufferMode);
+    }
+
+    #[test]
+    fn test_end_drawing_framebuffer() {
+        set_platform_mode(PlatformMode::FramebufferMode);
+        update(PlatformEffect::EndDrawingFramebuffer).unwrap();
+        assert_eq!(get_platform_mode(), PlatformMode::Render);
+    }
+
+    #[test]
+    fn test_begin_texture() {
+        set_platform_mode(PlatformMode::Render);
+        update(PlatformEffect::BeginDrawingTexture).unwrap();
+        assert_eq!(get_platform_mode(), PlatformMode::TextureMode);
+    }
+
+    #[test]
+    fn test_end_texture() {
+        set_platform_mode(PlatformMode::TextureMode);
+        update(PlatformEffect::EndDrawingTexture).unwrap();
+        assert_eq!(get_platform_mode(), PlatformMode::Render);
+    }
+
+    #[test]
+    fn test_begin_mode_2d_from_framebuffer() {
+        set_platform_mode(PlatformMode::FramebufferMode);
+        update(PlatformEffect::BeginMode2D).unwrap();
+        assert_eq!(get_platform_mode(), PlatformMode::FramebufferModeDraw2D);
+    }
+
+    #[test]
+    fn test_end_mode_2d_to_framebuffer() {
+        set_platform_mode(PlatformMode::FramebufferModeDraw2D);
+        update(PlatformEffect::EndMode2D).unwrap();
+        assert_eq!(get_platform_mode(), PlatformMode::FramebufferMode);
+    }
+
+    #[test]
+    fn test_begin_mode_2d_from_texture() {
+        set_platform_mode(PlatformMode::TextureMode);
+        update(PlatformEffect::BeginMode2D).unwrap();
+        assert_eq!(get_platform_mode(), PlatformMode::TextureModeDraw2D);
+    }
+
+    #[test]
+    fn test_end_mode_2d_to_texture() {
+        set_platform_mode(PlatformMode::TextureModeDraw2D);
+        update(PlatformEffect::EndMode2D).unwrap();
+        assert_eq!(get_platform_mode(), PlatformMode::TextureMode);
+    }
+
+    #[test]
+    fn test_init_to_init_raylib() {
+        set_platform_mode(PlatformMode::Init);
+        update(PlatformEffect::InitWindow).unwrap();
+        assert_eq!(get_platform_mode(), PlatformMode::InitRaylib);
+    }
+
+    #[test]
+    fn test_init_raylib_to_render() {
+        set_platform_mode(PlatformMode::InitRaylib);
+        update(PlatformEffect::EndInitWindow).unwrap();
+        assert_eq!(get_platform_mode(), PlatformMode::Render);
+    }
+}


### PR DESCRIPTION
Move the configuration and platform_mode out into a separate module, so that we can call roc_init before starting up raylib. This enables networking by providing information required to either start the worker thread or not. 

This PR also improves the tests for mode transitions, and refactors to make things easier to follow.