### PR TITLE
Update Roc nightly to 2026-08-23

### DIFF
--- a/.roc-version
+++ b/.roc-version
@@ -1,1 +1,1 @@
-nightly-2026-08-21-90da19f
+nightly-2026-08-23-fb208ba

--- a/examples/async_read/main.roc
+++ b/examples/async_read/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Files

--- a/examples/breakout/main.roc
+++ b/examples/breakout/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Audio

--- a/examples/camera/main.roc
+++ b/examples/camera/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Camera

--- a/examples/capture_plot/main.roc
+++ b/examples/capture_plot/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Capture

--- a/examples/capture_screenshot/main.roc
+++ b/examples/capture_screenshot/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Capture

--- a/examples/capture_ui_demo/main.roc
+++ b/examples/capture_ui_demo/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Capture

--- a/examples/cave_climb/main.roc
+++ b/examples/cave_climb/main.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst",
-	roc: "nightly-2026-08-21-90da19f",
+	roc: "nightly-2026-08-23-fb208ba",
 }
 
 import rr.App

--- a/examples/drop_viewer/main.roc
+++ b/examples/drop_viewer/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Assets

--- a/examples/generated_assets/main.roc
+++ b/examples/generated_assets/main.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst",
-	roc: "nightly-2026-08-21-90da19f",
+	roc: "nightly-2026-08-23-fb208ba",
 }
 
 import rr.App

--- a/examples/hello_world/main.roc
+++ b/examples/hello_world/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Color

--- a/examples/http_fetch/main.roc
+++ b/examples/http_fetch/main.roc
@@ -1,7 +1,7 @@
 app [Model, program] {
 	rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst",
 	http: "https://github.com/roc-lang/http/releases/download/1.0.0/6ZUwqYhCS8PU9Mo6MF7oV82ET2o7KYb57CLKDq4cq4sS.tar.zst",
-	roc: "nightly-2026-08-21-90da19f",
+	roc: "nightly-2026-08-23-fb208ba",
 }
 
 import rr.App

--- a/examples/input_inspector/main.roc
+++ b/examples/input_inspector/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.Draw
 import rr.Color

--- a/examples/live_plot/main.roc
+++ b/examples/live_plot/main.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst",
-	roc: "nightly-2026-08-21-90da19f",
+	roc: "nightly-2026-08-23-fb208ba",
 }
 
 import rr.App

--- a/examples/particles/main.roc
+++ b/examples/particles/main.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst",
-	roc: "nightly-2026-08-21-90da19f",
+	roc: "nightly-2026-08-23-fb208ba",
 }
 
 import rr.App

--- a/examples/pong/main.roc
+++ b/examples/pong/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.Draw
 import rr.Color

--- a/examples/post_process/main.roc
+++ b/examples/post_process/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Assets

--- a/examples/postcard_studio/main.roc
+++ b/examples/postcard_studio/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Capture

--- a/examples/projective_texture/main.roc
+++ b/examples/projective_texture/main.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst",
-	roc: "nightly-2026-08-21-90da19f",
+	roc: "nightly-2026-08-23-fb208ba",
 }
 
 import rr.App

--- a/examples/responsive_ui/main.roc
+++ b/examples/responsive_ui/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Color

--- a/examples/snake/main.roc
+++ b/examples/snake/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Time

--- a/examples/sqlite_scores/main.roc
+++ b/examples/sqlite_scores/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Color

--- a/examples/task_sleep/main.roc
+++ b/examples/task_sleep/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Task

--- a/examples/top_down/main.roc
+++ b/examples/top_down/main.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst",
-	roc: "nightly-2026-08-21-90da19f",
+	roc: "nightly-2026-08-23-fb208ba",
 }
 
 import rr.App

--- a/examples/udp_cursor/main.roc
+++ b/examples/udp_cursor/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Color

--- a/platform/main-wayland.roc
+++ b/platform/main-wayland.roc
@@ -52,7 +52,7 @@
 ## A whole app: it opens a window, draws one circle, and exits on escape.
 ##
 ## ```roc
-## app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+## app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 ##
 ## import rr.App
 ## import rr.Color

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -52,7 +52,7 @@
 ## A whole app: it opens a window, draws one circle, and exits on escape.
 ##
 ## ```roc
-## app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+## app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 ##
 ## import rr.App
 ## import rr.Color

--- a/scripts/local_bundles.py
+++ b/scripts/local_bundles.py
@@ -15,7 +15,7 @@ Three things bite local testing because of it:
    names it however it was last rewritten. When two of those routes resolve
    different builds of the package, the same types arrive under two nominal
    identities. `test/package_interop/README.md` records what that costs.
-   (Measured on the pin in `.roc-version`, `nightly-2026-08-21-90da19f`, the
+   (Measured on the pin in `.roc-version`, `nightly-2026-08-23-fb208ba`, the
    compiler tolerates it: path and URL unify, and so do two *different* types
    bundles on either side of one app. It has not always, and the arrangement is
    still one where an app can be built against a package build nobody shipped.)
@@ -188,8 +188,8 @@ def check_roc_pin(root: Path, roc: str = "roc") -> str | None:
     against a locally built compiler.
 
     A build of the pinned revision counts as a match even though it reports its
-    build mode instead of the tag -- `release-fast-90da19f4` is the compiler
-    `nightly-2026-08-21-90da19f` names. `roc_platform_abi.compiler_matches_pin`
+    build mode instead of the tag -- `release-fast-fb208ba` is the compiler
+    `nightly-2026-08-23-fb208ba` names. `roc_platform_abi.compiler_matches_pin`
     is the shared rule; this falls back to a plain comparison if that module
     cannot parse the pin.
     """

--- a/scripts/roc_platform_abi.py
+++ b/scripts/roc_platform_abi.py
@@ -82,8 +82,8 @@ def compiler_matches_pin(observed: str, pin: RocPin) -> bool:
     """Is `observed` (a `roc version` line) the compiler `pin` names?
 
     The published nightly reports the whole tag. A compiler built from the same
-    revision reports its build mode and commit instead -- `release-fast-90da19f4`
-    for `nightly-2026-08-21-90da19f` -- which is the same compiler and should be
+    revision reports its build mode and commit instead -- `release-fast-fb208ba`
+    for `nightly-2026-08-23-fb208ba` -- which is the same compiler and should be
     allowed. Match on the commit, taking the shorter of the two hashes so either
     abbreviation is accepted.
     """

--- a/scripts/test_model_allocation.py
+++ b/scripts/test_model_allocation.py
@@ -4,7 +4,7 @@
 The host consumes its model box on every `update_for_host` call and the platform
 adapter boxes the returned model again. If nothing else references the old model
 while `update` runs, writing to a list in it is an in-place write and a frame
-costs nothing proportional to the list. As of the `nightly-2026-08-21-90da19f`
+costs nothing proportional to the list. As of the `nightly-2026-08-23-fb208ba`
 pin that is what happens: `test/model_inplace` writes one element of a
 one-million-`F32` list and the frame allocates only the model box.
 

--- a/test/asset_store_compile.roc
+++ b/test/asset_store_compile.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "../platform/main.roc",
-	roc: "nightly-2026-08-21-90da19f",
+	roc: "nightly-2026-08-23-fb208ba",
 }
 
 import rr.App

--- a/test/cli_args/main.roc
+++ b/test/cli_args/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 

--- a/test/cmd/main.roc
+++ b/test/cmd/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Cmd

--- a/test/compile_fail/app_config_module.roc
+++ b/test/compile_fail/app_config_module.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.AppConfig

--- a/test/compile_fail/app_config_to_host.roc
+++ b/test/compile_fail/app_config_to_host.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/app_host_config.roc
+++ b/test/compile_fail/app_host_config.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/app_host_module.roc
+++ b/test/compile_fail/app_host_module.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/assets_host_module.roc
+++ b/test/compile_fail/assets_host_module.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/audio_host_module.roc
+++ b/test/compile_fail/audio_host_module.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/capture_host_module.roc
+++ b/test/compile_fail/capture_host_module.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/cmd_host_module.roc
+++ b/test/compile_fail/cmd_host_module.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/draw_host_module.roc
+++ b/test/compile_fail/draw_host_module.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/file_module_removed.roc
+++ b/test/compile_fail/file_module_removed.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 # Large reads now return `List(U8)` from `Files`; the old module must stay absent.
 import rr.App

--- a/test/compile_fail/files_host_module.roc
+++ b/test/compile_fail/files_host_module.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/font_handle_manufacture.roc
+++ b/test/compile_fail/font_handle_manufacture.roc
@@ -1,7 +1,7 @@
 app [Model, program] {
 	rr: platform "../../platform/main.roc",
 	rrt: "../../types/main.roc",
-	roc: "nightly-2026-08-21-90da19f",
+	roc: "nightly-2026-08-23-fb208ba",
 }
 
 # A font's resource identity is private to the host. Applications can copy a

--- a/test/compile_fail/http_host_module.roc
+++ b/test/compile_fail/http_host_module.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/input_module_removed.roc
+++ b/test/compile_fail/input_module_removed.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/input_spawn_receiver.roc
+++ b/test/compile_fail/input_spawn_receiver.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 # `App.Input` is a pure value declared in the `roc-ray-types` package, so it has
 # no effectful receivers. `Task.spawn!(input, || ...)` is the only way to start

--- a/test/compile_fail/mouse_host_module.roc
+++ b/test/compile_fail/mouse_host_module.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/program_module_removed.roc
+++ b/test/compile_fail/program_module_removed.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/sqlite_db_manufacture.roc
+++ b/test/compile_fail/sqlite_db_manufacture.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 # A connection's identity is private to the host. An application can hold and
 # copy a `Db` it was given, but cannot manufacture one from a raw integer and

--- a/test/compile_fail/sqlite_host_module.roc
+++ b/test/compile_fail/sqlite_host_module.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/stdio_host_module.roc
+++ b/test/compile_fail/stdio_host_module.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/task_host_module.roc
+++ b/test/compile_fail/task_host_module.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/texture_handle_manufacture.roc
+++ b/test/compile_fail/texture_handle_manufacture.roc
@@ -1,7 +1,7 @@
 app [Model, program] {
 	rr: platform "../../platform/main.roc",
 	rrt: "../../types/main.roc",
-	roc: "nightly-2026-08-21-90da19f",
+	roc: "nightly-2026-08-23-fb208ba",
 }
 
 # A texture's resource identity is private to the host. Applications can copy a

--- a/test/compile_fail/tilemap_host_module.roc
+++ b/test/compile_fail/tilemap_host_module.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/time_host_module.roc
+++ b/test/compile_fail/time_host_module.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/transition_removed.roc
+++ b/test/compile_fail/transition_removed.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 # `update!` is effectful: host state changes are direct calls and deferred
 # work goes through `Task.spawn!`. The pure-update `Transition` builder is

--- a/test/compile_fail/udp_host_module.roc
+++ b/test/compile_fail/udp_host_module.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Draw

--- a/test/file_write/main.roc
+++ b/test/file_write/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Files

--- a/test/http_fetch/main.roc
+++ b/test/http_fetch/main.roc
@@ -1,7 +1,7 @@
 app [Model, program] {
 	rr: platform "../../platform/main.roc",
 	http: "https://github.com/roc-lang/http/releases/download/1.0.0/6ZUwqYhCS8PU9Mo6MF7oV82ET2o7KYb57CLKDq4cq4sS.tar.zst",
-	roc: "nightly-2026-08-21-90da19f",
+	roc: "nightly-2026-08-23-fb208ba",
 }
 
 import rr.App

--- a/test/model_inplace/main.roc
+++ b/test/model_inplace/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Color
@@ -7,7 +7,7 @@ import rr.Draw
 ## A measurement app: does a large collection in the model survive a frame
 ## without being copied?
 ##
-## It does, as of `nightly-2026-08-21-90da19f`. Run it under
+## It does, as of `nightly-2026-08-23-fb208ba`. Run it under
 ## `ROC_RAY_ALLOC_STATS=1` and read the per-frame allocator line: writing one
 ## element of a million-`F32` list in the model allocates well under a hundred
 ## bytes a frame -- the model box, and nothing proportional to the list.

--- a/test/package_interop/app.roc
+++ b/test/package_interop/app.roc
@@ -2,7 +2,7 @@ app [Model, program] {
 	rr: platform "../../platform/main.roc",
 	adapter: "input_adapter/main.roc",
 	rrt: "../../types/main.roc",
-	roc: "nightly-2026-08-21-90da19f",
+	roc: "nightly-2026-08-23-fb208ba",
 }
 
 import rr.App

--- a/test/sqlite/main.roc
+++ b/test/sqlite/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Draw

--- a/test/task_cap/main.roc
+++ b/test/task_cap/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Task

--- a/test/task_delivery/main.roc
+++ b/test/task_delivery/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Task

--- a/test/udp/main.roc
+++ b/test/udp/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Task

--- a/test/virtual_keys/main.roc
+++ b/test/virtual_keys/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-21-90da19f" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
 import rr.Devices


### PR DESCRIPTION
## Summary

- pin RocRay to `nightly-2026-08-23-fb208ba`
- update example and test app headers
- refresh nightly-specific documentation and compiler examples

## Verification

- `zig build lint`
- `zig build test`
- `python3 scripts/test_roc_platform_abi.py`
- `git diff --check`