### PR TITLE
set mouse cursor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,22 +65,34 @@ jobs:
 
       - name: Start HTTP server for bundle
         run: |
-          python3 -m http.server 8000 &
-          sleep 3
-
           BUNDLE_FILE=$(ls *.tar.zst 2>/dev/null | head -1)
           if [ -z "$BUNDLE_FILE" ]; then
             echo "Error: No bundle file found"
             exit 1
           fi
 
-          if ! curl -sf "http://localhost:8000/$BUNDLE_FILE" -o /dev/null; then
-            echo "Error: Bundle not accessible at http://localhost:8000/$BUNDLE_FILE"
-            exit 1
-          fi
-          echo "Bundle accessible at http://localhost:8000/$BUNDLE_FILE"
+          BUNDLE_URL="http://127.0.0.1:8000/$BUNDLE_FILE"
+          python3 -m http.server --bind 127.0.0.1 8000 &
+          SERVER_PID=$!
 
-          echo "BUNDLE_URL=http://localhost:8000/$BUNDLE_FILE" >> "$GITHUB_ENV"
+          for attempt in {1..30}; do
+            if curl -sf "$BUNDLE_URL" -o /dev/null; then
+              echo "Bundle accessible at $BUNDLE_URL"
+              echo "BUNDLE_URL=$BUNDLE_URL" >> "$GITHUB_ENV"
+              exit 0
+            fi
+
+            if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+              echo "Error: HTTP server exited before serving $BUNDLE_FILE"
+              exit 1
+            fi
+
+            sleep 1
+          done
+
+          echo "Error: Bundle not accessible at $BUNDLE_URL"
+          curl -v "$BUNDLE_URL" -o /dev/null || true
+          exit 1
 
       - name: Update examples to use bundled platform
         run: |

--- a/platform/Host.roc
+++ b/platform/Host.roc
@@ -1,5 +1,6 @@
 ## Host module - provides platform state and system effects
 import Keys
+import Mouse
 
 Host := {
 	frame_count : U64,
@@ -64,6 +65,13 @@ Host := {
 	## Exit the application with the given exit code.
 	## The exit happens after the current frame completes to allow proper cleanup.
 	exit! : I32 => {}
+
+	## Hosted cursor setter. Prefer `set_cursor!` in application code.
+	set_cursor_raw! : U8 => {}
+
+	## Set the OS cursor shape.
+	set_cursor! : Mouse.Cursor => {}
+	set_cursor! = |cursor| Host.set_cursor_raw!(Mouse.cursor_code(cursor))
 
 	## Read an environment variable by key.
 	## Returns Ok with the value if found, or Err NotFound if not set.

--- a/platform/Mouse.roc
+++ b/platform/Mouse.roc
@@ -10,6 +10,38 @@ Mouse := [].{
 
 	MouseButton := [Left, Right, Middle, Side, Extra, Forward, Back]
 
+	## Cursor shapes supported by raylib. `Default` restores the platform's
+	## standard cursor.
+	Cursor := [
+		Default,
+		Arrow,
+		IBeam,
+		Crosshair,
+		PointingHand,
+		ResizeEw,
+		ResizeNs,
+		ResizeNwse,
+		ResizeNesw,
+		ResizeAll,
+		NotAllowed,
+	]
+
+	cursor_code : Cursor -> U8
+	cursor_code = |cursor|
+		match cursor {
+			Default => 0
+			Arrow => 1
+			IBeam => 2
+			Crosshair => 3
+			PointingHand => 4
+			ResizeEw => 5
+			ResizeNs => 6
+			ResizeNwse => 7
+			ResizeNesw => 8
+			ResizeAll => 9
+			NotAllowed => 10
+		}
+
 	button_code : MouseButton -> U64
 	button_code = |button|
 		match button {
@@ -48,5 +80,7 @@ Mouse := [].{
 	expect button_code(Left) == 0
 	expect button_code(Back) == 6
 	expect button_state([7], Left, 1) and button_state([7], Left, 2) and button_state([7], Left, 4)
+	expect cursor_code(Default) == 0
+	expect cursor_code(NotAllowed) == 10
 
 }

--- a/platform/main-default.roc
+++ b/platform/main-default.roc
@@ -75,6 +75,7 @@ platform ""
 		"roc_host_read_file_raw": Host.read_file_raw!,
 		"roc_host_set_screen_size": Host.set_screen_size_raw!,
 		"roc_host_set_target_fps": Host.set_target_fps!,
+		"roc_mouse_set_cursor_raw": Host.set_cursor_raw!,
 		"roc_tilemap_load_tmx_raw": Tilemap.load_tmx_raw!,
 		"roc_draw_begin_camera": Draw.begin_camera!,
 		"roc_draw_end_camera": Draw.end_camera!,

--- a/platform/main-wayland.roc
+++ b/platform/main-wayland.roc
@@ -75,6 +75,7 @@ platform ""
 		"roc_host_read_file_raw": Host.read_file_raw!,
 		"roc_host_set_screen_size": Host.set_screen_size_raw!,
 		"roc_host_set_target_fps": Host.set_target_fps!,
+		"roc_mouse_set_cursor_raw": Host.set_cursor_raw!,
 		"roc_tilemap_load_tmx_raw": Tilemap.load_tmx_raw!,
 		"roc_draw_begin_camera": Draw.begin_camera!,
 		"roc_draw_end_camera": Draw.end_camera!,

--- a/src/backend_raylib.zig
+++ b/src/backend_raylib.zig
@@ -497,6 +497,26 @@ pub fn setTargetFps(fps: c_int) void {
     rl.SetTargetFPS(fps);
 }
 
+/// Mouse cursor shapes exposed by raylib.
+pub const MouseCursor = enum(c_int) {
+    default = 0,
+    arrow = 1,
+    ibeam = 2,
+    crosshair = 3,
+    pointing_hand = 4,
+    resize_ew = 5,
+    resize_ns = 6,
+    resize_nwse = 7,
+    resize_nesw = 8,
+    resize_all = 9,
+    not_allowed = 10,
+};
+
+/// Set the OS cursor shape.
+pub fn setMouseCursor(cursor: MouseCursor) void {
+    rl.SetMouseCursor(@intFromEnum(cursor));
+}
+
 /// Show the OS cursor.
 pub fn showCursor() void {
     rl.ShowCursor();

--- a/src/host_native.zig
+++ b/src/host_native.zig
@@ -924,6 +924,21 @@ fn hostedSetTargetFps(fps: i32) callconv(.c) void {
     raylib.setTargetFps(fps);
 }
 
+fn mouseCursorFromCode(code: u8) raylib.MouseCursor {
+    if (code > @intFromEnum(raylib.MouseCursor.not_allowed)) return .default;
+    return @enumFromInt(code);
+}
+
+fn hostedMouseSetCursorRaw(cursor: u8) callconv(.c) void {
+    if (active_headless) return;
+    raylib.setMouseCursor(mouseCursorFromCode(cursor));
+}
+
+test "mouse cursor codes map invalid values to default" {
+    try std.testing.expectEqual(raylib.MouseCursor.pointing_hand, mouseCursorFromCode(4));
+    try std.testing.expectEqual(raylib.MouseCursor.default, mouseCursorFromCode(255));
+}
+
 fn hostedRandomI32(min: i32, max: i32) callconv(.c) i32 {
     if (active_headless) return headlessRandomI32(min, max);
     return raylib.getRandomValue(min, max);
@@ -1184,6 +1199,7 @@ comptime {
         @export(&exportedReadFileRaw, .{ .name = "roc_host_read_file_raw" });
         @export(&hostedSetScreenSize, .{ .name = "roc_host_set_screen_size" });
         @export(&hostedSetTargetFps, .{ .name = "roc_host_set_target_fps" });
+        @export(&hostedMouseSetCursorRaw, .{ .name = "roc_mouse_set_cursor_raw" });
         @export(&exportedTilemapLoadTmxRaw, .{ .name = "roc_tilemap_load_tmx_raw" });
     }
 }

--- a/src/roc_platform_abi.zig
+++ b/src/roc_platform_abi.zig
@@ -4536,6 +4536,10 @@ pub extern fn roc_host_set_screen_size(arg0: HostSet_screen_size_rawArgs) callco
 /// Roc signature: I32 => {}
 pub extern fn roc_host_set_target_fps(arg0: i32) callconv(.c) void;
 
+/// Hosted symbol for Mouse.set_cursor_raw!
+/// Roc signature: U8 => {}
+pub extern fn roc_mouse_set_cursor_raw(arg0: u8) callconv(.c) void;
+
 /// Hosted symbol for Tilemap.load_tmx_raw!
 /// Roc signature: Str => { err : U8, map : { gids : List(U64), height : U64, layers : List({ gid_count : U64, gid_start : U64, height : U64, name : Str, opacity : F32, property_count : U64, property_start : U64, visible : Bool, width : U64 }), map_property_count : U64, map_property_start : U64, objects : List({ height : F32, id : U64, kind : U8, name : Str, point_count : U64, point_start : U64, property_count : U64, property_start : U64, rotation : F32, type_name : Str, width : F32, x : F32, y : F32 }), points : List({ x : F32, y : F32 }), properties : List({ bool_value : Bool, integer : I64, kind : U8, name : Str, number : F32, text : Str }), tile_height : F32, tile_properties : List({ gid : U64, property_count : U64, property_start : U64 }), tile_width : F32, tilesets : List({ columns : U64, first_gid : U64, image_height : F32, image_source : Str, image_width : F32, name : Str, property_count : U64, property_start : U64, tile_count : U64, tile_height : F32, tile_width : F32 }), width : U64 }, ok : Bool }
 pub extern fn roc_tilemap_load_tmx_raw(arg0: RocStr) callconv(.c) __AnonStruct_69c51f74695a8340;


### PR DESCRIPTION
## Summary

Interactive applications need to communicate what will happen when the user points at controls, text, resize handles, or unavailable actions. This API lets Roc applications select the appropriate OS cursor without exposing raylib's numeric cursor constants to application code.

## Changes

- add a typed `Mouse.Cursor` API mirroring raylib's documented [`MouseCursor` variants](https://github.com/raysan5/raylib/blob/6.0/src/raylib.h#L720-L734): `Default`, `Arrow`, `IBeam`, `Crosshair`, `PointingHand`, the five resize cursors, and `NotAllowed`
- expose `Host.set_cursor!` from the default and Wayland platform manifests
- wire cursor changes through the Roc ABI and native host to raylib's [`SetMouseCursor`](https://www.raylib.com/cheatsheet/cheatsheet.html)
