### PR TITLE
Document frame pacing and VSync behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ The goal isn't to build or support a large game engine. We're happy to help wher
 
 > **Performance:** For the best performance, run your app with `roc build` (e.g. `roc build examples/breakout.roc`) rather than `roc <file>`. `roc build` uses the optimised LLVM backend, while running directly uses the in-development backends. This is expected to be a temporary limitation while the dev backends mature.
 
+### Frame pacing
+
+`target_fps` and `vsync` control different parts of frame pacing:
+
+- `target_fps` asks raylib to limit the frame loop on the CPU. Set it to `0` (or a negative value) to render uncapped. This does not select a software renderer; native drawing remains GPU accelerated.
+- `vsync` asks the graphics driver to synchronize buffer presentation with the display. The driver, window system, and desktop compositor ultimately decide how that request behaves.
+
+RocRay defaults to `vsync: Bool.False` with a 240 FPS CPU-side cap. This gives predictable behavior across platforms while keeping CPU and GPU usage bounded. Enable VSync when tear-free presentation is more important and it behaves well on the target system.
+
+Some Linux configurations—particularly X11 applications presented through a Wayland compositor—can run substantially below the monitor refresh rate when VSync is enabled. Increasing `target_fps` cannot correct presentation stalls inside the driver. If this occurs, use `vsync: Bool.False` with a suitable software cap such as 60 or 120 FPS. Use an uncapped target for measurement rather than normal application operation, since it needlessly consumes CPU and GPU resources.
+
 ## Features
 
 - 2D drawing primitives (styled rectangles, rounded rectangles, circles, lines, triangles, polygons, gradients, text)

--- a/platform/App.roc
+++ b/platform/App.roc
@@ -70,6 +70,8 @@ App(_field) := { apply : AppConfig -> AppConfig }.{
 	}
 
 	target_fps : I32 -> App(I32)
+	## Set raylib's CPU-side frame-rate cap. Values at or below zero render
+	## uncapped. This neither selects a software renderer nor controls VSync.
 	target_fps = |value| {
 		apply: |cfg| { ..cfg, target_fps: value },
 	}
@@ -85,6 +87,8 @@ App(_field) := { apply : AppConfig -> AppConfig }.{
 	}
 
 	vsync : Bool -> App(Bool)
+	## Request synchronized buffer presentation from the graphics driver.
+	## Actual pacing depends on the driver, window system, and compositor.
 	vsync = |value| {
 		apply: |cfg| { ..cfg, vsync: value },
 	}

--- a/platform/Host.roc
+++ b/platform/Host.roc
@@ -109,7 +109,8 @@ Host := {
 			Err(NotSupported) => Err(NotSupported)
 		}
 
-	## Set the target frames per second for the render loop.
+	## Set raylib's CPU-side frame-rate cap. Values at or below zero render
+	## uncapped. This neither selects a software renderer nor controls VSync.
 	## Note: On web/WASM, this has no effect as the browser controls frame timing.
 	set_target_fps! : I32 => {}
 }


### PR DESCRIPTION
## Summary

- distinguish the CPU-side target FPS cap from driver-controlled VSync
- clarify that native rendering remains GPU accelerated
- document unexpected VSync slowdown on some Linux X11-on-Wayland configurations
- recommend a bounded CPU-side cap when affected and uncapped rendering only for measurement

## Investigation

A RocRay/Terracotta demo rendered at roughly 692 FPS uncapped and held 120 FPS with VSync disabled. With VSync enabled it fell to 34–36 FPS on a 60 Hz Mesa desktop. Profiling placed the delay inside raylib EndDrawing, and a minimal native C program linked against RocRay's vendored raylib reproduced both the slowdown and the VSync-disabled recovery. This indicates driver/compositor presentation behavior rather than a RocRay render-loop defect.

## Validation

- zig build test
- all 12 examples checked, formatted, tested, built, and run headlessly
- bundle and Wayland bundle package tests passed