### PR TITLE
Support dynamic linking roc apps

### DIFF
--- a/ci/all_tests.sh
+++ b/ci/all_tests.sh
@@ -45,6 +45,9 @@ done
 
 # run the cargo tests
 # note we need an `app.o` file to build the test runner, so do this after buildings the examples
+rm -f libapp.so
+rm -f libapp.dylib
+$ROC build --no-link --output app.o examples/basic-shapes.roc
 $CARGO test
 
 # test building docs website


### PR DESCRIPTION
With these changes you can now create an executable that links roc dynamically. This is useful for "hot-reloading" while developing with roc. Now you can build the whole "app" including the rust host platform once, and then rebuild the roc part and simply restart the executable.

To do this first build roc into a dylib (use `libapp.dylib` for macOS and `libapp.so` for linux etc...)
```
$ roc build --lib --output libapp.dylib examples/pong.roc
```

Then build the host, and move the executable somewhere easier to manage, for example the root directory.
```
$ cargo build
$ cp target/debug/rocray .
```

Then you can rebuild the roc app and just restart rocray which will re-load the new roc app. 

```
$ roc build --lib --output libapp.dylib examples/pong.roc
$ ./rocray
```

There are probably cli utilities that make this seamless. I hope we can make something nice using the justfile configuration.


