### PR TITLE
Pin nightly-2026-08-21-90da19f; model updates are now in place

### DIFF
--- a/.roc-version
+++ b/.roc-version
@@ -1,1 +1,1 @@
-nightly-2026-08-19-edec830
+nightly-2026-08-21-90da19f

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -379,12 +379,13 @@ That is how the cost of holding a collection in the model was measured:
 scripts/test_model_allocation.py --report
 ```
 
-Changing one element of a list in the model allocates a whole new list, every
-frame -- the model is still referenced by the box it arrived in, so the write
-is copy-on-write rather than in place. `test/model_inplace` is the probe,
-`scripts/test_model_allocation.py` runs in `all_tests.py` to keep the number
-from drifting in either direction, and its `--require-in-place` mode is the
-invariant we want and do not have.
+Changing one element of a list in the model is an in-place write: the box the
+model arrived in is consumed, so the list is uniquely referenced at the write
+and a frame costs only the model box. `test/model_inplace` is the probe and
+`scripts/test_model_allocation.py` runs in `all_tests.py`, holding steady-state
+per-frame allocation under a 16 KiB budget. Up to `nightly-2026-08-19-edec830`
+this instead copied the whole list every frame; `--characterize` re-runs the
+assertions that described that, and is expected to fail now.
 
 ## Bundles and targets
 

--- a/examples/async_read/main.roc
+++ b/examples/async_read/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.App
 import rr.Files

--- a/examples/breakout/main.roc
+++ b/examples/breakout/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.App
 import rr.Audio

--- a/examples/camera/main.roc
+++ b/examples/camera/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.App
 import rr.Camera

--- a/examples/capture_plot/main.roc
+++ b/examples/capture_plot/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.App
 import rr.Capture

--- a/examples/capture_screenshot/main.roc
+++ b/examples/capture_screenshot/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.App
 import rr.Capture

--- a/examples/capture_ui_demo/main.roc
+++ b/examples/capture_ui_demo/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.App
 import rr.Capture

--- a/examples/cave_climb/main.roc
+++ b/examples/cave_climb/main.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "../../platform/main.roc",
-	roc: "nightly-2026-08-19-edec830",
+	roc: "nightly-2026-08-21-90da19f",
 }
 
 import rr.App

--- a/examples/generated_assets/main.roc
+++ b/examples/generated_assets/main.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "../../platform/main.roc",
-	roc: "nightly-2026-08-19-edec830",
+	roc: "nightly-2026-08-21-90da19f",
 }
 
 import rr.App

--- a/examples/hello_world/main.roc
+++ b/examples/hello_world/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.App
 import rr.Color

--- a/examples/input_inspector/main.roc
+++ b/examples/input_inspector/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.Draw
 import rr.Color

--- a/examples/live_plot/main.roc
+++ b/examples/live_plot/main.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "../../platform/main.roc",
-	roc: "nightly-2026-08-19-edec830",
+	roc: "nightly-2026-08-21-90da19f",
 }
 
 import rr.App

--- a/examples/particles/main.roc
+++ b/examples/particles/main.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "../../platform/main.roc",
-	roc: "nightly-2026-08-19-edec830",
+	roc: "nightly-2026-08-21-90da19f",
 }
 
 import rr.App

--- a/examples/pong/main.roc
+++ b/examples/pong/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.Draw
 import rr.Color

--- a/examples/post_process/main.roc
+++ b/examples/post_process/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.App
 import rr.Assets

--- a/examples/postcard_studio/main.roc
+++ b/examples/postcard_studio/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.App
 import rr.Capture

--- a/examples/projective_texture/main.roc
+++ b/examples/projective_texture/main.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "../../platform/main.roc",
-	roc: "nightly-2026-08-19-edec830",
+	roc: "nightly-2026-08-21-90da19f",
 }
 
 import rr.App

--- a/examples/responsive_ui/main.roc
+++ b/examples/responsive_ui/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.App
 import rr.Color

--- a/examples/snake/main.roc
+++ b/examples/snake/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.App
 import rr.Time

--- a/examples/top_down/main.roc
+++ b/examples/top_down/main.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "../../platform/main.roc",
-	roc: "nightly-2026-08-19-edec830",
+	roc: "nightly-2026-08-21-90da19f",
 }
 
 import rr.App

--- a/platform/App.roc
+++ b/platform/App.roc
@@ -469,15 +469,14 @@ App := [].{
 	## asynchronous responses have no specified order. App termination drops pending
 	## response mappers because no later input can observe them.
 	##
-	## Changing a collection in the model costs a copy of it. The model reaches
-	## `update` still referenced by the box it arrived in, so the first write to
-	## one of its lists allocates a new one rather than mutating in place:
-	## measured at 4,000,000 bytes per frame for a one-million-element
+	## Changing a collection in the model is an in-place write. The model reaches
+	## `update` uniquely referenced -- the box it arrived in is consumed -- so
+	## writing to one of its lists mutates it rather than allocating a new one:
+	## measured at under a hundred bytes per frame for a one-million-element
 	## `List(F32)` (`test/model_inplace`, checked by
-	## `scripts/test_model_allocation.py`). Later writes to that same collection
-	## within one cycle are in place, so batching a cycle's changes into one
-	## `update` costs one copy rather than several. A collection that changes
-	## every frame is worth keeping small until this is fixed.
+	## `scripts/test_model_allocation.py`). A collection held in the model can
+	## therefore change every frame without a size-proportional cost. Earlier
+	## compiler pins copied it once per frame instead.
 	Transition(model, msg) := [
 		Transition(
 			{

--- a/platform/main-wayland.roc
+++ b/platform/main-wayland.roc
@@ -252,14 +252,14 @@ init_for_host! = ||
 ## invoked, receives this resulting model. The host assigns private
 ## tickets while it takes each returned callback envelope into its pending set.
 ##
-## Writing to a collection held in the model copies it. The box arrives holding
-## the model's only reference -- measured at refcount 1 on entry -- but
-## unboxing borrows rather than consumes and the box lives until this scope
-## ends, so `update` runs with the model's lists referenced more than once and
-## the first write to one allocates a whole new list. Measured at exactly one
-## copy per frame for a million-element `List(F32)`, 4,000,000 bytes, by
-## `test/model_inplace` under `scripts/test_model_allocation.py`. Writes after
-## the first, within the same cycle, are in place: the copy is unique.
+## Writing to a collection held in the model is an in-place write. The box
+## arrives holding the model's only reference -- measured at refcount 1 on entry
+## -- and unboxing here consumes it, so `update` runs with the model's lists
+## uniquely referenced and mutates them rather than copying. Measured on
+## `nightly-2026-08-21-90da19f` at under a hundred bytes per frame for a
+## million-element `List(F32)` by `test/model_inplace` under
+## `scripts/test_model_allocation.py`, which checks that budget. Earlier pins
+## copied the whole list every frame; `--characterize` describes that behaviour.
 update_for_host! : Box(Model), InputFromHostCycle(Msg) => Try({ model : Box(Model), requests : List(AppHost.SubmittedRequest(Msg)) }, I64)
 update_for_host! = |boxed_model, { devices, window, time, responses, capture }| {
 	messages = receive_responses(responses)

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -255,14 +255,14 @@ init_for_host! = ||
 ## invoked, receives this resulting model. The host assigns private
 ## tickets while it takes each returned callback envelope into its pending set.
 ##
-## Writing to a collection held in the model copies it. The box arrives holding
-## the model's only reference -- measured at refcount 1 on entry -- but
-## unboxing borrows rather than consumes and the box lives until this scope
-## ends, so `update` runs with the model's lists referenced more than once and
-## the first write to one allocates a whole new list. Measured at exactly one
-## copy per frame for a million-element `List(F32)`, 4,000,000 bytes, by
-## `test/model_inplace` under `scripts/test_model_allocation.py`. Writes after
-## the first, within the same cycle, are in place: the copy is unique.
+## Writing to a collection held in the model is an in-place write. The box
+## arrives holding the model's only reference -- measured at refcount 1 on entry
+## -- and unboxing here consumes it, so `update` runs with the model's lists
+## uniquely referenced and mutates them rather than copying. Measured on
+## `nightly-2026-08-21-90da19f` at under a hundred bytes per frame for a
+## million-element `List(F32)` by `test/model_inplace` under
+## `scripts/test_model_allocation.py`, which checks that budget. Earlier pins
+## copied the whole list every frame; `--characterize` describes that behaviour.
 update_for_host! : Box(Model), InputFromHostCycle(Msg) => Try({ model : Box(Model), requests : List(AppHost.SubmittedRequest(Msg)) }, I64)
 update_for_host! = |boxed_model, { devices, window, time, responses, capture }| {
 	messages = receive_responses(responses)

--- a/scripts/local_bundles.py
+++ b/scripts/local_bundles.py
@@ -15,7 +15,7 @@ Three things bite local testing because of it:
    names it however it was last rewritten. When two of those routes resolve
    different builds of the package, the same types arrive under two nominal
    identities. `test/package_interop/README.md` records what that costs.
-   (Measured on the pin in `.roc-version`, `nightly-2026-08-19-edec830`, the
+   (Measured on the pin in `.roc-version`, `nightly-2026-08-21-90da19f`, the
    compiler tolerates it: path and URL unify, and so do two *different* types
    bundles on either side of one app. It has not always, and the arrangement is
    still one where an app can be built against a package build nobody shipped.)
@@ -175,8 +175,8 @@ def check_roc_pin(root: Path, roc: str = "roc") -> str | None:
     against a locally built compiler.
 
     A build of the pinned revision counts as a match even though it reports its
-    build mode instead of the tag -- `release-fast-edec8304` is the compiler
-    `nightly-2026-08-19-edec830` names. `roc_platform_abi.compiler_matches_pin`
+    build mode instead of the tag -- `release-fast-90da19f4` is the compiler
+    `nightly-2026-08-21-90da19f` names. `roc_platform_abi.compiler_matches_pin`
     is the shared rule; this falls back to a plain comparison if that module
     cannot parse the pin.
     """

--- a/scripts/roc_platform_abi.py
+++ b/scripts/roc_platform_abi.py
@@ -82,8 +82,8 @@ def compiler_matches_pin(observed: str, pin: RocPin) -> bool:
     """Is `observed` (a `roc version` line) the compiler `pin` names?
 
     The published nightly reports the whole tag. A compiler built from the same
-    revision reports its build mode and commit instead -- `release-fast-edec8304`
-    for `nightly-2026-08-19-edec830` -- which is the same compiler and should be
+    revision reports its build mode and commit instead -- `release-fast-90da19f4`
+    for `nightly-2026-08-21-90da19f` -- which is the same compiler and should be
     allowed. Match on the commit, taking the shorter of the two hashes so either
     abbreviation is accepted.
     """

--- a/scripts/test_model_allocation.py
+++ b/scripts/test_model_allocation.py
@@ -2,48 +2,29 @@
 """Measure what one frame costs a large collection held in the app's model.
 
 The host consumes its model box on every `update_for_host` call and the platform
-adapter boxes the returned model again. If nothing else referenced the old model
-while `update` ran, writing to a list in it would be an in-place write and a
-frame would cost nothing proportional to the list. It is not, and it does:
-`test/model_inplace` writes one element of a one-million-`F32` list and the
-frame allocates a whole new list, every frame.
+adapter boxes the returned model again. If nothing else references the old model
+while `update` runs, writing to a list in it is an in-place write and a frame
+costs nothing proportional to the list. As of the `nightly-2026-08-21-90da19f`
+pin that is what happens: `test/model_inplace` writes one element of a
+one-million-`F32` list and the frame allocates only the model box.
 
 That result is measured, not assumed, and this script is how it stays measured.
 It builds the probe app, runs it headless under `ROC_RAY_ALLOC_STATS=1`, and
-checks the steady-state per-frame numbers against what was observed:
+checks that steady-state per-frame allocation stays under a small fixed budget
+for both the `set` and `append` patterns.
 
-    set     one full copy of the list per frame (4,000,000 bytes for 1M F32)
-    append  a copy sized to the exact new length, so the per-frame cost grows
-            by one element a frame -- growth is not amortized, because an
-            amortized grow needs a uniquely referenced list and this is not one
-
-Both assertions are two-sided on purpose. A frame that costs more than one copy
-is a regression. A frame that costs less means somebody made the model's
-collections unique again: that is the outcome everyone wants, and the fix for
-this failure is to switch this check to `--require-in-place`, delete the
-characterization numbers, and update the notes in `platform/main.roc` and
-`platform/App.roc` that record the copying behaviour.
-
-`--require-in-place` asserts the invariant that copying denies: steady-state
-per-frame allocation under a small fixed budget. It is expected to FAIL today.
-It is here so the goal is executable rather than described.
-
-TODO: make `--require-in-place` the checked mode once the copy is gone. It is
-not a platform bug to fix here. The host hands over its only box reference and
-clears its own slot first, and the list's refcount at `update_for_host` entry
-measures 1; it measures 3 by the time the copy is allocated, both increfs
-coming from Roc-compiled code. `Box.unbox` is specified as retaining its result
-and borrowing its argument, never consuming the box, so the box and the
-unboxed model are both live while `update` runs and `List.set` takes its
-copy-on-write path. The compiler can consume the box instead -- its `box_reuse`
-rewrite does exactly that for a straight-line `unbox -> produce -> box -> ret`
--- but the adapter branches and runs effects between those points. Weighing
-mutation points when choosing between a borrow and an owned move is named as
-future work in the compiler's design notes.
+It did not always hold. Under earlier pins each frame copied the whole list:
+`Box.unbox` is specified as retaining its result and borrowing its argument, so
+the box and the unboxed model were both live while `update` ran and `List.set`
+took its copy-on-write path. The compiler now consumes the box instead, and the
+list's refcount at the mutation point is 1. `--characterize` re-runs the old
+two-sided copying assertions; it is expected to FAIL now, and is kept so a
+regression back to copying can be identified rather than just measured as "more
+than the budget".
 
 Usage:
-    scripts/test_model_allocation.py                # characterize (CI default)
-    scripts/test_model_allocation.py --require-in-place   # the goal; fails today
+    scripts/test_model_allocation.py                # check in-place (CI default)
+    scripts/test_model_allocation.py --characterize # the old copying numbers
     scripts/test_model_allocation.py --report       # print every pattern's cost
 """
 
@@ -178,9 +159,9 @@ def check_copies_once(rows: list[dict[str, int]], pattern: str) -> list[str]:
     if measured < one_copy // 2:
         return [
             f"{pattern}: {measured} bytes per frame is less than one copy of the list "
-            f"({one_copy}). The model's collections may be unique again -- if so, "
-            "rerun with --require-in-place, make that the checked contract, and "
-            "update the notes in platform/main.roc and platform/App.roc"
+            f"({one_copy}); the model's collections are unique. This is the wanted "
+            "outcome and the default mode checks it -- --characterize only "
+            "describes the copying behaviour that preceded it"
         ]
     return []
 
@@ -241,10 +222,10 @@ def main() -> int:
         "--skip-build", action="store_true", help="Reuse the probe executable already built"
     )
     parser.add_argument(
-        "--require-in-place",
+        "--characterize",
         action="store_true",
-        help="Assert the invariant this repo does not currently hold: steady-state "
-        f"per-frame allocation under {IN_PLACE_BUDGET_BYTES} bytes. Expected to FAIL.",
+        help="Assert the copying behaviour that preceded the compiler fix: one full "
+        "copy of the list per frame. Expected to FAIL on the current pin.",
     )
     parser.add_argument("--report", action="store_true", help="Print every pattern's cost")
     parser.add_argument("--verbose", "-v", action="store_true", help="Show build output")
@@ -277,18 +258,13 @@ def main() -> int:
         f"append={append_bytes} bytes/frame"
     )
 
-    if args.require_in_place:
-        failures = check_in_place(set_rows, "set") + check_in_place(append_rows, "append")
-    else:
+    if args.characterize:
         failures = (
             check_copies_once(set_rows, "set")
             + check_append_regrows_exactly(append_rows)
         )
-        # Always say where the invariant stands, so the gap between what is
-        # checked and what is wanted never has to be rediscovered.
-        outstanding = check_in_place(set_rows, "set")
-        if outstanding:
-            print(f"XFAIL (known, not a regression): {outstanding[0]}")
+    else:
+        failures = check_in_place(set_rows, "set") + check_in_place(append_rows, "append")
 
     for failure in failures:
         print(f"FAILED: {failure}", file=sys.stderr)

--- a/test/asset_store_compile.roc
+++ b/test/asset_store_compile.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "../platform/main.roc",
-	roc: "nightly-2026-08-19-edec830",
+	roc: "nightly-2026-08-21-90da19f",
 }
 
 import rr.App

--- a/test/cli_args/main.roc
+++ b/test/cli_args/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.App
 

--- a/test/compile_fail/app_config_module.roc
+++ b/test/compile_fail/app_config_module.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.App
 import rr.AppConfig

--- a/test/compile_fail/app_config_to_host.roc
+++ b/test/compile_fail/app_config_to_host.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/app_host_config.roc
+++ b/test/compile_fail/app_host_config.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/app_host_module.roc
+++ b/test/compile_fail/app_host_module.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/app_transport_type.roc
+++ b/test/compile_fail/app_transport_type.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/capture_stop_effect.roc
+++ b/test/compile_fail/capture_stop_effect.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 # Finalizing a recording is an encode and a file write. As an effect it was
 # reachable from `render!`, which put both in the middle of drawing a frame, at

--- a/test/compile_fail/file_module_removed.roc
+++ b/test/compile_fail/file_module_removed.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 # Large reads now return `List(U8)` from `Files`; the old module must stay absent.
 import rr.App

--- a/test/compile_fail/input_module_removed.roc
+++ b/test/compile_fail/input_module_removed.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/program_module_removed.roc
+++ b/test/compile_fail/program_module_removed.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/texture_handle_manufacture.roc
+++ b/test/compile_fail/texture_handle_manufacture.roc
@@ -1,7 +1,7 @@
 app [Model, program] {
 	rr: platform "../../platform/main.roc",
 	rrt: "../../types/main.roc",
-	roc: "nightly-2026-08-19-edec830",
+	roc: "nightly-2026-08-21-90da19f",
 }
 
 # A texture's resource identity is private to the host. Applications can copy a

--- a/test/model_inplace/main.roc
+++ b/test/model_inplace/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-19-edec830" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
 
 import rr.App
 import rr.Color
@@ -7,31 +7,25 @@ import rr.Draw
 ## A measurement app: does a large collection in the model survive a frame
 ## without being copied?
 ##
-## It does not. Run it under `ROC_RAY_ALLOC_STATS=1` and read the per-frame
-## allocator line: writing one element of a million-`F32` list in the model
-## allocates 4,000,000 bytes a frame, every frame. `scripts/test_model_allocation.py`
-## is the same measurement as a check.
+## It does, as of `nightly-2026-08-21-90da19f`. Run it under
+## `ROC_RAY_ALLOC_STATS=1` and read the per-frame allocator line: writing one
+## element of a million-`F32` list in the model allocates well under a hundred
+## bytes a frame -- the model box, and nothing proportional to the list.
+## `scripts/test_model_allocation.py` is the same measurement as a check.
 ##
-## Where the second reference comes from, since it is not the host: the host
-## clears its own slot before the call (`takeModel`), and the list's refcount
-## measured at `update_for_host` entry is 1. It reads 3 by the time the copy is
-## allocated. Both increfs happen in Roc-compiled code below `update_for_host`.
-## The compiler's rule for `Box.unbox` is `retainsResultBorrowingArgs`
-## (`src/base/LowLevel.zig`): it never consumes the box, so either the payload
-## is increfed or the box is kept alive across every use of the payload. Either
-## way the box and the unboxed model are both live when `update` runs, so
-## `List.set` takes the copy-on-write path (`makeUnique`, refcount != 1). The
-## compiler does have a rewrite that consumes the box instead -- `box_reuse`,
-## for a straight-line `unbox -> produce -> box -> ret` -- but the adapter has
-## branches and effects between those points and does not match it. The
-## interaction is a documented open item in the compiler's own design notes: a
-## borrow whose lifetime extends past a uniqueness-checked mutation of its
-## lender forces the runtime copy path.
-##
-## So this is not an app-level mistake, and the controls below show it: the
-## same write to a list that never came through the model is in place, and a
-## second write to the model's list in the same frame is free, because by then
-## the copy is unique.
+## It did not always. Up to `nightly-2026-08-19-edec830` the same write cost
+## 4,000,000 bytes a frame. The host was never the second reference: it clears
+## its own slot before the call (`takeModel`), and the list's refcount measured
+## at `update_for_host` entry was 1. It read 3 by the time the copy was
+## allocated, both increfs from Roc-compiled code below `update_for_host`. The
+## compiler's rule for `Box.unbox` was `retainsResultBorrowingArgs`
+## (`src/base/LowLevel.zig`): it never consumed the box, so the box and the
+## unboxed model were both live when `update` ran and `List.set` took the
+## copy-on-write path (`makeUnique`, refcount != 1). The adapter branches and
+## runs effects between the unbox and the rebox, so the `box_reuse` rewrite --
+## which handles a straight-line `unbox -> produce -> box -> ret` -- did not
+## match it. The compiler now consumes the box here, and the controls below
+## agree with the headline number rather than contrasting with it.
 ##
 ## `ROC_RAY_MODEL_PATTERN` selects which pattern the frame exercises. The first
 ## two are what an app would really write; the rest are controls that separate

--- a/test/package_interop/app.roc
+++ b/test/package_interop/app.roc
@@ -2,7 +2,7 @@ app [Model, program] {
 	rr: platform "../../platform/main.roc",
 	adapter: "input_adapter/main.roc",
 	rrt: "../../types/main.roc",
-	roc: "nightly-2026-08-19-edec830",
+	roc: "nightly-2026-08-21-90da19f",
 }
 
 import rr.App


### PR DESCRIPTION
Bumps the pin from `nightly-2026-08-19-edec830` to `nightly-2026-08-21-90da19f`: `.roc-version`, every app header that names the nightly, and the example tags inside the pin-matching docstrings.

## The model copy is gone

This is the upstream fix we were waiting on. Under the old pin, `List.set` on a million-element `List(F32)` held in the model allocated 4,000,000 bytes **every frame** — `Box.unbox` borrowed rather than consumed its argument, so the box stayed live across the mutation and `List.set` took its copy-on-write path.

On this pin the compiler consumes the box. The list's refcount at the write is 1, and a frame costs **88 bytes** — the model box and nothing proportional to the list:

```
steady-state update allocation: set=88 bytes/frame (0.00 copies of the list), append=88 bytes/frame
```

So `scripts/test_model_allocation.py` flips, exactly as its own TODO prescribed:

- the in-place budget (16 KiB/frame) is now the **checked contract** and the default mode
- the two-sided copying assertions move behind `--characterize`, which is expected to fail now and is kept so a regression back to copying is identified rather than just measured as "over budget"

The notes that recorded the copying behaviour are rewritten to record the in-place behaviour and what preceded it: `platform/main.roc`, `platform/main-wayland.roc` (kept in sync), `platform/App.roc`, `test/model_inplace/main.roc`, and `CONTRIBUTING.md`. App authors no longer need to keep a per-frame collection small.

## Verification

Run locally against the new compiler:

- `scripts/all_tests.py` — **all tests passed** (fmt / check / test / build / headless run over all 19 examples, CLI probe, allocation check, package interop, Wayland bundle). `cave_climb`'s build remains on its pre-existing declared skip.
- `zig build lint` — passed, including the `main.roc` / `main-wayland.roc` header-sync check.
- `scripts/roc_platform_abi.py --check` — verified; the generated ABI is **unchanged** by this bump.

Draft pending CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)