### PR TITLE
Prevent Debug hosts from replacing release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,10 +104,10 @@ jobs:
       - name: Run Roc check/fmt/test
         # Skip on Windows - roc executable PATH issues and MSVC requirements
         if: runner.os != 'Windows'
-        run: scripts/all_tests.py --skip-build --skip-bundle-test
+        run: scripts/all_tests.py --skip-platform-build --skip-roc-build --skip-bundle-test
 
       - name: Build and run examples headlessly
         # Linux covers headless runtime; macOS currently hangs in generated executables
         # and Windows has roc executable PATH issues plus MSVC requirements.
         if: runner.os == 'Linux'
-        run: scripts/all_tests.py --runtime-only --skip-bundle-test
+        run: scripts/all_tests.py --skip-platform-build --runtime-only --skip-bundle-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,9 +77,12 @@ jobs:
 
       - name: Validate Roc examples and docs
         run: |
-          scripts/all_tests.py --skip-build --skip-bundle-test
+          scripts/all_tests.py --skip-platform-build --skip-roc-build --skip-bundle-test
           rm -rf /tmp/roc-ray-release-docs
           roc docs platform/main-default.roc --output=/tmp/roc-ray-release-docs
+
+      - name: Verify release hosts
+        run: scripts/check_release_hosts.py
 
       - name: Resolve previous default bundle
         if: github.event_name == 'workflow_dispatch'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,8 @@ Or run just the Roc example tests directly:
 
 ```bash
 scripts/all_tests.py            # check, fmt, test, build, headless runtime
-scripts/all_tests.py --skip-build
+scripts/all_tests.py --skip-platform-build # reuse host libraries from zig build
+scripts/all_tests.py --skip-roc-build      # skip building and running Roc apps
 ```
 
 Enable the pre-commit hook (run once after cloning):

--- a/build.zig
+++ b/build.zig
@@ -83,10 +83,6 @@ pub fn build(b: *std.Build) void {
     cleanup_step.dependOn(&CleanupStep.create(b, b.path("platform/libhost.a")).step);
     cleanup_step.dependOn(&CleanupStep.create(b, b.path("platform/host.lib")).step);
 
-    // Default step: build the host library for all native targets
-    const all_step = b.getInstallStep();
-    all_step.dependOn(cleanup_step);
-
     // Generate X11 stubs step (needed for Linux cross-compilation)
     const x11_stubs_step = b.step("generate-x11-stubs", "Generate X11 stub libraries for Linux cross-compilation");
     const x11_stub_target = b.resolveTargetQuery(.{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .gnu });
@@ -95,6 +91,12 @@ pub fn build(b: *std.Build) void {
 
     // Create copy step for all targets
     const copy_all = b.addUpdateSourceFiles();
+    copy_all.step.dependOn(cleanup_step);
+
+    // Default step: build the host library for all native targets. Ensure the
+    // cleanup completes before generated libraries are copied into the source
+    // tree; sibling dependencies would be free to run in either order.
+    const all_step = b.getInstallStep();
     all_step.dependOn(&copy_all.step);
 
     // Generate Windows import libraries (needed for Windows cross-compilation)
@@ -203,8 +205,13 @@ pub fn build(b: *std.Build) void {
 
     if (run_roc_tests) {
         // Run Roc tests (check, fmt, test, build)
-        const roc_tests = b.addSystemCommand(&.{ "python3", "scripts/all_tests.py" });
+        const roc_tests = b.addSystemCommand(&.{
+            "python3",
+            "scripts/all_tests.py",
+            "--skip-platform-build",
+        });
         roc_tests.setCwd(b.path(".")); // Run from project root
+        roc_tests.step.dependOn(&copy_all.step);
         test_step.dependOn(&roc_tests.step);
     }
 }

--- a/scripts/all_tests.py
+++ b/scripts/all_tests.py
@@ -15,7 +15,8 @@ This script runs:
 
 Usage:
     ./scripts/all_tests.py                   # Run all tests
-    ./scripts/all_tests.py --skip-build      # Skip roc build
+    ./scripts/all_tests.py --skip-platform-build # Reuse existing host libraries
+    ./scripts/all_tests.py --skip-roc-build  # Skip roc build
     ./scripts/all_tests.py --skip-runtime    # Skip running built examples
     ./scripts/all_tests.py --skip-roc-test   # Skip roc test
     ./scripts/all_tests.py --runtime-only    # Only build and run examples headlessly
@@ -453,7 +454,18 @@ def run_wayland_bundle_test(root: Path, example: Path, verbose: bool) -> list[st
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run all roc-ray tests")
-    parser.add_argument("--skip-build", action="store_true", help="Skip roc build")
+    parser.add_argument(
+        "--skip-platform-build",
+        action="store_true",
+        help="Reuse existing host libraries instead of running zig build first",
+    )
+    parser.add_argument(
+        "--skip-roc-build",
+        "--skip-build",
+        dest="skip_roc_build",
+        action="store_true",
+        help="Skip roc build (--skip-build is a deprecated alias)",
+    )
     parser.add_argument(
         "--skip-roc-test",
         action="store_true",
@@ -486,8 +498,8 @@ def main() -> int:
     args = parser.parse_args()
     if args.headless_frames < 1:
         parser.error("--headless-frames must be greater than zero")
-    if args.runtime_only and args.skip_build:
-        parser.error("--runtime-only cannot be combined with --skip-build")
+    if args.runtime_only and args.skip_roc_build:
+        parser.error("--runtime-only cannot be combined with --skip-roc-build")
 
     # Find project root (parent of scripts/)
     root = Path(__file__).resolve().parent.parent
@@ -510,13 +522,17 @@ def _run_tests(args: argparse.Namespace, root: Path, examples: list[Path]) -> in
 
     failed = []
 
-    # Build platform (ensures fresh host, not cached)
-    print("\nBuilding platform (zig build)...")
-    if not run_cmd(["zig", "build"], "zig build", args.verbose, cwd=root):
-        print("  FAILED")
-        failed.append("zig build")
+    if args.skip_platform_build:
+        print("\nReusing existing host libraries (--skip-platform-build)")
     else:
-        print("  ok")
+        # Standalone runs build a fresh host. Orchestrators that already chose
+        # an optimization mode must pass --skip-platform-build.
+        print("\nBuilding platform (zig build)...")
+        if not run_cmd(["zig", "build"], "zig build", args.verbose, cwd=root):
+            print("  FAILED")
+            failed.append("zig build")
+        else:
+            print("  ok")
 
     if args.runtime_only:
         print("\nSkipping roc check/fmt/test (--runtime-only)")
@@ -558,8 +574,8 @@ def _run_tests(args: argparse.Namespace, root: Path, examples: list[Path]) -> in
 
     # roc build (run from examples dir so executables are created there)
     built_examples: list[Path] = []
-    if args.skip_build:
-        print("\nSkipping roc build (--skip-build)")
+    if args.skip_roc_build:
+        print("\nSkipping roc build (--skip-roc-build)")
     else:
         print("\nRunning roc build...")
         for example in examples:
@@ -579,8 +595,8 @@ def _run_tests(args: argparse.Namespace, root: Path, examples: list[Path]) -> in
 
     if args.skip_runtime:
         print("\nSkipping headless runtime (--skip-runtime)")
-    elif args.skip_build:
-        print("\nSkipping headless runtime (--skip-build)")
+    elif args.skip_roc_build:
+        print("\nSkipping headless runtime (--skip-roc-build)")
     else:
         failed.extend(
             run_headless_examples(root, built_examples, args.headless_frames, args.verbose)

--- a/scripts/check_release_hosts.py
+++ b/scripts/check_release_hosts.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Reject release host libraries that contain Zig's debug allocator."""
+
+from pathlib import Path
+
+
+HOST_LIBRARIES = (
+    Path("platform/targets/x64mac/libhost.a"),
+    Path("platform/targets/arm64mac/libhost.a"),
+    Path("platform/targets/x64glibc/libhost.a"),
+    Path("platform/targets/x64win/host.lib"),
+)
+DEBUG_ALLOCATOR_MARKERS = (
+    b"heap.debug_allocator.DebugAllocator",
+    b"debug.captureCurrentStackTrace",
+)
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for library in HOST_LIBRARIES:
+        if not library.is_file():
+            failures.append(f"missing release host: {library}")
+            continue
+
+        contents = library.read_bytes()
+        markers = [
+            marker.decode() for marker in DEBUG_ALLOCATOR_MARKERS if marker in contents
+        ]
+        if markers:
+            failures.append(
+                f"{library} contains debug allocator marker(s): {', '.join(markers)}"
+            )
+        else:
+            print(f"Verified release host: {library}")
+
+    if failures:
+        for failure in failures:
+            print(f"ERROR: {failure}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/host_native.zig
+++ b/src/host_native.zig
@@ -50,6 +50,7 @@ const DEFAULT_HEADLESS_FRAMES: u64 = 3;
 const HEADLESS_FRAME_NANOS: u64 = 16_666_667;
 const HEADLESS_FRAME_TIME: f32 = 1.0 / 60.0;
 const HEADLESS_RESOURCE_SIZE: f32 = 64;
+const use_debug_allocator = builtin.mode == .Debug;
 
 /// Global flag to track if dbg or expect_failed was called.
 /// If set, program exits with non-zero code to prevent accidental commits.
@@ -1281,16 +1282,21 @@ fn platform_main(argc: usize, argv: [*][*:0]u8) c_int {
         host_environ = @as([*]const [*:0]u8, @ptrCast(std.c.environ))[0..n];
     }
 
-    var gpa: std.heap.DebugAllocator(.{}) = .{};
-    defer {
-        if (gpa.deinit() == .leak) std.log.warn("Memory leak detected", .{});
-    }
+    var debug_allocator: std.heap.DebugAllocator(.{}) = .{};
+    defer if (use_debug_allocator) {
+        if (debug_allocator.deinit() == .leak) std.log.warn("Memory leak detected", .{});
+    };
+
+    const allocator = if (use_debug_allocator)
+        debug_allocator.allocator()
+    else
+        std.heap.smp_allocator;
 
     // The Roc runtime environment: allocator + I/O backend. We supply our own
     // dbg/expect/crashed handlers below, so the I/O backend (only used by the
     // generated DefaultHandlers) is left as a no-op freestanding implementation.
     var roc_env = abi.RocEnv{
-        .allocator = gpa.allocator(),
+        .allocator = allocator,
         .roc_io = abi.RocIo.freestanding(),
     };
 
@@ -1321,5 +1327,5 @@ fn platform_main(argc: usize, argv: [*][*:0]u8) c_int {
         return runHeadlessApp(&roc_host, app_config, options.headless_frames);
     }
 
-    return runNormalApp(&roc_host, gpa.allocator(), app_config);
+    return runNormalApp(&roc_host, allocator, app_config);
 }


### PR DESCRIPTION
## Summary

- separate platform-host builds from Roc application builds in the test runner so orchestrated CI and release jobs can reuse the host they already built
- make Zig build-test dependencies explicit and order cleanup before copying generated host libraries
- use DebugAllocator only for Debug hosts and use the fast SMP allocator in release hosts
- reject release host libraries containing DebugAllocator or stack-capture code before bundling

## Root cause

The release workflow correctly built ReleaseFast hosts, then scripts/all_tests.py unconditionally ran a plain zig build. That rebuilt the same platform/targets files in Debug mode immediately before bundling. The old --skip-build option only skipped roc build, which obscured the overwrite.

## Testing

- zig build test -Droc-tests=false
- zig build test
- zig build -Doptimize=ReleaseFast followed by scripts/check_release_hosts.py
- confirmed the guard rejects all four Debug host libraries
- ran the release validation command and confirmed all four ReleaseFast library hashes remained unchanged
- generated a release bundle and built all 12 examples against it
- inspected the bundled arm64mac host and confirmed it contains no DebugAllocator or captureCurrentStackTrace symbols
- ran hello_world headlessly for 10,000 frames against the generated bundle