### PR TITLE
Use 0.7 release bundle in examples

### DIFF
--- a/examples/breakout.roc
+++ b/examples/breakout.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../platform/main-default.roc" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.7/8gdZaHEpySPZUzMBCT6RkEF9CBpcbi5F3E7QmNu4NTCU.tar.zst" }
 
 import rr.App
 import rr.Audio

--- a/examples/camera.roc
+++ b/examples/camera.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../platform/main-default.roc" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.7/8gdZaHEpySPZUzMBCT6RkEF9CBpcbi5F3E7QmNu4NTCU.tar.zst" }
 
 import rr.App
 import rr.Camera

--- a/examples/cave_climb.roc
+++ b/examples/cave_climb.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../platform/main-default.roc" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.7/8gdZaHEpySPZUzMBCT6RkEF9CBpcbi5F3E7QmNu4NTCU.tar.zst" }
 
 import rr.App
 import rr.Assets

--- a/examples/hello_world.roc
+++ b/examples/hello_world.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../platform/main-default.roc" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.7/8gdZaHEpySPZUzMBCT6RkEF9CBpcbi5F3E7QmNu4NTCU.tar.zst" }
 
 import rr.Draw
 import rr.Color

--- a/examples/keyboard.roc
+++ b/examples/keyboard.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../platform/main-default.roc" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.7/8gdZaHEpySPZUzMBCT6RkEF9CBpcbi5F3E7QmNu4NTCU.tar.zst" }
 
 import rr.Draw
 import rr.Color

--- a/examples/kitchen_sink.roc
+++ b/examples/kitchen_sink.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../platform/main-default.roc" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.7/8gdZaHEpySPZUzMBCT6RkEF9CBpcbi5F3E7QmNu4NTCU.tar.zst" }
 
 import rr.Draw
 import rr.Color

--- a/examples/pong.roc
+++ b/examples/pong.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../platform/main-default.roc" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.7/8gdZaHEpySPZUzMBCT6RkEF9CBpcbi5F3E7QmNu4NTCU.tar.zst" }
 
 import rr.Draw
 import rr.Color

--- a/examples/read_env.roc
+++ b/examples/read_env.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../platform/main-default.roc" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.7/8gdZaHEpySPZUzMBCT6RkEF9CBpcbi5F3E7QmNu4NTCU.tar.zst" }
 
 import rr.Draw
 import rr.Color

--- a/examples/snake.roc
+++ b/examples/snake.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../platform/main-default.roc" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.7/8gdZaHEpySPZUzMBCT6RkEF9CBpcbi5F3E7QmNu4NTCU.tar.zst" }
 
 import rr.App
 import rr.Audio

--- a/examples/sprites.roc
+++ b/examples/sprites.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../platform/main-default.roc" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.7/8gdZaHEpySPZUzMBCT6RkEF9CBpcbi5F3E7QmNu4NTCU.tar.zst" }
 
 import rr.App
 import rr.Assets

--- a/examples/text_ui.roc
+++ b/examples/text_ui.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../platform/main-default.roc" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.7/8gdZaHEpySPZUzMBCT6RkEF9CBpcbi5F3E7QmNu4NTCU.tar.zst" }
 
 import rr.Draw
 import rr.Color

--- a/examples/top_down.roc
+++ b/examples/top_down.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../platform/main-default.roc" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.7/8gdZaHEpySPZUzMBCT6RkEF9CBpcbi5F3E7QmNu4NTCU.tar.zst" }
 
 import rr.App
 import rr.Assets

--- a/platform/App.roc
+++ b/platform/App.roc
@@ -14,9 +14,9 @@ AppConfig : {
 App(_field) := { apply : AppConfig -> AppConfig }.{
 	Config : AppConfig
 
-	## TODO(roc#9655): make this `Try(model, [Exit(I64), ..])` once open
-	## error rows through exposed platform aliases like `App.Init(Model)` no
-	## longer panic the compiler.
+	## Effectful startup callback run after the host has initialized raylib and
+	## audio. Return `Ok(model)` to start the app, or `Err(Exit(code))` to quit
+	## before the first frame.
 	InitCallback(model) : Host => Try(model, [Exit(I64)])
 
 	Init(model) : {


### PR DESCRIPTION
- Update all examples to use the RocRay 0.7 default release bundle.
- Replace a public App docs TODO with user-facing InitCallback wording.
