### PR TITLE
Add Wayland glibc stub symbols

### DIFF
--- a/ci/all_tests.py
+++ b/ci/all_tests.py
@@ -34,6 +34,7 @@ import threading
 from pathlib import Path
 
 IS_WINDOWS = platform.system() == "Windows"
+IS_LINUX = platform.system() == "Linux"
 
 # Platform references used by examples. Bundle tests temporarily rewrite one of
 # these to the localhost bundle URL.
@@ -317,17 +318,24 @@ def run_wayland_bundle_test(root: Path, example: Path, verbose: bool) -> list[st
                 print(f"  Skipping URL import check for {example.name} (no platform ref)")
             else:
                 example.write_text(rewritten)
+                command = "build" if IS_LINUX else "check"
                 ok = run_cmd(
-                    ["roc", "check", example.name],
-                    f"wayland bundle check {example.name}",
+                    ["roc", command, example.name],
+                    f"wayland bundle {command} {example.name}",
                     verbose,
                     cwd=examples_dir,
                 )
                 if ok:
-                    print(f"  Checking {example.name} against Wayland bundle URL... ok")
+                    print(
+                        f"  {command.capitalize()}ing {example.name} "
+                        "against Wayland bundle URL... ok"
+                    )
                 else:
-                    print(f"  Checking {example.name} against Wayland bundle URL... FAILED")
-                    failed.append(f"wayland bundle check {example.name}")
+                    print(
+                        f"  {command.capitalize()}ing {example.name} "
+                        "against Wayland bundle URL... FAILED"
+                    )
+                    failed.append(f"wayland bundle {command} {example.name}")
         finally:
             example.write_text(original)
             httpd.shutdown()

--- a/platform/targets/arm64glibc/libc_stub.s
+++ b/platform/targets/arm64glibc/libc_stub.s
@@ -1217,6 +1217,13 @@ pipe:
     ret
 
 .balign 8
+.globl pipe2
+.type pipe2, %function
+pipe2:
+    mov x0, #0
+    ret
+
+.balign 8
 .globl dup
 .type dup, %function
 dup:
@@ -1683,6 +1690,41 @@ ftruncate:
 .globl ftruncate64
 .type ftruncate64, %function
 ftruncate64:
+    mov x0, #0
+    ret
+
+.balign 8
+.globl memfd_create
+.type memfd_create, %function
+memfd_create:
+    mov x0, #0
+    ret
+
+.balign 8
+.globl posix_fallocate
+.type posix_fallocate, %function
+posix_fallocate:
+    mov x0, #0
+    ret
+
+.balign 8
+.globl mkostemp
+.type mkostemp, %function
+mkostemp:
+    mov x0, #0
+    ret
+
+.balign 8
+.globl timerfd_create
+.type timerfd_create, %function
+timerfd_create:
+    mov x0, #0
+    ret
+
+.balign 8
+.globl timerfd_settime
+.type timerfd_settime, %function
+timerfd_settime:
     mov x0, #0
     ret
 

--- a/platform/targets/x64glibc/libc_stub.s
+++ b/platform/targets/x64glibc/libc_stub.s
@@ -1225,6 +1225,13 @@ pipe:
     ret
 
 .balign 8
+.globl pipe2
+.type pipe2, %function
+pipe2:
+    xor %rax, %rax
+    ret
+
+.balign 8
 .globl dup
 .type dup, %function
 dup:
@@ -1730,6 +1737,41 @@ ftruncate:
 .globl ftruncate64
 .type ftruncate64, %function
 ftruncate64:
+    xor %rax, %rax
+    ret
+
+.balign 8
+.globl memfd_create
+.type memfd_create, %function
+memfd_create:
+    xor %rax, %rax
+    ret
+
+.balign 8
+.globl posix_fallocate
+.type posix_fallocate, %function
+posix_fallocate:
+    xor %rax, %rax
+    ret
+
+.balign 8
+.globl mkostemp
+.type mkostemp, %function
+mkostemp:
+    xor %rax, %rax
+    ret
+
+.balign 8
+.globl timerfd_create
+.type timerfd_create, %function
+timerfd_create:
+    xor %rax, %rax
+    ret
+
+.balign 8
+.globl timerfd_settime
+.type timerfd_settime, %function
+timerfd_settime:
     xor %rax, %rax
     ret
 


### PR DESCRIPTION
## Summary
- add missing glibc stub exports used by GLFW's Wayland backend
- cover `pipe2`, `memfd_create`, `posix_fallocate`, `mkostemp`, `timerfd_create`, and `timerfd_settime`
- keep `x64glibc` and `arm64glibc` stubs in sync
- make the Wayland bundle helper run `roc build` on Linux so PR CI catches linker failures against the Wayland bundle

## Why
The Release workflow's Wayland bundle test linked the real Wayland raylib archive against Roc's `x64glibc` target stub libc. The archive referenced these glibc symbols from GLFW's Wayland source files, but the generated stub libc did not export them, so lld failed before producing the test binaries.

The existing PR CI Wayland bundle check only used `roc check`, which validates the package URL/import shape but does not exercise the linker. On Linux it now uses `roc build`; on macOS it keeps `roc check` because Roc reports that cross-compilation to glibc targets is not supported there.

## Test Plan
- `bash -n bundle.sh`
- `bash -n scripts/build-raylib-wayland.sh`
- `ruby -ryaml -e 'ARGV.each { |p| YAML.load_file(p); puts "parsed #{p}" }' .github/workflows/*.yml`
- `python3 -m py_compile ci/all_tests.py ci/test_bundle_artifact.py`
- `zig build`
- `zig build test -Droc-tests=false`
- `nm -D platform/targets/x64glibc/libc.so` confirms the six new symbols are exported
- `bash bundle.sh --platform wayland`
- `python3 ci/all_tests.py --skip-bundle-test`
- targeted Wayland helper check passed locally with localhost server escalation
- pre-commit hook passed full local checks twice, including default bundle URL builds and the Wayland bundle package check

Not locally runnable on this macOS host: the Linux `x64glibc` release bundle link test. The updated Linux PR CI path should now exercise that linker step for the Wayland bundle.
