### PR TITLE
close open Host tag unions

### DIFF
--- a/platform/Host.roc
+++ b/platform/Host.roc
@@ -63,7 +63,7 @@ Host := {
 
 	## Read an environment variable by key.
 	## Returns Ok with the value if found, or Err NotFound if not set.
-	read_env! : Host, Str => Try(Str, [NotFound, ..])
+	read_env! : Host, Str => Try(Str, [NotFound])
 
 	## Raw hosted file read. Prefer `read_file!`.
 	read_file_raw! : Str => ReadFileRawResult
@@ -89,7 +89,7 @@ Host := {
 
 	## Set the window/screen size.
 	## Returns Err NotSupported on platforms that don't support window resizing (e.g., web).
-	set_screen_size! : { width : F32, height : F32 } => Try({}, [NotSupported, ..])
+	set_screen_size! : { width : F32, height : F32 } => Try({}, [NotSupported])
 
 	## Set the target frames per second for the render loop.
 	## Note: On web/WASM, this has no effect as the browser controls frame timing.


### PR DESCRIPTION
# Changes
- fixed https://github.com/lukewilliamboswell/roc-ray/issues/107

# Test
before
```
❯ roc examples/hello_world.roc

┌────────────────────────────────────┐
│ HOST BOUNDARY REQUIRES CLOSED ROWS ├─ Host-bound types cannot contain open record ──┐
└┬───────────────────────────────────┘  or tag-union rows.                            │
 │                                                                                    │
 │  read_env! : Host, Str => Try(Str, [NotFound, ..])                                 │
 │  ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾                                 │
 └──────────────────────────────────────────────────────────── platform/Host.roc:66:2 ┘

    Close every record and tag-union row in this type before it crosses the host
    boundary.


┌────────────────────────────────────┐
│ HOST BOUNDARY REQUIRES CLOSED ROWS ├─ Host-bound types cannot contain open record ──┐
└┬───────────────────────────────────┘  or tag-union rows.                            │
 │                                                                                    │
 │  set_screen_size! : { width : F32, height : F32 } => Try({}, [NotSupported, ..])   │
 │  ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾   │
 └──────────────────────────────────────────────────────────── platform/Host.roc:92:2 ┘

    Close every record and tag-union row in this type before it crosses the host
    boundary.


Found 2 error(s) and 0 warning(s) for examples/hello_world.roc.
```

after 
```
❯ roc examples/hello_world.roc
INFO: Initializing raylib 6.0
INFO: Platform backend: DESKTOP (GLFW)
INFO: Supported raylib modules:
INFO:     > rcore:..... loaded (mandatory)
INFO:     > rlgl:...... loaded (mandatory)
INFO:     > rshapes:... loaded (optional)
INFO:     > rtextures:. loaded (optional)
INFO:     > rtext:..... loaded (optional)
INFO:     > rmodels:... loaded (optional)
INFO:     > raudio:.... loaded (optional)
INFO: DISPLAY: Device initialized successfully
INFO:     > Display size: 1512 x 982
INFO:     > Screen size:  800 x 600
INFO:     > Render size:  800 x 600
INFO:     > Viewport offsets: 0, 0
INFO: GLAD: OpenGL extensions loaded successfully
INFO: GL: Supported extensions count: 43
INFO: GL: OpenGL device information:
INFO:     > Vendor:   Apple
INFO:     > Renderer: Apple M2 Pro
INFO:     > Version:  4.1 Metal - 88.1
INFO:     > GLSL:     4.10
INFO: GL: VAO extension detected, VAO functions loaded successfully
INFO: GL: NPOT textures extension detected, full NPOT textures supported
INFO: GL: DXT compressed textures supported
INFO: PLATFORM: DESKTOP (GLFW - Cocoa): Initialized successfully
INFO: TEXTURE: [ID 1] Texture loaded successfully (1x1 | R8G8B8A8 | 1 mipmaps)
INFO: TEXTURE: [ID 1] Default texture loaded successfully
INFO: SHADER: [ID 1] Vertex shader compiled successfully
INFO: SHADER: [ID 2] Fragment shader compiled successfully
INFO: SHADER: [ID 3] Program shader loaded successfully
INFO: SHADER: [ID 3] Default shader loaded successfully
INFO: RLGL: Render batch vertex buffers loaded successfully in RAM (CPU)
INFO: RLGL: Render batch vertex buffers loaded successfully in VRAM (GPU)
INFO: RLGL: Default OpenGL state initialized successfully
INFO: TEXTURE: [ID 2] Texture loaded successfully (128x128 | GRAY_ALPHA | 1 mipmaps)
INFO: FONT: Default font loaded successfully (224 glyphs)
INFO: SYSTEM: Working Directory: /Users/romain/Projects/roc-ray
INFO: TIMER: Target time per frame: 4.167 milliseconds
INFO: AUDIO: Device initialized successfully
INFO:     > Backend:       miniaudio | Core Audio
INFO:     > Format:        32-bit IEEE Floating Point -> 32-bit IEEE Floating Point
INFO:     > Channels:      2 -> 2
INFO:     > Sample rate:   44100 -> 44100
INFO:     > Periods size:  1323
INFO: AUDIO: Device closed successfully
INFO: TEXTURE: [ID 2] Unloaded texture data from VRAM (GPU)
INFO: SHADER: [ID 3] Default shader unloaded successfully
INFO: TEXTURE: [ID 1] Default texture unloaded successfully
INFO: Window closed successfully
```