### PR TITLE
Enable High DPI resolution

### DIFF
--- a/src/backend_raylib.zig
+++ b/src/backend_raylib.zig
@@ -112,6 +112,8 @@ pub fn loadFont(path: [*:0]const u8, size: c_int) ?u64 {
     const font = rl.LoadFontEx(path, font_size, null, 0);
     if (!rl.IsFontValid(font)) return null;
 
+    rl.SetTextureFilter(font.texture, rl.TEXTURE_FILTER_BILINEAR);
+
     fonts[font_count] = font;
     font_count += 1;
     return @intCast(font_count);
@@ -458,7 +460,7 @@ pub fn setConfigFlags(flags: c_uint) void {
 
 /// Build raylib window config flags from Roc app config booleans.
 pub fn windowConfigFlags(resizable: bool, fullscreen: bool, vsync: bool) c_uint {
-    var flags: c_uint = 0;
+    var flags: c_uint = @as(c_uint, @intCast(rl.FLAG_WINDOW_HIGHDPI));
     if (resizable) flags |= @as(c_uint, @intCast(rl.FLAG_WINDOW_RESIZABLE));
     if (fullscreen) flags |= @as(c_uint, @intCast(rl.FLAG_FULLSCREEN_MODE));
     if (vsync) flags |= @as(c_uint, @intCast(rl.FLAG_VSYNC_HINT));


### PR DESCRIPTION
## What Changed

- Enable HiDPI window rendering by including `FLAG_WINDOW_HIGHDPI` in the raylib window config flags before `InitWindow`.
- Apply bilinear texture filtering to custom font atlases immediately after a successful `LoadFontEx`.

## Motivation

On HiDPI displays, a window has both a logical size and a backing framebuffer size. For example, an 800x600 window may need a 1600x1200 framebuffer on a Retina display so that one logical point maps to multiple physical pixels. If the framebuffer stays at the logical size, the OS has to scale the final rendered image up to the display, which makes every primitive look softer or more pixelated.

Text rendered through `roc-ray` custom fonts could look visibly pixelated on macOS/Retina displays. Bilinear filtering improves custom font atlas sampling, but it does not address the lower-resolution-window case because the final surface is still being scaled after all drawing is complete.

Enabling `FLAG_WINDOW_HIGHDPI` makes raylib request a high-DPI framebuffer where available. On Retina displays, this improves the resolution of the final rendered surface, affecting text, borders, shapes, and textures. That is why it is more consequential than texture filtering for this class of visual issue.

This is a good default for `roc-ray`: on standard-DPI displays it should be neutral, while on HiDPI displays it avoids OS-level upscaling of the whole window. If a compatibility issue appears later, `roc-ray` can expose a high-level `high_dpi` app option that defaults to enabled, rather than leaving Retina output low-resolution by default or exposing raw raylib flags as the main configuration surface.

Bilinear filtering remains useful as a complementary custom font improvement. It smooths atlas sampling when text is drawn at a size that differs from the loaded atlas size, which is common for UI text rendered from larger font atlases.

## Test 

before:  
<img width="793" height="275" alt="Screenshot 2026-07-13 at 16 02 29" src="https://github.com/user-attachments/assets/360fed21-0977-40d8-8818-e533b2c94514" />

after:  
<img width="794" height="278" alt="Screenshot 2026-07-13 at 16 01 48" src="https://github.com/user-attachments/assets/c3048dc6-2350-4021-8889-f67e4c519024" />
