### PR TITLE
0.10.0 refactor Font

### DIFF
--- a/.types-version
+++ b/.types-version
@@ -7,4 +7,4 @@
 #
 # Produced by .github/workflows/release-types.yml. Empty until the first
 # roc-ray-types release is cut.
-https://github.com/lukewilliamboswell/roc-ray/releases/download/types-0.6.1/9AUpNYVQ9qPGKENm8dDJbqyCAyJi35jHUs8SCZugzF4x.tar.zst
+https://github.com/lukewilliamboswell/roc-ray/releases/download/types-0.7.0/DWjJtKpk4QZWZcuafPm7gg9WGLxaeS1hetkYZMeboWQE.tar.zst

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ xvfb-run -a zig build graphical-smoke
 
 Run it when changing primitives, texture coordinates, shaders, blending,
 scissoring, render textures, paired drawing modes, or native font metrics. It
-also compares the scalar snapshot inside `Draw.Font` with raylib's
+also compares the scalar snapshot inside `Text.Font` with raylib's
 `MeasureTextEx` for the default font and, when the system provides one, a
 loaded proportional font. The ordinary headless app runs verify composition
 and lifecycle behavior, not framebuffer pixels.
@@ -243,7 +243,7 @@ go and take them: `App.Startup` is a capability token the platform adapter
 mints, and a type nobody outside the platform can construct would be a type
 nobody outside the platform can use. Instead the package exposes a plan and a
 pure constructor -- `Toolkit.required_assets : Theme -> List(AssetRequest)` and
-`Toolkit.init : List(Draw.Texture), Draw.Font -> Toolkit.State` -- and the
+`Toolkit.init : List(Draw.Texture), Text.Font -> Toolkit.State` -- and the
 app's `init!` walks the plan, calls `Assets.load_texture!` and
 `Draw.load_store_font!`, and hands the results back. For work that waits the
 package exposes a closure rather than spawning: `Toolkit.fetch_theme! : () =>

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ font = startup.default_font!()?
 ```
 
 `Text.Font` carries both its opaque host handle and an immutable metric
-snapshot, so `Text.measure` is pure.
+snapshot, so `font.measure(...)` is pure.
 
 ## Project links
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ complete app, then choose a project from the
 [API reference](https://lukewilliamboswell.github.io/roc-ray/) documents the
 available features and functions.
 
+Configure a shared startup font when one font serves most of the app:
+
+```roc
+config = App.default.with_default_font({ path: "assets/body.ttf", size: 32 })
+font = startup.default_font!()?
+```
+
+`Text.Font` carries both its opaque host handle and an immutable metric
+snapshot, so `Text.measure` is pure.
+
 ## Project links
 
 - [Examples and learning path](examples/README.md)

--- a/examples/breakout/main.roc
+++ b/examples/breakout/main.roc
@@ -81,7 +81,7 @@ Model : {
 	won_line : Text.Prepared,
 	over_line : Text.Prepared,
 	restart_line : Text.Prepared,
-	font : Draw.Font,
+	font : Text.Font,
 }
 
 FrameInput : {

--- a/examples/capture_ui_demo/main.roc
+++ b/examples/capture_ui_demo/main.roc
@@ -124,7 +124,7 @@ init! = App.init(
 )
 
 ## Prepare one label per reachable click count, so `render!` never lays out text.
-prepare_counter_labels! : Draw.Font, U64, List(Text.Prepared) => Try(List(Text.Prepared), [ResourceLimit, ..])
+prepare_counter_labels! : Text.Font, U64, List(Text.Prepared) => Try(List(Text.Prepared), [ResourceLimit, ..])
 prepare_counter_labels! = |font, index, acc|
 	if index > max_clicks {
 		Ok(acc)
@@ -137,7 +137,7 @@ prepare_counter_labels! = |font, index, acc|
 ##
 ## The script types that string in order and backspace only ever removes from
 ## its end, so every state the field can reach is one of these prefixes.
-prepare_field_labels! : Draw.Font, U64, List(Text.Prepared) => Try(List(Text.Prepared), [ResourceLimit, ..])
+prepare_field_labels! : Text.Font, U64, List(Text.Prepared) => Try(List(Text.Prepared), [ResourceLimit, ..])
 prepare_field_labels! = |font, index, acc|
 	if index > List.len(field_text) {
 		Ok(acc)

--- a/examples/cave_climb/Cave.roc
+++ b/examples/cave_climb/Cave.roc
@@ -1,6 +1,7 @@
 ## Domain data for Cave Climb. Keeping these shapes together makes the world
 ## model readable without mixing it with asset loading, simulation, or drawing.
 import rr.Draw
+import rr.Text
 import rr.Math
 import rr.Physics
 import rr.Sprite
@@ -150,7 +151,7 @@ Cave := [].{
 	}
 
 	Model : {
-		font : Draw.Font,
+		font : Text.Font,
 		tiles : Draw.Texture,
 		characters : Draw.Texture,
 		enemies_texture : Draw.Texture,

--- a/examples/cave_climb/main.roc
+++ b/examples/cave_climb/main.roc
@@ -13,6 +13,7 @@ import rr.Assets
 import rr.Camera
 import rr.Color
 import rr.Draw
+import rr.Text
 import rr.Devices
 import rr.Keys
 import rr.Math
@@ -1045,7 +1046,7 @@ draw_player! = |frame, characters, player| {
 	frame.rectangle!({ x: pos.x - half_player_w, y: pos.y - half_player_h, width: player_width, height: player_height, style: Draw.outlined(Color.with_alpha(Color.white, 90), 2) })
 }
 
-draw_hud! : Draw.Frame, Level, World, Draw.Font => {}
+draw_hud! : Draw.Frame, Level, World, Text.Font => {}
 draw_hud! = |frame, level, world, font| {
 	frame.rectangle_gradient_v!({ x: 0, y: 0, width: screen_w, height: 76, color_top: Color.with_alpha(Color.black, 220), color_bottom: Color.with_alpha(Color.black, 110) })
 	frame.text!({ pos: { x: 22, y: 16 }, text: "Cave Climb", size: 27, spacing: Draw.default_spacing, color: Color.white, font: font, align: Draw.align_top_left })

--- a/examples/hello_world/main.roc
+++ b/examples/hello_world/main.roc
@@ -17,7 +17,7 @@ import rr.Text
 Model : {
 	title : Text.Prepared,
 	help : Text.Prepared,
-	font : Draw.Font,
+	font : Text.Font,
 	layout : Layout,
 	pointer : { x : F32, y : F32 },
 	accent_on : Bool,
@@ -34,14 +34,15 @@ Layout : {
 
 program = { init!, update!, render! }
 
-init! : App.Init(Model, [ResourceLimit])
+init! : App.Init(Model, [AssetPathInvalid, AssetNotFound, AssetReadFailed, FontLoadFailed, ResourceLimit])
 init! = App.init(
 	App.default
 		.with_title("Hello RocRay")
 		.with_size({ width: 800, height: 600 })
-		.with_frame_pacing(Capped(120)),
-	|_startup| {
-		font = Draw.default_font!()
+		.with_frame_pacing(Capped(120))
+		.with_default_font({ path: "examples/live_plot/assets/fonts/LiberationSans-Regular.ttf", size: 38 }),
+	|startup| {
+		font = startup.default_font!()?
 		Ok({
 			title: Text.from("Roc :heart: Raylib", font).size(38).prepare!()?,
 			help: Text.from("Move the pointer  -  click for an accent  -  ESC exits", font).size(18).prepare!()?,
@@ -78,10 +79,10 @@ update! = |model, program_input| {
 	}
 }
 
-solve_layout : Draw.Font -> Layout
+solve_layout : Text.Font -> Layout
 solve_layout = |font| {
 	panel: { x: 120, y: 150, width: 560, height: 300 },
-	title_size: font.measure({ text: "Roc :heart: Raylib", size: 38, spacing: Text.default_spacing }),
+	title_size: Text.measure(font, { text: "Roc :heart: Raylib", size: 38, spacing: Text.default_spacing }),
 }
 
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])

--- a/examples/hello_world/main.roc
+++ b/examples/hello_world/main.roc
@@ -82,7 +82,7 @@ update! = |model, program_input| {
 solve_layout : Text.Font -> Layout
 solve_layout = |font| {
 	panel: { x: 120, y: 150, width: 560, height: 300 },
-	title_size: Text.measure(font, { text: "Roc :heart: Raylib", size: 38, spacing: Text.default_spacing }),
+	title_size: font.measure({ text: "Roc :heart: Raylib", size: 38, spacing: Text.default_spacing }),
 }
 
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])

--- a/examples/input_inspector/main.roc
+++ b/examples/input_inspector/main.roc
@@ -7,6 +7,7 @@
 app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc2/CaTEYs2hRbxfDqcG6deiU9kmGXaR5T1tEgf4ASxHt1S1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.Draw
+import rr.Text
 import rr.Color
 import rr.Devices
 import rr.Window
@@ -20,7 +21,7 @@ import rr.Capture
 ## latest device snapshot, and the last colour read beneath the pointer. The
 ## font is retained for drawing each new snapshot.
 Model : {
-	font : Draw.Font,
+	font : Text.Font,
 
 	## Text typed since the last clear, and what the clipboard last did with it.
 	typed : Str,
@@ -233,14 +234,14 @@ theme = {
 }
 
 ## A titled surface for one group of indicators.
-panel! : Draw.Frame, Draw.Font, { x : F32, y : F32, width : F32, height : F32, label : Str } => {}
+panel! : Draw.Frame, Text.Font, { x : F32, y : F32, width : F32, height : F32, label : Str } => {}
 panel! = |frame, font, cfg| {
 	frame.rounded_rectangle!({ x: cfg.x, y: cfg.y, width: cfg.width, height: cfg.height, radius: 12, segments: 8, style: Draw.filled_and_outlined(theme.panel, theme.edge, 1) })
 	frame.text!({ pos: { x: cfg.x + 18, y: cfg.y + 12 }, text: cfg.label, size: 14, spacing: Draw.default_spacing, color: theme.muted, font: font, align: Draw.align_top_left })
 }
 
 ## One indicator chip, lit while the snapshot says its input is active.
-chip! : Draw.Frame, Draw.Font, { x : F32, y : F32, width : F32, label : Str, on : Bool } => {}
+chip! : Draw.Frame, Text.Font, { x : F32, y : F32, width : F32, label : Str, on : Bool } => {}
 chip! = |frame, font, cfg| {
 	fill = if cfg.on theme.active else theme.idle
 	edge = if cfg.on theme.active else theme.edge
@@ -251,7 +252,7 @@ chip! = |frame, font, cfg| {
 
 ## A small square light next to a label, for the signals that are on or off
 ## rather than named keys.
-light! : Draw.Frame, Draw.Font, { x : F32, y : F32, label : Str, on : Bool } => {}
+light! : Draw.Frame, Text.Font, { x : F32, y : F32, label : Str, on : Bool } => {}
 light! = |frame, font, cfg| {
 	frame.text!({ pos: { x: cfg.x, y: cfg.y + 3 }, text: cfg.label, size: 16, spacing: Draw.default_spacing, color: theme.muted, font: font, align: Draw.align_top_left })
 	fill = if cfg.on theme.active else theme.idle
@@ -259,7 +260,7 @@ light! = |frame, font, cfg| {
 }
 
 ## A line of body text inside a panel.
-line! : Draw.Frame, Draw.Font, { x : F32, y : F32, text : Str, color : Color.Rgba } => {}
+line! : Draw.Frame, Text.Font, { x : F32, y : F32, text : Str, color : Color.Rgba } => {}
 line! = |frame, font, cfg|
 	frame.text!({ pos: { x: cfg.x, y: cfg.y }, text: cfg.text, size: 16, spacing: Draw.default_spacing, color: cfg.color, font: font, align: Draw.align_top_left })
 

--- a/examples/live_plot/main.roc
+++ b/examples/live_plot/main.roc
@@ -202,8 +202,8 @@ Model : {
 	## Two atlases of one face. A glyph atlas is rasterised at the size it is
 	## loaded at, so the figures and labels get one and the small tracked
 	## capitals get another.
-	font : Draw.Font,
-	small : Draw.Font,
+	font : Text.Font,
+	small : Text.Font,
 	title : Text.Prepared,
 	eyebrow : Text.Prepared,
 	deck : Text.Prepared,
@@ -2722,11 +2722,11 @@ draw_footer! = |frame, model| {
 # Text and numbers
 # ---------------------------------------------------------------------------
 
-text_left! : Draw.Frame, Draw.Font, Math.Vec2, Str, F32, F32, Color.Rgba => {}
+text_left! : Draw.Frame, Text.Font, Math.Vec2, Str, F32, F32, Color.Rgba => {}
 text_left! = |frame, font, pos, content, size, spacing, color|
 	frame.text!({ pos: pos, text: content, size: size, spacing: spacing, color: color, font: font, align: Draw.align_top_left })
 
-text_right! : Draw.Frame, Draw.Font, Math.Vec2, Str, F32, F32, Color.Rgba => {}
+text_right! : Draw.Frame, Text.Font, Math.Vec2, Str, F32, F32, Color.Rgba => {}
 text_right! = |frame, font, pos, content, size, spacing, color|
 	frame.text!({ pos: pos, text: content, size: size, spacing: spacing, color: color, font: font, align: Draw.align_top_right })
 

--- a/examples/pong/main.roc
+++ b/examples/pong/main.roc
@@ -31,7 +31,7 @@ Model := {
 	hit_sound : Audio.Sound,
 	wall_sound : Audio.Sound,
 	score_sound : Audio.Sound,
-	font : Draw.Font,
+	font : Text.Font,
 
 	## Presentation state, advanced by the same pure step as the rules.
 	## `trail` is the ball's recent positions, newest first; `flash` decays from
@@ -486,7 +486,7 @@ test_model = {
 	hit_sound: Audio.Sound.stub,
 	wall_sound: Audio.Sound.stub,
 	score_sound: Audio.Sound.stub,
-	font: Draw.Font.stub,
+	font: Text.font_stub,
 	trail: [],
 	flash: 0,
 	flash_color: ball_neon,

--- a/examples/snake/main.roc
+++ b/examples/snake/main.roc
@@ -58,7 +58,7 @@ Model : {
 	eat_sound : Audio.Sound,
 	crash_sound : Audio.Sound,
 	start_sound : Audio.Sound,
-	font : Draw.Font,
+	font : Text.Font,
 
 	## Wall-clock seconds since launch, advanced by `update!` and used only by
 	## the renderer, to pulse the food and breathe the restart prompt.
@@ -347,7 +347,7 @@ test_model = {
 	eat_sound: Audio.Sound.stub,
 	crash_sound: Audio.Sound.stub,
 	start_sound: Audio.Sound.stub,
-	font: Draw.Font.stub,
+	font: Text.font_stub,
 	elapsed: 0,
 	title: Text.Prepared.stub,
 	hint: Text.Prepared.stub,

--- a/examples/sqlite_scores/main.roc
+++ b/examples/sqlite_scores/main.roc
@@ -25,7 +25,7 @@ Model : {
 	status : Status,
 	pending : Bool,
 	rng : Random.State,
-	font : Draw.Font,
+	font : Text.Font,
 
 	## Wall-clock seconds since startup, so the in-flight indicator turns.
 	elapsed : F32,
@@ -483,7 +483,7 @@ test_model = {
 	status: Ready,
 	pending: Bool.False,
 	rng: Random.seed(1),
-	font: Draw.Font.stub,
+	font: Text.font_stub,
 	elapsed: 0,
 	title: Text.Prepared.stub,
 	subtitle: Text.Prepared.stub,

--- a/examples/task_sleep/main.roc
+++ b/examples/task_sleep/main.roc
@@ -21,7 +21,7 @@ Model : {
 	elapsed : F32,
 	title : Text.Prepared,
 	hint : Text.Prepared,
-	font : Draw.Font,
+	font : Text.Font,
 }
 
 ## How far the app has got: waiting on the sleeper, or holding the cycle its

--- a/examples/top_down/main.roc
+++ b/examples/top_down/main.roc
@@ -18,6 +18,7 @@ import rr.Camera
 import rr.Color
 import rr.Capture
 import rr.Draw
+import rr.Text
 import rr.Devices
 import rr.Keys
 import rr.Math
@@ -296,7 +297,7 @@ Sounds : {
 ## Keeping resources beside the world lets `update!` advance the game and
 ## `render!` draw the result without loading anything again.
 Model : {
-	font : Draw.Font,
+	font : Text.Font,
 	characters : Draw.Texture,
 	tiles : Draw.Texture,
 	level : Level,
@@ -522,7 +523,7 @@ make_sounds! = || {
 	Ok({ collect, hurt, win, lose, gate, dash, sparkle, music })
 }
 
-new_game : Draw.Font, Draw.Texture, Draw.Texture, Level, Sounds -> Model
+new_game : Text.Font, Draw.Texture, Draw.Texture, Level, Sounds -> Model
 new_game = |font, characters, tiles, level, sounds| {
 	font,
 	characters,
@@ -1204,7 +1205,7 @@ shaken_target = |world| {
 	}
 }
 
-draw_world! : Draw.Frame, Level, Draw.Texture, Draw.Texture, World, Math.Rect, Draw.Font => {}
+draw_world! : Draw.Frame, Level, Draw.Texture, Draw.Texture, World, Math.Rect, Text.Font => {}
 draw_world! = |frame, level, characters, tiles, world, viewport, font| {
 	frame.rectangle_gradient_v!({ x: level.bounds.x, y: level.bounds.y, width: level.bounds.width, height: level.bounds.height, color_top: Color.from_hex_rgb(0x173833), color_bottom: Color.from_hex_rgb(0x132821) })
 	level.tilemap.draw_all_in!(frame, viewport)
@@ -1266,14 +1267,14 @@ draw_tile! = |frame, tiles, tile, pos, scale| tile_sprite(tiles, tile, pos, scal
 draw_tile_centered! : Draw.Frame, Draw.Texture, Tile, Math.Vec2, F32, F32 => {}
 draw_tile_centered! = |frame, tiles, tile, pos, scale, rotation| tile_sprite(tiles, tile, pos, scale).centered().rotation(rotation).draw!(frame)
 
-draw_spawn! : Draw.Frame, Level, Draw.Font => {}
+draw_spawn! : Draw.Frame, Level, Text.Font => {}
 draw_spawn! = |frame, level, font| {
 	frame.circle_gradient!({ center: level.spawn, radius: 72, color_inner: Color.with_alpha(Color.from_hex_rgb(0x2a9d8f), 120), color_outer: Color.with_alpha(Color.from_hex_rgb(0x2a9d8f), 0) })
 	frame.circle!({ center: level.spawn, radius: 42, style: Draw.filled_and_outlined(Color.from_hex_rgb(0x2a9d8f), Color.white, 4) })
 	frame.text!({ pos: { x: level.spawn.x, y: level.spawn.y + 63 }, text: "START", size: 18, spacing: Draw.default_spacing, color: Color.with_alpha(Color.white, 190), font, align: Draw.align_top_center })
 }
 
-draw_exit! : Draw.Frame, Level, World, Draw.Font => {}
+draw_exit! : Draw.Frame, Level, World, Text.Font => {}
 draw_exit! = |frame, level, world, font| {
 	is_open = gate_is_open(world.gate)
 	color = if is_open Color.from_hex_rgb(0xf9c74f) else Color.from_hex_rgb(0x576066)
@@ -1432,7 +1433,7 @@ draw_bar! = |frame, x, y, width, height, amount, color| {
 	frame.rounded_rectangle!({ x, y, width: width * Math.clamp(amount, 0, 1), height, radius: 5, segments: 6, style: Draw.filled(color) })
 }
 
-draw_hud! : Draw.Frame, Level, World, Draw.Font => {}
+draw_hud! : Draw.Frame, Level, World, Text.Font => {}
 draw_hud! = |frame, level, world, font| {
 	is_open = gate_is_open(world.gate)
 

--- a/platform/App.roc
+++ b/platform/App.roc
@@ -63,6 +63,8 @@ import Capture
 import Files
 import AppHost
 import AppTransport
+import DrawHost
+import rrt.Font
 
 App := [].{
 
@@ -98,6 +100,7 @@ App := [].{
 		visible : Bool,
 		output_dir : Str,
 		recording : AppRecording,
+		default_font : { path : Str, size : I32 },
 	}.{
 
 		## Return a config with a different window title.
@@ -181,6 +184,12 @@ App := [].{
 		without_recording : Config -> Config
 		without_recording = |cfg| { ..cfg, recording: NoRecording }
 
+		## Load the startup default font from a working-directory-relative asset
+		## path at the requested base pixel size. The path is validated and loaded
+		## once before `Startup.default_font!` returns it.
+		with_default_font : Config, { path : Str, size : I32 } -> Config
+		with_default_font = |cfg, value| { ..cfg, default_font: value }
+
 		## Inspect the window title.
 		title : Config -> Str
 		title = |cfg| cfg.title
@@ -225,6 +234,11 @@ App := [].{
 		## Inspect whether the app records itself from startup.
 		recording : Config -> [NoRecording, Record(Capture.Recording)]
 		recording = |cfg| cfg.recording
+
+		## Inspect the configured startup default-font intent. An empty path means
+		## the backend's built-in font.
+		default_font : Config -> { path : Str, size : I32 }
+		default_font = |cfg| cfg.default_font
 	}
 
 	## Opaque, zero-sized authority the host supplies only while it runs `init!`.
@@ -239,7 +253,16 @@ App := [].{
 	## the first `App.Input` supplies the first sampled values. After
 	## initialization, change host state by calling effects from `update!`, and
 	## ask for work that waits with `Task.spawn!`.
-	Startup : HostHost.Startup
+	Startup :: HostHost.Startup.{
+
+		## Return the configured startup font. Legal only in `init!`.
+		default_font! : Startup => Try(Font, [AssetPathInvalid, AssetNotFound, AssetReadFailed, FontLoadFailed, ResourceLimit, ..])
+		default_font! = |startup| App.default_font!(startup)
+
+		## Construct the public startup capability at the private host boundary.
+		for_host : HostHost.Startup -> Startup
+		for_host = |startup| Startup.(startup)
+	}
 
 	## Exit the application with the given exit code.
 	##
@@ -403,6 +426,29 @@ App := [].{
 	set_cursor! : Startup, Mouse.Cursor => {}
 	set_cursor! = |_startup, cursor| MouseHost.set_cursor!(Mouse.cursor_code(cursor))
 
+	## Return the configured startup font, or the backend's built-in font when
+	## none was configured. A configured path is resolved from the process
+	## working directory. The host loads it once; repeat calls return retained
+	## aliases of the same resource. Legal only in `init!`.
+	default_font! : Startup => Try(Font, [AssetPathInvalid, AssetNotFound, AssetReadFailed, FontLoadFailed, ResourceLimit, ..])
+	default_font! = |_startup| {
+		result = DrawHost.startup_default_font!()
+		if result.err == 1 {
+			Err(AssetPathInvalid)
+		} else if result.err == 2 {
+			Err(AssetNotFound)
+		} else if result.err == 3 {
+			Err(AssetReadFailed)
+		} else if result.err == 4 {
+			Err(FontLoadFailed)
+		} else if result.err != 0 {
+			Err(ResourceLimit)
+		} else {
+			metrics = DrawHost.font_metrics!(result.font)
+			Ok({ handle: result.font, metrics })
+		}
+	}
+
 	## Effectful startup callback run after the host has initialized raylib and
 	## audio. Return `Ok(model)` to start the app, `Err(Exit(code))` to quit
 	## before the first frame, or let other initialization errors propagate.
@@ -435,6 +481,7 @@ App := [].{
 		visible: Bool.True,
 		output_dir: ".",
 		recording: NoRecording,
+		default_font: { path: "", size: 20 },
 	}
 
 	## Build initialization from a static startup configuration.

--- a/platform/AppConfig.roc
+++ b/platform/AppConfig.roc
@@ -38,6 +38,8 @@ AppHostConfig : {
 	record_timing : U8,
 	record_cursor : U8,
 	record_quality : U8,
+	default_font_path : Str,
+	default_font_size : I32,
 }
 
 AppConfig := [].{
@@ -52,6 +54,7 @@ AppConfig := [].{
 		size = cfg.size()
 		min_size = cfg.min_size()
 		record = host_recording(cfg.recording())
+		default_font = cfg.default_font()
 		{
 			title: cfg.title(),
 			width: size.width,
@@ -77,6 +80,8 @@ AppConfig := [].{
 			record_timing: record.timing,
 			record_cursor: record.cursor,
 			record_quality: record.quality,
+			default_font_path: default_font.path,
+			default_font_size: default_font.size,
 		}
 	}
 }
@@ -175,6 +180,10 @@ expect {
 	host.record_every_nth == 1 and host.record_timing == 1 and host.record_cursor == 0
 }
 expect AppConfig.to_host({}, App.default.with_recording(RrtCapture.default)).record_quality == 1
+expect {
+	host = AppConfig.to_host({}, App.default.with_default_font({ path: "assets/body.ttf", size: 32 }))
+	host.default_font_path == "assets/body.ttf" and host.default_font_size == 32
+}
 expect {
 	fast = RrtCapture.default.with_quality(Fast)
 	best = RrtCapture.default.with_quality(Best)

--- a/platform/AssetsHost.roc
+++ b/platform/AssetsHost.roc
@@ -12,7 +12,7 @@ AssetsHost := [].{
 
 		## The invalid token, as a resource-free handle. See `Assets.Store.stub`.
 		stub : Store
-		stub = Store.(Box.box(0))
+		stub = Store.(Box.box(U64.highest))
 	}
 
 	StoreOpen : {

--- a/platform/AudioHost.roc
+++ b/platform/AudioHost.roc
@@ -8,14 +8,14 @@ AudioHost := [].{
 
 		## The invalid token, as a resource-free handle. See `Audio.Sound.stub`.
 		stub : Sound
-		stub = Sound.(Box.box(0))
+		stub = Sound.(Box.box(U64.highest))
 	}
 
 	Music :: Box(U64).{
 
 		## The invalid token, as a resource-free handle. See `Audio.Music.stub`.
 		stub : Music
-		stub = Music.(Box.box(0))
+		stub = Music.(Box.box(U64.highest))
 	}
 
 	SoundResult : { sound : Sound, err : U8 }

--- a/platform/Draw.roc
+++ b/platform/Draw.roc
@@ -36,8 +36,8 @@ import Assets
 import Camera
 import Color
 import DrawHost
+import rrt.Font
 import Math
-import rrt.Font as RrtFont
 
 TextureDrawConfig : {
 	texture : Assets.Texture,
@@ -362,21 +362,10 @@ Draw := [].{
 	}
 
 	## Scalar metrics for one glyph, shared with platform-independent packages.
-	GlyphMetrics : RrtFont.GlyphMetrics
+	GlyphMetrics : Font.GlyphMetrics
 
 	## Text measurement result.
-	TextSize : RrtFont.Size
-
-	## A native font handle paired with an immutable scalar metric snapshot.
-	## Loading constructs the snapshot once; every receiver on it is pure.
-	##
-	## Declared in the `roc-ray-types` package's `Font` and re-exported here,
-	## which is also where `base_size`, `line_spacing`, `glyphs`,
-	## `get_glyph_index`, `measure` and `stub` are documented. A layout package
-	## can therefore measure text against a real font without depending on this
-	## platform. Loading one is an effect and stays here: `Draw.default_font!`,
-	## `Draw.load_store_font!`, and `Draw.font_from_bytes!`.
-	Font : RrtFont.Font
+	TextSize : Font.Size
 
 	## Horizontal text anchor.
 	HAlign : [Left, Center, Right]
@@ -887,7 +876,7 @@ Draw := [].{
 	##
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
 	default_font! : () => Font
-	default_font! = || font_from_host!(DefaultFont)
+	default_font! = || font_from_host!(DrawHost.default_font!())
 
 	## Default text glyph spacing in logical pixels.
 	default_spacing : F32
@@ -1134,7 +1123,7 @@ Draw := [].{
 		} else if result.err != 0 {
 			Err(ResourceLimit)
 		} else {
-			Ok(font_from_host!(LoadedFont(result.font)))
+			Ok(font_from_host!(result.font))
 		}
 	}
 
@@ -1146,7 +1135,7 @@ Draw := [].{
 	font_from_bytes! : FontBytes => Try(Font, [FontLoadFailed, ResourceLimit, ..])
 	font_from_bytes! = |cfg| {
 		result = DrawHost.load_font_bytes!({ format: font_format_code(cfg.format), bytes: cfg.bytes, size: cfg.size })
-		if result.err == 2 Err(ResourceLimit) else if result.err != 0 Err(FontLoadFailed) else Ok(font_from_host!(LoadedFont(result.font)))
+		if result.err == 2 Err(ResourceLimit) else if result.err != 0 Err(FontLoadFailed) else Ok(font_from_host!(result.font))
 	}
 
 	## Create a draw configuration covering the whole texture at the origin.
@@ -1404,7 +1393,7 @@ Draw := [].{
 			size: cfg.size,
 			spacing: Draw.default_spacing,
 			color: cfg.color,
-			font: DefaultFont,
+			font: Font.stub.handle,
 			align_x: 0,
 			align_y: 0,
 		})
@@ -1420,7 +1409,7 @@ Draw := [].{
 			size: cfg.size,
 			spacing: Draw.default_spacing,
 			color: cfg.color,
-			font: DefaultFont,
+			font: Font.stub.handle,
 			align_x: 0,
 			align_y: 0,
 		})
@@ -1436,7 +1425,7 @@ Draw := [].{
 			size: cfg.size,
 			spacing: Draw.default_spacing,
 			color: cfg.color,
-			font: DefaultFont,
+			font: Font.stub.handle,
 			align_x: 0.5,
 			align_y: 0.5,
 		})
@@ -1448,17 +1437,11 @@ Draw := [].{
 ## This is the one impure step in a font's life: it asks the host for the atlas
 ## metrics once, when the font loads, so that every reader afterwards -- here,
 ## in an app, or in a package that never heard of this platform -- is pure.
-## Private, because minting a `Draw.Font` is the host's business.
-font_from_host! : DrawHost.Font => Draw.Font
+## Private, because minting a live `Font` is the host's business.
+font_from_host! : Font.Handle => Font
 font_from_host! = |handle| {
 	metrics = DrawHost.font_metrics!(handle)
-	{
-		handle: handle,
-		base_size_value: metrics.base_size,
-		line_spacing_value: metrics.line_spacing,
-		fallback_index: metrics.fallback_index,
-		glyph_values: metrics.glyphs,
-	}
+	{ handle, metrics }
 }
 
 blend_mode_code : Draw.BlendMode -> U8
@@ -1573,15 +1556,13 @@ expect match Draw.ProjectiveQuad.from_corners({
 ## A `Texture`, a `Shader`, and a `RenderTexture` each hold a `Box` and cannot be
 ## compared -- a type reaching a host-resource box does not support equality --
 ## so these read the ordinary data beside the handle instead.
-expect Draw.Font.stub.base_size() == 1
-expect Draw.Font.stub.line_spacing() == 0
-expect List.is_empty(Draw.Font.stub.glyphs())
+expect Font.stub.metrics.base_size == 1
+expect Font.stub.metrics.line_spacing == 0
+expect List.len(Font.stub.metrics.glyphs) == 1
 
-## A font with no glyphs measures every string as zero-wide. The height is the
-## requested size because that is one line of it, and the `base_size` of 1 is
-## what keeps the scale factor finite rather than dividing by zero.
-expect Draw.Font.stub.measure({ text: "", size: 20, spacing: 1 }) == { width: 0, height: 0 }
-expect Draw.Font.stub.measure({ text: "inert", size: 20, spacing: 0 }) == { width: 0, height: 20 }
+## The synthetic stub measures one advance per Unicode scalar.
+expect Font.measure(Font.stub, { text: "", size: 20, spacing: 1 }) == { width: 0, height: 0 }
+expect Font.measure(Font.stub, { text: "inert", size: 20, spacing: 0 }) == { width: 100, height: 20 }
 
 ## A stub render target's colour attachment is the `roc-ray-types` package's
 ## `Texture.stub`, so it has no area and its vertically flipped source

--- a/platform/DrawHost.roc
+++ b/platform/DrawHost.roc
@@ -20,7 +20,7 @@ DrawHost := [].{
 
 		## The invalid token, as a resource-free handle. See `Text.Prepared.stub`.
 		stub : PreparedText
-		stub = PreparedText.(Box.box(0))
+		stub = PreparedText.(Box.box(U64.highest))
 	}
 
 	RenderTexture :: Texture.{
@@ -39,7 +39,7 @@ DrawHost := [].{
 
 		## The invalid token, as a resource-free handle. See `Draw.Shader.stub`.
 		stub : Shader
-		stub = Shader.(Box.box(0))
+		stub = Shader.(Box.box(U64.highest))
 	}
 
 	Uniform :: { shader : Shader, location : I32 }.{

--- a/platform/DrawHost.roc
+++ b/platform/DrawHost.roc
@@ -5,7 +5,7 @@ import Assets
 import Camera
 import Color
 import Math
-import rrt.Font as RrtFont
+import rrt.Font
 import rrt.Texture
 
 DrawHost := [].{
@@ -22,14 +22,6 @@ DrawHost := [].{
 		stub : PreparedText
 		stub = PreparedText.(Box.box(0))
 	}
-
-	## Which font a draw call names. Declared in the `roc-ray-types` package's
-	## `Font`, so the handle the host mints and the one a `Draw.Font` carries are
-	## one type.
-	Font : RrtFont.Handle
-
-	## The native font resource a handle carries.
-	FontResource : RrtFont.Resource
 
 	RenderTexture :: Texture.{
 		texture : RenderTexture -> Texture
@@ -71,12 +63,12 @@ DrawHost := [].{
 	Polygon : { points : List(Math.Vec2), color : Color.Rgba }
 	PolygonLines : { points : List(Math.Vec2), color : Color.Rgba, thickness : F32 }
 	Fps : { pos : Math.Vec2, size : F32, color : Color.Rgba }
-	Text : { pos : Math.Vec2, text : Str, size : F32, spacing : F32, color : Color.Rgba, font : Font }
-	TextAligned : { pos : Math.Vec2, text : Str, size : F32, spacing : F32, color : Color.Rgba, font : Font, align_x : F32, align_y : F32 }
+	Text : { pos : Math.Vec2, text : Str, size : F32, spacing : F32, color : Color.Rgba, font : Font.Handle }
+	TextAligned : { pos : Math.Vec2, text : Str, size : F32, spacing : F32, color : Color.Rgba, font : Font.Handle, align_x : F32, align_y : F32 }
 	GlyphMetric : { codepoint : U32, advance_x : F32, offset_x : F32, offset_y : F32, width : F32, height : F32 }
 	FontMetrics : { base_size : F32, line_spacing : F32, fallback_index : U64, glyphs : List(GlyphMetric) }
 	FrameSize : { width : F32, height : F32 }
-	PrepareText : { text : Str, size : F32, spacing : F32, font : Font }
+	PrepareText : { text : Str, size : F32, spacing : F32, font : Font.Handle }
 	PrepareTextResult : { prepared : PreparedText, width : F32, height : F32, err : U8 }
 	PreparedTextDraw : { prepared : PreparedText, pos : Math.Vec2, color : Color.Rgba }
 	LoadFontBytes : { format : U8, bytes : List(U8), size : I32 }
@@ -98,7 +90,7 @@ DrawHost := [].{
 	ShaderVec3 : { uniform : Uniform, value : { x : F32, y : F32, z : F32 } }
 	ShaderVec4 : { uniform : Uniform, value : { x : F32, y : F32, z : F32, w : F32 } }
 	ShaderTexture : { uniform : Uniform, texture : Texture }
-	FontResult : { font : FontResource, err : U8 }
+	FontResult : { font : Font.Handle, err : U8 }
 	RenderTextureResult : { target : RenderTexture, err : U8 }
 	ShaderResult : { shader : Shader, err : U8 }
 
@@ -118,12 +110,14 @@ DrawHost := [].{
 	clear! : Color.Rgba => {}
 	fps! : Fps => {}
 	line! : Line => {}
+	default_font! : () => Font.Handle
+	startup_default_font! : () => FontResult
 	load_font_bytes! : LoadFontBytes => FontResult
 	load_store_font! : LoadStoreFont => FontResult
 	load_render_texture! : RenderTextureSize => RenderTextureResult
 	load_shader_source! : LoadShaderSource => ShaderResult
 	load_store_shader! : LoadStoreShader => ShaderResult
-	font_metrics! : Font => FontMetrics
+	font_metrics! : Font.Handle => FontMetrics
 	frame_size! : () => FrameSize
 	prepare_text! : PrepareText => PrepareTextResult
 	draw_prepared_text! : PreparedTextDraw => {}

--- a/platform/SqliteHost.roc
+++ b/platform/SqliteHost.roc
@@ -39,7 +39,7 @@ SqliteHost := [].{
 
 		## The invalid token, as a resource-free handle. See `Sqlite.Db.stub`.
 		stub : Db
-		stub = Db.(Box.box(0))
+		stub = Db.(Box.box(U64.highest))
 	}
 
 	## Opaque prepared statement. Its heap slot retains the connection's, so a
@@ -48,7 +48,7 @@ SqliteHost := [].{
 
 		## The invalid token, as a resource-free handle. See `Sqlite.Stmt.stub`.
 		stub : Stmt
-		stub = Stmt.(Box.box(0))
+		stub = Stmt.(Box.box(U64.highest))
 	}
 
 	## One column of one row, in row-major order, `ncols` to a row.

--- a/platform/Text.roc
+++ b/platform/Text.roc
@@ -26,9 +26,6 @@ Text := [].{
 	## from `roc-ray-types`, re-exported for applications that depend only on the
 	## platform.
 	Font : RrtFont.Font
-	FontMetrics : RrtFont.FontMetrics
-	GlyphMetrics : RrtFont.GlyphMetrics
-	Measure : RrtFont.Measure
 
 	## Which horizontal edge or centre of the text `pos` names.
 	HAlign : [Left, Center, Right]

--- a/platform/Text.roc
+++ b/platform/Text.roc
@@ -22,6 +22,14 @@ import rrt.Font as RrtFont
 
 Text := [].{
 
+	## A host-owned font and immutable metric snapshot. This is the shared type
+	## from `roc-ray-types`, re-exported for applications that depend only on the
+	## platform.
+	Font : RrtFont.Font
+	FontMetrics : RrtFont.FontMetrics
+	GlyphMetrics : RrtFont.GlyphMetrics
+	Measure : RrtFont.Measure
+
 	## Which horizontal edge or centre of the text `pos` names.
 	HAlign : [Left, Center, Right]
 
@@ -40,6 +48,14 @@ Text := [].{
 	## third name; they are one type.
 	Size : RrtFont.Size
 
+	## Resource-free synthetic monospace font for pure layout tests.
+	font_stub : Font
+	font_stub = RrtFont.stub
+
+	## Measure text from the immutable metric snapshot carried by a font.
+	measure : Font, Measure -> Size
+	measure = |font, cfg| RrtFont.measure(font, cfg)
+
 	## Everything a draw needs beyond the text itself: where to put it, what
 	## colour to paint it, and which point of it `pos` names.
 	Placement : {
@@ -57,7 +73,7 @@ Text := [].{
 		content : Str,
 		size : F32,
 		spacing : F32,
-		font : Draw.Font,
+		font : RrtFont.Font,
 	}.{
 
 		## Draw this text at a different pixel size. The default is `20`.
@@ -74,7 +90,7 @@ Text := [].{
 		spacing = |builder, value| { ..builder, spacing: value }
 
 		## Draw this text in a different font.
-		font : Builder, Draw.Font -> Builder
+		font : Builder, RrtFont.Font -> Builder
 		font = |builder, value| { ..builder, font: value }
 
 		## Cache immutable UTF-8 text, font and style, and measurement in the
@@ -148,7 +164,7 @@ Text := [].{
 
 	## Start describing a string drawn in a font. Adjust the result with
 	## `size`, `spacing` and `font`, then call `prepare!`.
-	from : Str, Draw.Font -> Builder
+	from : Str, RrtFont.Font -> Builder
 	from = |content, font| {
 		content,
 		size: 20,

--- a/platform/Text.roc
+++ b/platform/Text.roc
@@ -52,10 +52,6 @@ Text := [].{
 	font_stub : Font
 	font_stub = RrtFont.stub
 
-	## Measure text from the immutable metric snapshot carried by a font.
-	measure : Font, Measure -> Size
-	measure = |font, cfg| RrtFont.measure(font, cfg)
-
 	## Everything a draw needs beyond the text itself: where to put it, what
 	## colour to paint it, and which point of it `pos` names.
 	Placement : {

--- a/platform/UdpHost.roc
+++ b/platform/UdpHost.roc
@@ -27,7 +27,7 @@ UdpHost := [].{
 
 		## The invalid token, as a resource-free handle. See `Udp.Socket.stub`.
 		stub : Handle
-		stub = Handle.(Box.box(0))
+		stub = Handle.(Box.box(U64.highest))
 	}
 
 	## A request to bind. `ip` is a dotted-quad IPv4 literal, which the host

--- a/platform/main-wayland.roc
+++ b/platform/main-wayland.roc
@@ -117,6 +117,8 @@ platform ""
 		"roc_draw_draw_texture_quad_raw": DrawHost.draw_texture_quad!,
 		"roc_draw_end_scissor_raw": DrawHost.end_scissor!,
 		"roc_draw_fps": DrawHost.fps!,
+		"roc_draw_default_font_raw": DrawHost.default_font!,
+		"roc_draw_startup_default_font_raw": DrawHost.startup_default_font!,
 		"roc_draw_font_metrics_raw": DrawHost.font_metrics!,
 		"roc_draw_frame_size": DrawHost.frame_size!,
 		"roc_draw_line_raw": DrawHost.line!,
@@ -346,7 +348,7 @@ app_input_from_raw = |devices, window, time, capture, messages, dropped, dropped
 ## No input, window, or timing observations have been sampled at this point.
 init_for_host! : () => Try(Box(Model), I64)
 init_for_host! = ||
-	match (program.init!.run!)(HostHost.Startup.for_host) {
+	match (program.init!.run!)(App.Startup.for_host(HostHost.Startup.for_host)) {
 		Ok(model) => Ok(Box.box(model))
 		Err(Exit(code)) => Err(code)
 		Err(_) => Err(-1)

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -117,6 +117,8 @@ platform ""
 		"roc_draw_draw_texture_quad_raw": DrawHost.draw_texture_quad!,
 		"roc_draw_end_scissor_raw": DrawHost.end_scissor!,
 		"roc_draw_fps": DrawHost.fps!,
+		"roc_draw_default_font_raw": DrawHost.default_font!,
+		"roc_draw_startup_default_font_raw": DrawHost.startup_default_font!,
 		"roc_draw_font_metrics_raw": DrawHost.font_metrics!,
 		"roc_draw_frame_size": DrawHost.frame_size!,
 		"roc_draw_line_raw": DrawHost.line!,
@@ -349,7 +351,7 @@ app_input_from_raw = |devices, window, time, capture, messages, dropped, dropped
 ## No input, window, or timing observations have been sampled at this point.
 init_for_host! : () => Try(Box(Model), I64)
 init_for_host! = ||
-	match (program.init!.run!)(HostHost.Startup.for_host) {
+	match (program.init!.run!)(App.Startup.for_host(HostHost.Startup.for_host)) {
 		Ok(model) => Ok(Box.box(model))
 		Err(Exit(code)) => Err(code)
 		Err(_) => Err(-1)

--- a/scripts/test_app_transport_privacy.py
+++ b/scripts/test_app_transport_privacy.py
@@ -129,7 +129,7 @@ CASES = (
     ),
     (
         ROOT / "test" / "compile_fail" / "font_handle_manufacture.roc",
-        ("cannot use opaque nominal type", "instance of Font.Resource"),
+        ("cannot use opaque nominal type", "instance of Font.Handle"),
     ),
 )
 

--- a/src/graphical_smoke.zig
+++ b/src/graphical_smoke.zig
@@ -95,7 +95,7 @@ const DecodedCodepoint = struct {
 };
 
 /// Every string below is valid UTF-8, exactly as `Str` values are. This is the
-/// same byte-to-codepoint boundary used by `Text.measure`.
+/// same byte-to-codepoint boundary used by the `Font.measure` receiver.
 fn decodeUtf8(text: []const u8, index: usize) DecodedCodepoint {
     const first: u32 = text[index];
     if (first < 0x80) return .{ .codepoint = first, .next = index + 1 };
@@ -113,7 +113,7 @@ fn decodeUtf8(text: []const u8, index: usize) DecodedCodepoint {
     };
 }
 
-/// Pure equivalent of `Text.measure` for a native parity check.
+/// Pure equivalent of the `Font.measure` receiver for a native parity check.
 fn measureSnapshot(snapshot: MetricSnapshot, text: []const u8, size: f32, spacing: f32) MetricMeasurement {
     if (text.len == 0 or text[0] == 0) return .{ .width = 0, .height = 0 };
 

--- a/src/graphical_smoke.zig
+++ b/src/graphical_smoke.zig
@@ -45,7 +45,7 @@ const MetricMeasurement = struct {
     height: f32,
 };
 
-/// Copy precisely the scalar data `Draw.Font` receives from a live raylib
+/// Copy precisely the scalar data `Text.Font` receives from a live raylib
 /// font. The measurement below deliberately has no access to the font after
 /// this point, matching the pure Roc API's ownership boundary.
 fn snapshotFontMetrics(allocator: std.mem.Allocator, font: backend.Font) !MetricSnapshot {
@@ -66,7 +66,7 @@ fn snapshotFontMetrics(allocator: std.mem.Allocator, font: backend.Font) !Metric
             if (glyph.codepoint == fallback_codepoint) break index;
         } else 0,
         // roc-ray exposes no text-line-spacing setter; this is raylib 6's
-        // initial value, retained by `Draw.Font` with the glyph scalars.
+        // initial value, retained by `Text.Font` with the glyph scalars.
         .line_spacing = 2,
         .glyphs = glyphs,
     };
@@ -95,7 +95,7 @@ const DecodedCodepoint = struct {
 };
 
 /// Every string below is valid UTF-8, exactly as `Str` values are. This is the
-/// same byte-to-codepoint boundary used by `Draw.Font.measure`.
+/// same byte-to-codepoint boundary used by `Text.measure`.
 fn decodeUtf8(text: []const u8, index: usize) DecodedCodepoint {
     const first: u32 = text[index];
     if (first < 0x80) return .{ .codepoint = first, .next = index + 1 };
@@ -113,7 +113,7 @@ fn decodeUtf8(text: []const u8, index: usize) DecodedCodepoint {
     };
 }
 
-/// Pure equivalent of `Draw.Font.measure` for a native parity check.
+/// Pure equivalent of `Text.measure` for a native parity check.
 fn measureSnapshot(snapshot: MetricSnapshot, text: []const u8, size: f32, spacing: f32) MetricMeasurement {
     if (text.len == 0 or text[0] == 0) return .{ .width = 0, .height = 0 };
 

--- a/src/host_native.zig
+++ b/src/host_native.zig
@@ -3312,14 +3312,14 @@ test "copied shared texture destroys its native resource exactly once after the 
 /// The box is a genuine Roc allocation rather than a fake, so the host's
 /// decref of it runs the same path it runs at runtime and the testing allocator
 /// reports a leak or a double free either way.
-fn allocateTestResourceStub(host: *RocHost, token: u64) *u64 {
+fn allocateTestResourceStub(host: *RocHost) *u64 {
     const handle: *u64 = @ptrCast(@alignCast(abi.allocateBox(@sizeOf(u64), @alignOf(u64), false, host)));
-    handle.* = token;
+    handle.* = INVALID_RESOURCE_TOKEN;
     return handle;
 }
 
 fn allocateTestTextureStub(host: *RocHost, width: f32, height: f32) abi.Texture {
-    return .{ .handle = allocateTestResourceStub(host, INVALID_RESOURCE_TOKEN), .width = width, .height = height };
+    return .{ .handle = allocateTestResourceStub(host), .width = width, .height = height };
 }
 
 /// Take a second reference to a live host resource handle, the way a Roc value
@@ -3430,9 +3430,9 @@ test "resource-free draw handles are inert, and leave real resources alone" {
     // The Roc side publishes a `stub` for every resource an app can hold in its
     // model -- `Text.font_stub`, `Draw.Shader.stub`, `Draw.RenderTexture.stub`,
     // `Text.Prepared.stub`, `Assets.Store.stub` -- so that a pure test can write
-    // a model down. Font and texture use the maximum U64 token, while the
-    // other resource stubs carry zero. The host resolves none of them, refuses
-    // the operations they reach, and releases the box exactly once.
+    // a model down. Every resource stub carries the maximum U64 token. The host
+    // resolves none of them, refuses the operations they reach, and releases
+    // the box exactly once.
     //
     // A real resource of each kind is live throughout, and goes through the
     // same calls itself. Stub traffic must not disturb it, and the operations
@@ -3458,10 +3458,10 @@ test "resource-free draw handles are inert, and leave real resources alone" {
     // Stub tokens resolve nowhere. This is the property every stub rests on,
     // and the reason `stub` can be a pure value at all.
     try std.testing.expect(font_heap.get(INVALID_RESOURCE_TOKEN) == null);
-    try std.testing.expect(shader_heap.get(0) == null);
-    try std.testing.expect(render_texture_heap.get(0) == null);
-    try std.testing.expect(prepared_text_heap.get(0) == null);
-    try std.testing.expect(store_heap.get(0) == null);
+    try std.testing.expect(shader_heap.get(INVALID_RESOURCE_TOKEN) == null);
+    try std.testing.expect(render_texture_heap.get(INVALID_RESOURCE_TOKEN) == null);
+    try std.testing.expect(prepared_text_heap.get(INVALID_RESOURCE_TOKEN) == null);
+    try std.testing.expect(store_heap.get(INVALID_RESOURCE_TOKEN) == null);
 
     const real_shader = storeShader(.headless).?;
     const real_target = storeRenderTexture(.headless).?;
@@ -3472,13 +3472,13 @@ test "resource-free draw handles are inert, and leave real resources alone" {
 
         // A stub font has no metrics to snapshot; the headless answer is the
         // built-in one, and the transferred handle is still released.
-        const snapshot = hostedDrawFontMetricsRaw(&roc_host, allocateTestResourceStub(&roc_host, INVALID_RESOURCE_TOKEN));
+        const snapshot = hostedDrawFontMetricsRaw(&roc_host, allocateTestResourceStub(&roc_host));
         defer snapshot.glyphs.decref(&roc_host);
 
         // Preparing text with a stub font is refused rather than silently
         // prepared against the default font, and consumes no heap slot.
         const prepared = hostedDrawPrepareTextRaw(&roc_host, .{
-            .font = allocateTestResourceStub(&roc_host, INVALID_RESOURCE_TOKEN),
+            .font = allocateTestResourceStub(&roc_host),
             .text = abi.RocStr.fromSlice("inert", &roc_host),
             .size = 16,
             .spacing = 1,
@@ -3490,26 +3490,26 @@ test "resource-free draw handles are inert, and leave real resources alone" {
 
         // A uniform cannot be resolved on a stub shader.
         try std.testing.expectEqual(@as(i32, -1), hostedDrawShaderLocationRaw(&roc_host, .{
-            .shader = allocateTestResourceStub(&roc_host, 0),
+            .shader = allocateTestResourceStub(&roc_host),
             .name = abi.RocStr.fromSlice("uTime", &roc_host),
         }));
 
         // Every store-backed loader reports the read it could not make.
         const store_texture = hostedAssetsLoadStoreTextureRaw(&roc_host, .{
-            .store = allocateTestResourceStub(&roc_host, 0),
+            .store = allocateTestResourceStub(&roc_host),
             .path = abi.RocStr.fromSlice("atlas.png", &roc_host),
         });
         try std.testing.expectEqual(STORE_LOAD_ERR_READ, store_texture.err);
 
         const store_font = hostedDrawLoadStoreFontRaw(&roc_host, .{
-            .store = allocateTestResourceStub(&roc_host, 0),
+            .store = allocateTestResourceStub(&roc_host),
             .path = abi.RocStr.fromSlice("body.ttf", &roc_host),
             .size = 16,
         });
         try std.testing.expectEqual(STORE_LOAD_ERR_READ, store_font.err);
 
         const store_shader = hostedDrawLoadStoreShaderRaw(&roc_host, .{
-            .store = allocateTestResourceStub(&roc_host, 0),
+            .store = allocateTestResourceStub(&roc_host),
             .vertex_path = abi.RocStr.empty(),
             .fragment_path = abi.RocStr.fromSlice("blur.fs", &roc_host),
         });
@@ -3526,10 +3526,10 @@ test "resource-free draw handles are inert, and leave real resources alone" {
 
         // A scope cannot be opened on a stub, and reports the same refusal a
         // released resource would. Nothing is leased, so there is no end call.
-        try std.testing.expectEqual(SCOPE_UNAVAILABLE, hostedDrawBeginShaderRaw(.{ .arg0 = allocateTestResourceStub(&roc_host, 0) }));
+        try std.testing.expectEqual(SCOPE_UNAVAILABLE, hostedDrawBeginShaderRaw(.{ .arg0 = allocateTestResourceStub(&roc_host) }));
         try std.testing.expectEqual(@as(usize, 0), shader_lease_count);
         try std.testing.expectEqual(SCOPE_UNAVAILABLE, hostedDrawBeginRenderTextureRaw(.{
-            .handle = allocateTestResourceStub(&roc_host, 0),
+            .handle = allocateTestResourceStub(&roc_host),
             .height = 90,
             .width = 160,
         }));
@@ -3540,7 +3540,7 @@ test "resource-free draw handles are inert, and leave real resources alone" {
         // one is: no draw is counted and nothing faults.
         const draws_before = prepared_text_draw_calls;
         hostedDrawPreparedTextRaw(&roc_host, .{
-            .prepared = allocateTestResourceStub(&roc_host, 0),
+            .prepared = allocateTestResourceStub(&roc_host),
             .pos = .{ .x = 10, .y = 20 },
             .color = .{ .r = 255, .g = 255, .b = 255, .a = 255 },
         });
@@ -3595,8 +3595,8 @@ test "resource-free audio handles are inert across every sound and music call" {
         active_roc_host = null;
     }
 
-    try std.testing.expect(sound_heap.get(0) == null);
-    try std.testing.expect(music_heap.get(0) == null);
+    try std.testing.expect(sound_heap.get(INVALID_RESOURCE_TOKEN) == null);
+    try std.testing.expect(music_heap.get(INVALID_RESOURCE_TOKEN) == null);
 
     const real_sound = storeSound(.headless).?;
     const real_music = storeMusic(.headless).?;
@@ -3605,30 +3605,30 @@ test "resource-free audio handles are inert across every sound and music call" {
         const scope = PhaseScope.enter(.update);
         defer scope.leave();
 
-        hostedAudioPlay(allocateTestResourceStub(&roc_host, 0));
-        hostedAudioStop(allocateTestResourceStub(&roc_host, 0));
-        hostedAudioPause(allocateTestResourceStub(&roc_host, 0));
-        hostedAudioResume(allocateTestResourceStub(&roc_host, 0));
-        hostedAudioSetVolume(allocateTestResourceStub(&roc_host, 0), 0.5);
-        hostedAudioSetPitch(allocateTestResourceStub(&roc_host, 0), 1.5);
-        hostedAudioSetPan(allocateTestResourceStub(&roc_host, 0), -0.25);
-        try std.testing.expect(!hostedAudioIsPlaying(allocateTestResourceStub(&roc_host, 0)));
+        hostedAudioPlay(allocateTestResourceStub(&roc_host));
+        hostedAudioStop(allocateTestResourceStub(&roc_host));
+        hostedAudioPause(allocateTestResourceStub(&roc_host));
+        hostedAudioResume(allocateTestResourceStub(&roc_host));
+        hostedAudioSetVolume(allocateTestResourceStub(&roc_host), 0.5);
+        hostedAudioSetPitch(allocateTestResourceStub(&roc_host), 1.5);
+        hostedAudioSetPan(allocateTestResourceStub(&roc_host), -0.25);
+        try std.testing.expect(!hostedAudioIsPlaying(allocateTestResourceStub(&roc_host)));
 
-        hostedAudioPlayMusic(allocateTestResourceStub(&roc_host, 0));
-        hostedAudioStopMusic(allocateTestResourceStub(&roc_host, 0));
-        hostedAudioPauseMusic(allocateTestResourceStub(&roc_host, 0));
-        hostedAudioResumeMusic(allocateTestResourceStub(&roc_host, 0));
-        hostedAudioSetMusicVolume(allocateTestResourceStub(&roc_host, 0), 0.5);
-        hostedAudioSetMusicPitch(allocateTestResourceStub(&roc_host, 0), 1.5);
-        hostedAudioSetMusicPan(allocateTestResourceStub(&roc_host, 0), -0.25);
-        hostedAudioSetMusicLooping(allocateTestResourceStub(&roc_host, 0), true);
-        hostedAudioSeekMusic(allocateTestResourceStub(&roc_host, 0), 12.5);
+        hostedAudioPlayMusic(allocateTestResourceStub(&roc_host));
+        hostedAudioStopMusic(allocateTestResourceStub(&roc_host));
+        hostedAudioPauseMusic(allocateTestResourceStub(&roc_host));
+        hostedAudioResumeMusic(allocateTestResourceStub(&roc_host));
+        hostedAudioSetMusicVolume(allocateTestResourceStub(&roc_host), 0.5);
+        hostedAudioSetMusicPitch(allocateTestResourceStub(&roc_host), 1.5);
+        hostedAudioSetMusicPan(allocateTestResourceStub(&roc_host), -0.25);
+        hostedAudioSetMusicLooping(allocateTestResourceStub(&roc_host), true);
+        hostedAudioSeekMusic(allocateTestResourceStub(&roc_host), 12.5);
 
         // A stream that does not exist has no length and has played nothing,
         // rather than reporting whatever the last real stream did.
-        try std.testing.expect(!hostedAudioIsMusicPlaying(allocateTestResourceStub(&roc_host, 0)));
-        try std.testing.expectEqual(@as(f32, 0), hostedAudioMusicLength(allocateTestResourceStub(&roc_host, 0)));
-        try std.testing.expectEqual(@as(f32, 0), hostedAudioMusicTimePlayed(allocateTestResourceStub(&roc_host, 0)));
+        try std.testing.expect(!hostedAudioIsMusicPlaying(allocateTestResourceStub(&roc_host)));
+        try std.testing.expectEqual(@as(f32, 0), hostedAudioMusicLength(allocateTestResourceStub(&roc_host)));
+        try std.testing.expectEqual(@as(f32, 0), hostedAudioMusicTimePlayed(allocateTestResourceStub(&roc_host)));
 
         // The real resources go through the same calls. Each consumes the
         // reference it was handed, so each call gets its own.
@@ -4562,7 +4562,7 @@ test "opening a store and loading a texture from it wait rather than load" {
         defer update.leave();
         last_phase_violation = null;
         _ = hostedAssetsLoadStoreTextureRaw(&roc_host, .{
-            .store = allocateTestResourceStub(&roc_host, 0),
+            .store = allocateTestResourceStub(&roc_host),
             .path = abi.RocStr.fromSlice("logo.png", &roc_host),
         });
         const violation = last_phase_violation orelse return error.OperationWasNotRejected;
@@ -5419,7 +5419,7 @@ test "the store-backed font and shader loaders wait rather than load" {
         defer update.leave();
         last_phase_violation = null;
         _ = hostedDrawLoadStoreFontRaw(&roc_host, .{
-            .store = allocateTestResourceStub(&roc_host, 0),
+            .store = allocateTestResourceStub(&roc_host),
             .path = abi.RocStr.fromSlice("body.ttf", &roc_host),
             .size = 16,
         });
@@ -5430,7 +5430,7 @@ test "the store-backed font and shader loaders wait rather than load" {
 
         last_phase_violation = null;
         _ = hostedDrawLoadStoreShaderRaw(&roc_host, .{
-            .store = allocateTestResourceStub(&roc_host, 0),
+            .store = allocateTestResourceStub(&roc_host),
             .vertex_path = abi.RocStr.empty(),
             .fragment_path = abi.RocStr.fromSlice("blur.fs", &roc_host),
         });

--- a/src/host_native.zig
+++ b/src/host_native.zig
@@ -1978,16 +1978,25 @@ var camera_scope_count: usize = 0;
 var scissor_scopes: [SCOPE_STACK_LIMIT]abi.DrawHostBegin_scissorArgs = undefined;
 var scissor_scope_count: usize = 0;
 
+const INVALID_RESOURCE_TOKEN = std.math.maxInt(u64);
+
 const InvalidResourceBox = extern struct {
     refcount: isize = 0,
-    token: u64 = 0,
+    token: u64 = INVALID_RESOURCE_TOKEN,
 };
 
 var invalid_resource_box: InvalidResourceBox = .{};
 
+const DefaultFontBox = extern struct {
+    refcount: isize = 0,
+    token: u64 = 0,
+};
+
+var default_font_box: DefaultFontBox = .{};
+
 const InvalidTextureBox = extern struct {
     refcount: isize = 0,
-    payload: u64 = 0,
+    payload: u64 = INVALID_RESOURCE_TOKEN,
 };
 
 var invalid_texture_box: InvalidTextureBox = .{};
@@ -2228,6 +2237,14 @@ var file_bytes_delivery_reservations = FileBytesDeliveryReservations{};
 var sound_heap: SoundHeap = .{};
 var music_heap: MusicHeap = .{};
 var font_heap: FontHeap = .{};
+const StartupFontConfig = struct {
+    path: []const u8 = &.{},
+    size: i32 = 20,
+};
+
+/// Host-lifetime owner for a configured startup font, when present.
+var startup_font_handle: ?*u64 = null;
+var startup_font_config: StartupFontConfig = .{};
 var texture_heap: TextureHeap = .{};
 var render_texture_heap: RenderTextureHeap = .{};
 var shader_heap: ShaderHeap = .{};
@@ -2850,7 +2867,7 @@ test "prepared text allocates long native bytes once and retains its loaded font
     @memset(&long_text, 'x');
     const font = storeFont(.headless).?;
     const result = hostedDrawPrepareTextRaw(&roc_host, .{
-        .font = .{ .payload = .{ .loaded_font = font }, .tag = .LoadedFont },
+        .font = font,
         .text = abi.RocStr.fromSlice(&long_text, &roc_host),
         .size = 18,
         .spacing = 1,
@@ -2913,7 +2930,7 @@ test "prepared text rejects resource kind confusion and releases transferred own
 
     const font_shader = storeShader(.headless).?;
     const result = hostedDrawPrepareTextRaw(&roc_host, .{
-        .font = .{ .payload = .{ .loaded_font = font_shader }, .tag = .LoadedFont },
+        .font = font_shader,
         .text = abi.RocStr.empty(),
         .size = 16,
         .spacing = 1,
@@ -3194,7 +3211,7 @@ test "invalid headless render target dimensions do not consume a heap slot" {
     const before = render_texture_heap.active();
     const target = hostedDrawLoadRenderTextureRaw(.{ .height = 0, .width = 160 });
     try std.testing.expectEqual(RESOURCE_ERR_FAILED, target.err);
-    try std.testing.expectEqual(@as(u64, 0), target.target.handle.*);
+    try std.testing.expectEqual(INVALID_RESOURCE_TOKEN, target.target.handle.*);
     drainRetiredResourcesUpTo(std.math.maxInt(usize));
     try std.testing.expectEqual(before, render_texture_heap.active());
 }
@@ -3290,21 +3307,19 @@ test "copied shared texture destroys its native resource exactly once after the 
     try std.testing.expectEqual(destroyed_before + 1, texture_destroy_count);
 }
 
-/// The handle a Roc `stub` value carries: a real `Box(0)`.
+/// Allocate the real Roc box carried by a resource `stub` value.
 ///
-/// Zero is the officialized invalid token -- `decodeToken` rejects it and no
-/// heap ever emits it -- so every resource operation this reaches takes its
-/// unresolvable-handle branch. The box is a genuine Roc allocation rather than
-/// a fake, so the host's decref of it runs the same path it runs at runtime and
-/// the testing allocator reports a leak or a double free either way.
-fn allocateTestResourceStub(host: *RocHost) *u64 {
+/// The box is a genuine Roc allocation rather than a fake, so the host's
+/// decref of it runs the same path it runs at runtime and the testing allocator
+/// reports a leak or a double free either way.
+fn allocateTestResourceStub(host: *RocHost, token: u64) *u64 {
     const handle: *u64 = @ptrCast(@alignCast(abi.allocateBox(@sizeOf(u64), @alignOf(u64), false, host)));
-    handle.* = 0;
+    handle.* = token;
     return handle;
 }
 
 fn allocateTestTextureStub(host: *RocHost, width: f32, height: f32) abi.Texture {
-    return .{ .handle = allocateTestResourceStub(host), .width = width, .height = height };
+    return .{ .handle = allocateTestResourceStub(host, INVALID_RESOURCE_TOKEN), .width = width, .height = height };
 }
 
 /// Take a second reference to a live host resource handle, the way a Roc value
@@ -3334,7 +3349,7 @@ test "resource-free texture is safe across hosted operations and ordinary deallo
     }
 
     const destroyed_before = texture_destroy_count;
-    try std.testing.expect(nativeTextureForToken(0) == null);
+    try std.testing.expect(nativeTextureForToken(INVALID_RESOURCE_TOKEN) == null);
 
     {
         const scope = PhaseScope.enter(.render);
@@ -3413,11 +3428,11 @@ test "resource-free texture is safe across hosted operations and ordinary deallo
 
 test "resource-free draw handles are inert, and leave real resources alone" {
     // The Roc side publishes a `stub` for every resource an app can hold in its
-    // model -- `Draw.Font.stub`, `Draw.Shader.stub`, `Draw.RenderTexture.stub`,
+    // model -- `Text.font_stub`, `Draw.Shader.stub`, `Draw.RenderTexture.stub`,
     // `Text.Prepared.stub`, `Assets.Store.stub` -- so that a pure test can write
-    // a model down. Each one carries `Box(0)`, and this is the other half of
-    // that promise: the host resolves none of them, refuses the operations they
-    // reach, and releases the box exactly once.
+    // a model down. Font and texture use the maximum U64 token, while the
+    // other resource stubs carry zero. The host resolves none of them, refuses
+    // the operations they reach, and releases the box exactly once.
     //
     // A real resource of each kind is live throughout, and goes through the
     // same calls itself. Stub traffic must not disturb it, and the operations
@@ -3440,9 +3455,9 @@ test "resource-free draw handles are inert, and leave real resources alone" {
         active_roc_host = null;
     }
 
-    // Zero resolves nowhere, in any heap. This is the property every stub rests
-    // on, and the reason `stub` can be a pure value at all.
-    try std.testing.expect(font_heap.get(0) == null);
+    // Stub tokens resolve nowhere. This is the property every stub rests on,
+    // and the reason `stub` can be a pure value at all.
+    try std.testing.expect(font_heap.get(INVALID_RESOURCE_TOKEN) == null);
     try std.testing.expect(shader_heap.get(0) == null);
     try std.testing.expect(render_texture_heap.get(0) == null);
     try std.testing.expect(prepared_text_heap.get(0) == null);
@@ -3457,16 +3472,13 @@ test "resource-free draw handles are inert, and leave real resources alone" {
 
         // A stub font has no metrics to snapshot; the headless answer is the
         // built-in one, and the transferred handle is still released.
-        const snapshot = hostedDrawFontMetricsRaw(&roc_host, .{
-            .payload = .{ .loaded_font = allocateTestResourceStub(&roc_host) },
-            .tag = .LoadedFont,
-        });
+        const snapshot = hostedDrawFontMetricsRaw(&roc_host, allocateTestResourceStub(&roc_host, INVALID_RESOURCE_TOKEN));
         defer snapshot.glyphs.decref(&roc_host);
 
         // Preparing text with a stub font is refused rather than silently
         // prepared against the default font, and consumes no heap slot.
         const prepared = hostedDrawPrepareTextRaw(&roc_host, .{
-            .font = .{ .payload = .{ .loaded_font = allocateTestResourceStub(&roc_host) }, .tag = .LoadedFont },
+            .font = allocateTestResourceStub(&roc_host, INVALID_RESOURCE_TOKEN),
             .text = abi.RocStr.fromSlice("inert", &roc_host),
             .size = 16,
             .spacing = 1,
@@ -3478,26 +3490,26 @@ test "resource-free draw handles are inert, and leave real resources alone" {
 
         // A uniform cannot be resolved on a stub shader.
         try std.testing.expectEqual(@as(i32, -1), hostedDrawShaderLocationRaw(&roc_host, .{
-            .shader = allocateTestResourceStub(&roc_host),
+            .shader = allocateTestResourceStub(&roc_host, 0),
             .name = abi.RocStr.fromSlice("uTime", &roc_host),
         }));
 
         // Every store-backed loader reports the read it could not make.
         const store_texture = hostedAssetsLoadStoreTextureRaw(&roc_host, .{
-            .store = allocateTestResourceStub(&roc_host),
+            .store = allocateTestResourceStub(&roc_host, 0),
             .path = abi.RocStr.fromSlice("atlas.png", &roc_host),
         });
         try std.testing.expectEqual(STORE_LOAD_ERR_READ, store_texture.err);
 
         const store_font = hostedDrawLoadStoreFontRaw(&roc_host, .{
-            .store = allocateTestResourceStub(&roc_host),
+            .store = allocateTestResourceStub(&roc_host, 0),
             .path = abi.RocStr.fromSlice("body.ttf", &roc_host),
             .size = 16,
         });
         try std.testing.expectEqual(STORE_LOAD_ERR_READ, store_font.err);
 
         const store_shader = hostedDrawLoadStoreShaderRaw(&roc_host, .{
-            .store = allocateTestResourceStub(&roc_host),
+            .store = allocateTestResourceStub(&roc_host, 0),
             .vertex_path = abi.RocStr.empty(),
             .fragment_path = abi.RocStr.fromSlice("blur.fs", &roc_host),
         });
@@ -3514,10 +3526,10 @@ test "resource-free draw handles are inert, and leave real resources alone" {
 
         // A scope cannot be opened on a stub, and reports the same refusal a
         // released resource would. Nothing is leased, so there is no end call.
-        try std.testing.expectEqual(SCOPE_UNAVAILABLE, hostedDrawBeginShaderRaw(.{ .arg0 = allocateTestResourceStub(&roc_host) }));
+        try std.testing.expectEqual(SCOPE_UNAVAILABLE, hostedDrawBeginShaderRaw(.{ .arg0 = allocateTestResourceStub(&roc_host, 0) }));
         try std.testing.expectEqual(@as(usize, 0), shader_lease_count);
         try std.testing.expectEqual(SCOPE_UNAVAILABLE, hostedDrawBeginRenderTextureRaw(.{
-            .handle = allocateTestResourceStub(&roc_host),
+            .handle = allocateTestResourceStub(&roc_host, 0),
             .height = 90,
             .width = 160,
         }));
@@ -3528,7 +3540,7 @@ test "resource-free draw handles are inert, and leave real resources alone" {
         // one is: no draw is counted and nothing faults.
         const draws_before = prepared_text_draw_calls;
         hostedDrawPreparedTextRaw(&roc_host, .{
-            .prepared = allocateTestResourceStub(&roc_host),
+            .prepared = allocateTestResourceStub(&roc_host, 0),
             .pos = .{ .x = 10, .y = 20 },
             .color = .{ .r = 255, .g = 255, .b = 255, .a = 255 },
         });
@@ -3593,30 +3605,30 @@ test "resource-free audio handles are inert across every sound and music call" {
         const scope = PhaseScope.enter(.update);
         defer scope.leave();
 
-        hostedAudioPlay(allocateTestResourceStub(&roc_host));
-        hostedAudioStop(allocateTestResourceStub(&roc_host));
-        hostedAudioPause(allocateTestResourceStub(&roc_host));
-        hostedAudioResume(allocateTestResourceStub(&roc_host));
-        hostedAudioSetVolume(allocateTestResourceStub(&roc_host), 0.5);
-        hostedAudioSetPitch(allocateTestResourceStub(&roc_host), 1.5);
-        hostedAudioSetPan(allocateTestResourceStub(&roc_host), -0.25);
-        try std.testing.expect(!hostedAudioIsPlaying(allocateTestResourceStub(&roc_host)));
+        hostedAudioPlay(allocateTestResourceStub(&roc_host, 0));
+        hostedAudioStop(allocateTestResourceStub(&roc_host, 0));
+        hostedAudioPause(allocateTestResourceStub(&roc_host, 0));
+        hostedAudioResume(allocateTestResourceStub(&roc_host, 0));
+        hostedAudioSetVolume(allocateTestResourceStub(&roc_host, 0), 0.5);
+        hostedAudioSetPitch(allocateTestResourceStub(&roc_host, 0), 1.5);
+        hostedAudioSetPan(allocateTestResourceStub(&roc_host, 0), -0.25);
+        try std.testing.expect(!hostedAudioIsPlaying(allocateTestResourceStub(&roc_host, 0)));
 
-        hostedAudioPlayMusic(allocateTestResourceStub(&roc_host));
-        hostedAudioStopMusic(allocateTestResourceStub(&roc_host));
-        hostedAudioPauseMusic(allocateTestResourceStub(&roc_host));
-        hostedAudioResumeMusic(allocateTestResourceStub(&roc_host));
-        hostedAudioSetMusicVolume(allocateTestResourceStub(&roc_host), 0.5);
-        hostedAudioSetMusicPitch(allocateTestResourceStub(&roc_host), 1.5);
-        hostedAudioSetMusicPan(allocateTestResourceStub(&roc_host), -0.25);
-        hostedAudioSetMusicLooping(allocateTestResourceStub(&roc_host), true);
-        hostedAudioSeekMusic(allocateTestResourceStub(&roc_host), 12.5);
+        hostedAudioPlayMusic(allocateTestResourceStub(&roc_host, 0));
+        hostedAudioStopMusic(allocateTestResourceStub(&roc_host, 0));
+        hostedAudioPauseMusic(allocateTestResourceStub(&roc_host, 0));
+        hostedAudioResumeMusic(allocateTestResourceStub(&roc_host, 0));
+        hostedAudioSetMusicVolume(allocateTestResourceStub(&roc_host, 0), 0.5);
+        hostedAudioSetMusicPitch(allocateTestResourceStub(&roc_host, 0), 1.5);
+        hostedAudioSetMusicPan(allocateTestResourceStub(&roc_host, 0), -0.25);
+        hostedAudioSetMusicLooping(allocateTestResourceStub(&roc_host, 0), true);
+        hostedAudioSeekMusic(allocateTestResourceStub(&roc_host, 0), 12.5);
 
         // A stream that does not exist has no length and has played nothing,
         // rather than reporting whatever the last real stream did.
-        try std.testing.expect(!hostedAudioIsMusicPlaying(allocateTestResourceStub(&roc_host)));
-        try std.testing.expectEqual(@as(f32, 0), hostedAudioMusicLength(allocateTestResourceStub(&roc_host)));
-        try std.testing.expectEqual(@as(f32, 0), hostedAudioMusicTimePlayed(allocateTestResourceStub(&roc_host)));
+        try std.testing.expect(!hostedAudioIsMusicPlaying(allocateTestResourceStub(&roc_host, 0)));
+        try std.testing.expectEqual(@as(f32, 0), hostedAudioMusicLength(allocateTestResourceStub(&roc_host, 0)));
+        try std.testing.expectEqual(@as(f32, 0), hostedAudioMusicTimePlayed(allocateTestResourceStub(&roc_host, 0)));
 
         // The real resources go through the same calls. Each consumes the
         // reference it was handed, so each call gets its own.
@@ -3912,7 +3924,7 @@ test "every fixed resource heap reports capacity plus one as ResourceLimit" {
     var prepared_texts: [256]*u64 = undefined;
     for (&prepared_texts) |*prepared| {
         const result = hostedDrawPrepareTextRaw(&roc_host, .{
-            .font = .{ .payload = undefined, .tag = .DefaultFont },
+            .font = defaultFontHandle(),
             .text = abi.RocStr.empty(),
             .size = 16,
             .spacing = 1,
@@ -3921,7 +3933,7 @@ test "every fixed resource heap reports capacity plus one as ResourceLimit" {
         prepared.* = result.prepared;
     }
     try std.testing.expectEqual(RESOURCE_ERR_LIMIT, hostedDrawPrepareTextRaw(&roc_host, .{
-        .font = .{ .payload = undefined, .tag = .DefaultFont },
+        .font = defaultFontHandle(),
         .text = abi.RocStr.empty(),
         .size = 16,
         .spacing = 1,
@@ -3950,6 +3962,91 @@ fn storeFont(resource: FontResource) ?*u64 {
         destroyFont(&rejected);
         return null;
     };
+}
+
+fn defaultFontHandle() *u64 {
+    return &default_font_box.token;
+}
+
+test "the built-in font is token zero and consumes no font heap slot" {
+    try std.testing.expectEqual(@as(u64, 0), defaultFontHandle().*);
+    try std.testing.expectEqual(@as(usize, 0), font_heap.active());
+}
+
+fn releaseStartupFontHandle(host: *RocHost) void {
+    if (startup_font_handle) |handle| releaseResourceBox(host, handle);
+    startup_font_handle = null;
+}
+
+fn configuredStartupFont(host: *RocHost) abi.DrawHostLoad_font_bytesRetRecord {
+    enforcePhase("App.Startup.default_font!", during_startup);
+    if (startup_font_config.path.len == 0) return .{ .font = defaultFontHandle(), .err = RESOURCE_ERR_NONE };
+    if (!isSafeStoreRelativePath(startup_font_config.path)) return .{ .font = invalidResourceHandle(), .err = STORE_LOAD_ERR_PATH };
+    if (startup_font_config.size <= 0) return .{ .font = invalidResourceHandle(), .err = STORE_LOAD_ERR_DECODE };
+
+    if (startup_font_handle) |handle| {
+        abi.increfBox(@ptrCast(handle), 1);
+        return .{ .font = handle, .err = RESOURCE_ERR_NONE };
+    }
+
+    const file_type = fontFileTypeFromPath(startup_font_config.path) orelse return .{ .font = invalidResourceHandle(), .err = STORE_LOAD_ERR_DECODE };
+    const allocator = allocatorFromHost(host);
+    const bytes = std.Io.Dir.cwd().readFileAlloc(mainThreadIo(), startup_font_config.path, allocator, .limited(MAX_ASSET_FILE_BYTES)) catch |err| {
+        return .{
+            .font = invalidResourceHandle(),
+            .err = switch (err) {
+                error.FileNotFound => STORE_LOAD_ERR_NOT_FOUND,
+                else => STORE_LOAD_ERR_READ,
+            },
+        };
+    };
+    defer allocator.free(bytes);
+
+    const handle = if (headlessMode())
+        storeFont(.headless)
+    else blk: {
+        const font = raylib.loadFontFromMemory(file_type, bytes, startup_font_config.size) orelse return .{ .font = invalidResourceHandle(), .err = STORE_LOAD_ERR_DECODE };
+        break :blk storeFont(.{ .native = font });
+    };
+    const stored = handle orelse return .{ .font = invalidResourceHandle(), .err = STORE_LOAD_ERR_LIMIT };
+    startup_font_handle = stored;
+    abi.increfBox(@ptrCast(stored), 1);
+    return .{ .font = stored, .err = RESOURCE_ERR_NONE };
+}
+
+fn exportedDrawStartupDefaultFontRaw() callconv(.c) abi.DrawHostLoad_font_bytesRetRecord {
+    return configuredStartupFont(activeHost());
+}
+
+test "configured startup font loads once and returns retained aliases" {
+    drainRetiredResourcesUpTo(std.math.maxInt(usize));
+    try std.testing.expectEqual(@as(usize, 0), font_heap.active());
+    var roc_env = abi.RocEnv{ .allocator = std.testing.allocator, .roc_io = abi.RocIo.freestanding() };
+    var roc_host = abi.makeRocHost(&roc_env);
+    roc_host.roc_dealloc = &nativeRocDealloc;
+    active_roc_host = &roc_host;
+    active_headless = true;
+    startup_font_config = .{ .path = "examples/live_plot/assets/fonts/LiberationSans-Regular.ttf", .size = 24 };
+    const phase = PhaseScope.enter(.startup);
+    defer {
+        phase.leave();
+        font_heap.deinitAll();
+        startup_font_handle = null;
+        startup_font_config = .{};
+        active_headless = false;
+        active_roc_host = null;
+    }
+
+    const first = configuredStartupFont(&roc_host);
+    const second = configuredStartupFont(&roc_host);
+    try std.testing.expectEqual(RESOURCE_ERR_NONE, first.err);
+    try std.testing.expectEqual(RESOURCE_ERR_NONE, second.err);
+    try std.testing.expectEqual(first.font, second.font);
+    try std.testing.expectEqual(@as(usize, 1), font_heap.active());
+    releaseResourceBox(&roc_host, first.font);
+    releaseResourceBox(&roc_host, second.font);
+    drainRetiredResourcesUpTo(std.math.maxInt(usize));
+    try std.testing.expectEqual(@as(usize, 1), font_heap.active());
 }
 
 fn storePreparedText(resource: PreparedTextResource) ?*u64 {
@@ -4465,7 +4562,7 @@ test "opening a store and loading a texture from it wait rather than load" {
         defer update.leave();
         last_phase_violation = null;
         _ = hostedAssetsLoadStoreTextureRaw(&roc_host, .{
-            .store = allocateTestResourceStub(&roc_host),
+            .store = allocateTestResourceStub(&roc_host, 0),
             .path = abi.RocStr.fromSlice("logo.png", &roc_host),
         });
         const violation = last_phase_violation orelse return error.OperationWasNotRejected;
@@ -5322,7 +5419,7 @@ test "the store-backed font and shader loaders wait rather than load" {
         defer update.leave();
         last_phase_violation = null;
         _ = hostedDrawLoadStoreFontRaw(&roc_host, .{
-            .store = allocateTestResourceStub(&roc_host),
+            .store = allocateTestResourceStub(&roc_host, 0),
             .path = abi.RocStr.fromSlice("body.ttf", &roc_host),
             .size = 16,
         });
@@ -5333,7 +5430,7 @@ test "the store-backed font and shader loaders wait rather than load" {
 
         last_phase_violation = null;
         _ = hostedDrawLoadStoreShaderRaw(&roc_host, .{
-            .store = allocateTestResourceStub(&roc_host),
+            .store = allocateTestResourceStub(&roc_host, 0),
             .vertex_path = abi.RocStr.empty(),
             .fragment_path = abi.RocStr.fromSlice("blur.fs", &roc_host),
         });
@@ -5366,13 +5463,19 @@ test "the store-backed font and shader loaders wait rather than load" {
     try std.testing.expect(last_phase_violation == null);
 }
 
-fn fontForValue(font_value: *const abi.DefaultFontOrLoadedFont) raylib.Font {
-    if (font_value.tag == .DefaultFont) return raylib.defaultFont();
-    const resource = font_heap.get(font_value.payload_loaded_font().*) orelse return raylib.defaultFont();
+fn fontForHandle(handle: *u64) raylib.Font {
+    if (builtin.is_test) return undefined;
+    if (handle.* == 0) return raylib.defaultFont();
+    const resource = font_heap.get(handle.*) orelse return raylib.defaultFont();
     return switch (resource.*) {
         .headless => raylib.defaultFont(),
         .native => |font| font,
     };
+}
+
+fn hostedDrawDefaultFontRaw() callconv(.c) *u64 {
+    enforcePhase("Draw.default_font!", during_load);
+    return defaultFontHandle();
 }
 
 fn headlessFontMetrics(host: *RocHost) abi.DrawHostFont_metricsRetRecord {
@@ -5427,14 +5530,14 @@ fn snapshotRaylibFontMetrics(host: *RocHost, font: raylib.Font) abi.DrawHostFont
     };
 }
 
-fn hostedDrawFontMetricsRaw(host: *RocHost, font: abi.DefaultFontOrLoadedFont) callconv(.c) abi.DrawHostFont_metricsRetRecord {
+fn hostedDrawFontMetricsRaw(host: *RocHost, font: *u64) callconv(.c) abi.DrawHostFont_metricsRetRecord {
     enforcePhase("Draw font metric snapshot", during_load);
-    defer font.decref(host);
+    defer releaseResourceBox(host, font);
     if (headlessMode()) return headlessFontMetrics(host);
-    return snapshotRaylibFontMetrics(host, fontForValue(&font));
+    return snapshotRaylibFontMetrics(host, fontForHandle(font));
 }
 
-fn exportedDrawFontMetricsRaw(font: abi.DefaultFontOrLoadedFont) callconv(.c) abi.DrawHostFont_metricsRetRecord {
+fn exportedDrawFontMetricsRaw(font: *u64) callconv(.c) abi.DrawHostFont_metricsRetRecord {
     return hostedDrawFontMetricsRaw(activeHost(), font);
 }
 
@@ -5454,10 +5557,7 @@ test "font metric snapshots release the source Font and retain only scalar Roc d
     }
 
     const source = storeFont(.headless).?;
-    const snapshot = hostedDrawFontMetricsRaw(&roc_host, .{
-        .payload = .{ .loaded_font = source },
-        .tag = .LoadedFont,
-    });
+    const snapshot = hostedDrawFontMetricsRaw(&roc_host, source);
     defer snapshot.glyphs.decref(&roc_host);
 
     try std.testing.expectEqual(@as(f32, 2), snapshot.base_size);
@@ -5478,25 +5578,23 @@ fn hostedDrawPrepareTextRaw(host: *RocHost, args: abi.DrawHostPrepare_textArgs) 
     defer args.text.decref(host);
     prepared_text_prepare_calls += 1;
 
-    var font: ?raylib.Font = null;
-    if (args.font.tag == .DefaultFont) {
-        if (!headlessMode()) font = raylib.defaultFont();
-    } else {
-        const font_resource = font_heap.get(args.font.payload_loaded_font().*) orelse {
-            args.font.decref(host);
-            return .{ .prepared = invalidResourceHandle(), .height = 0, .width = 0, .err = RESOURCE_ERR_FAILED };
-        };
-        font = switch (font_resource.*) {
+    const font: ?raylib.Font = if (args.font.* == 0)
+        if (builtin.is_test) null else raylib.defaultFont()
+    else if (font_heap.get(args.font.*)) |font_resource|
+        switch (font_resource.*) {
             .headless => null,
             .native => |loaded| loaded,
-        };
-    }
+        }
+    else {
+        releaseResourceBox(host, args.font);
+        return .{ .prepared = invalidResourceHandle(), .height = 0, .width = 0, .err = RESOURCE_ERR_FAILED };
+    };
 
     const text_slice = args.text.asSlice();
     const text_len = std.mem.indexOfScalar(u8, text_slice, 0) orelse text_slice.len;
     const allocator = allocatorFromHost(host);
     const allocation = allocator.alloc(u8, text_len + 1) catch {
-        args.font.decref(host);
+        releaseResourceBox(host, args.font);
         return .{ .prepared = invalidResourceHandle(), .height = 0, .width = 0, .err = RESOURCE_ERR_LIMIT };
     };
     @memcpy(allocation[0..text_len], text_slice[0..text_len]);
@@ -5511,12 +5609,11 @@ fn hostedDrawPrepareTextRaw(host: *RocHost, args: abi.DrawHostPrepare_textArgs) 
         break :blk TextMeasurement{ .height = size.y, .width = size.x };
     };
 
-    const font_owner = if (args.font.tag == .LoadedFont) args.font.payload_loaded_font() else null;
     const prepared = storePreparedText(.{
         .allocator = allocator,
         .text = text,
         .font = font,
-        .font_owner = font_owner,
+        .font_owner = args.font,
         .size = args.size,
         .spacing = args.spacing,
     }) orelse return .{ .prepared = invalidResourceHandle(), .height = 0, .width = 0, .err = RESOURCE_ERR_LIMIT };
@@ -5552,7 +5649,7 @@ fn exportedDrawPreparedTextRaw(args: abi.DrawHostDraw_prepared_textArgs) callcon
 fn hostedDrawTextRaw(host: *RocHost, args: abi.DrawHostTextArgs) callconv(.c) void {
     enforcePhase("Draw.text!", during_render);
     defer args.text.decref(host);
-    defer args.font.decref(host);
+    defer releaseResourceBox(host, args.font);
     if (headlessMode()) return;
 
     const text_slice = args.text.asSlice();
@@ -5562,7 +5659,7 @@ fn hostedDrawTextRaw(host: *RocHost, args: abi.DrawHostTextArgs) callconv(.c) vo
 
     raylib.drawTextZ(
         text.ptr,
-        fontForValue(&args.font),
+        fontForHandle(args.font),
         .{ .x = args.pos.x, .y = args.pos.y },
         args.size,
         args.spacing,
@@ -5577,7 +5674,7 @@ fn exportedDrawTextRaw(args: abi.DrawHostTextArgs) callconv(.c) void {
 fn hostedDrawTextAlignedRaw(host: *RocHost, args: abi.DrawHostText_alignedArgs) callconv(.c) void {
     enforcePhase("Draw.text_at!", during_render);
     defer args.text.decref(host);
-    defer args.font.decref(host);
+    defer releaseResourceBox(host, args.font);
     if (active_headless) return;
 
     const text_slice = args.text.asSlice();
@@ -5587,7 +5684,7 @@ fn hostedDrawTextAlignedRaw(host: *RocHost, args: abi.DrawHostText_alignedArgs) 
 
     raylib.drawTextAlignedZ(
         text.ptr,
-        fontForValue(&args.font),
+        fontForHandle(args.font),
         .{ .x = args.pos.x, .y = args.pos.y },
         args.size,
         args.spacing,
@@ -7057,6 +7154,10 @@ fn deinitResources() void {
     screen_snapshot_requested = false;
 
     // The final model has been dropped, so everything it held is retired.
+    // Release the configured startup-font cache now that no startup call can
+    // ask for another alias. The built-in font uses static token zero and owns
+    // no heap slot.
+    releaseStartupFontHandle(activeHost());
     // Destroy it all before the assertions below, which are about whether Roc
     // *released* its handles rather than about when the host got round to the
     // driver calls. Shutdown drains the complete retirement queue.
@@ -7098,6 +7199,7 @@ fn deinitResources() void {
     render_texture_heap.deinitAll();
     texture_heap.deinitAll();
     font_heap.deinitAll();
+    startup_font_handle = null;
     music_heap.deinitAll();
     sound_heap.deinitAll();
 }
@@ -7171,6 +7273,8 @@ comptime {
         @export(&hostedDrawEndScissorRaw, .{ .name = "roc_draw_end_scissor_raw" });
         @export(&hostedDrawEndShaderRaw, .{ .name = "roc_draw_end_shader_raw" });
         @export(&hostedDrawFps, .{ .name = "roc_draw_fps" });
+        @export(&hostedDrawDefaultFontRaw, .{ .name = "roc_draw_default_font_raw" });
+        @export(&exportedDrawStartupDefaultFontRaw, .{ .name = "roc_draw_startup_default_font_raw" });
         @export(&exportedDrawFontMetricsRaw, .{ .name = "roc_draw_font_metrics_raw" });
         @export(&hostedDrawFrameSizeRaw, .{ .name = "roc_draw_frame_size" });
         @export(&hostedDrawLineRaw, .{ .name = "roc_draw_line_raw" });
@@ -10291,7 +10395,13 @@ fn platform_main(argc: usize, argv: [*][*:0]u8) c_int {
     const config_phase = PhaseScope.enter(.startup);
     var app_config = app_config_for_host();
     config_phase.leave();
-    // The config now carries three Roc strings; `decref` releases all of them.
+    startup_font_config = .{
+        .path = app_config.default_font_path.asSlice(),
+        .size = app_config.default_font_size,
+    };
+    defer startup_font_config = .{};
+    // The config's Roc strings stay borrowed by startup configuration until
+    // the selected host lifetime finishes; `decref` then releases all of them.
     defer app_config.decref(&roc_host);
 
     if (options.headless) {

--- a/src/host_resource.zig
+++ b/src/host_resource.zig
@@ -250,6 +250,7 @@ fn encodeToken(index: usize, generation: u64, comptime kind: Kind) u64 {
 /// A kind byte that names no `Kind` is not a token this host ever emitted, so
 /// it fails here rather than reaching a heap that would have to decide.
 fn decodeToken(token: u64) ?struct { index: usize, kind: Kind, generation: u64 } {
+    if (token == std.math.maxInt(u64)) return null;
     const encoded_index = token & token_index_mask;
     const encoded_kind = (token >> token_index_bits) & token_kind_mask;
     const generation = token >> token_generation_shift;
@@ -260,6 +261,10 @@ fn decodeToken(token: u64) ?struct { index: usize, kind: Kind, generation: u64 }
 
 test "zero is not a resource token" {
     try std.testing.expect(decodeToken(0) == null);
+}
+
+test "maximum u64 is not a resource token" {
+    try std.testing.expect(decodeToken(std.math.maxInt(u64)) == null);
 }
 
 test "a kind byte no resource claims is not a resource token" {

--- a/src/roc_platform_abi.zig
+++ b/src/roc_platform_abi.zig
@@ -3101,50 +3101,50 @@ comptime {
 
 /// Element type for __AnonStruct_e7f1bd6203d0f761
 pub const __AnonStruct_e7f1bd6203d0f761 = if (@sizeOf(usize) == 4) extern struct {
-    font: DefaultFontOrLoadedFont,
+    font: *u64,
     text: RocStr,
     size: f32,
     spacing: f32,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        value.font.decref(roc_host);
+        decrefBoxWith(@ptrCast(value.font), @alignOf(u64), false, null, roc_host);
         value.text.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        value.font.incref(amount);
+        increfBox(@ptrCast(value.font), amount);
         value.text.incref(amount);
     }
 } else extern struct {
-    font: DefaultFontOrLoadedFont,
+    font: *u64,
     text: RocStr,
     size: f32,
     spacing: f32,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        value.font.decref(roc_host);
+        decrefBoxWith(@ptrCast(value.font), @alignOf(u64), false, null, roc_host);
         value.text.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        value.font.incref(amount);
+        increfBox(@ptrCast(value.font), amount);
         value.text.incref(amount);
     }
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_e7f1bd6203d0f761) != 48) @compileError("__AnonStruct_e7f1bd6203d0f761 size mismatch");
+        if (@sizeOf(__AnonStruct_e7f1bd6203d0f761) != 40) @compileError("__AnonStruct_e7f1bd6203d0f761 size mismatch");
         if (@alignOf(__AnonStruct_e7f1bd6203d0f761) != 8) @compileError("__AnonStruct_e7f1bd6203d0f761 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_e7f1bd6203d0f761) != 28) @compileError("__AnonStruct_e7f1bd6203d0f761 size mismatch");
+        if (@sizeOf(__AnonStruct_e7f1bd6203d0f761) != 24) @compileError("__AnonStruct_e7f1bd6203d0f761 size mismatch");
         if (@alignOf(__AnonStruct_e7f1bd6203d0f761) != 4) @compileError("__AnonStruct_e7f1bd6203d0f761 alignment mismatch");
     }
 }
@@ -3609,7 +3609,7 @@ comptime {
 
 /// Element type for __AnonStruct_18f9d3b1fa7f9242
 pub const __AnonStruct_18f9d3b1fa7f9242 = if (@sizeOf(usize) == 4) extern struct {
-    font: DefaultFontOrLoadedFont,
+    font: *u64,
     text: RocStr,
     pos: MathVec2,
     size: f32,
@@ -3618,7 +3618,7 @@ pub const __AnonStruct_18f9d3b1fa7f9242 = if (@sizeOf(usize) == 4) extern struct
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        value.font.decref(roc_host);
+        decrefBoxWith(@ptrCast(value.font), @alignOf(u64), false, null, roc_host);
         value.text.decref(roc_host);
         value.pos.decref(roc_host);
         value.color.decref(roc_host);
@@ -3627,13 +3627,13 @@ pub const __AnonStruct_18f9d3b1fa7f9242 = if (@sizeOf(usize) == 4) extern struct
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        value.font.incref(amount);
+        increfBox(@ptrCast(value.font), amount);
         value.text.incref(amount);
         value.pos.incref(amount);
         value.color.incref(amount);
     }
 } else extern struct {
-    font: DefaultFontOrLoadedFont,
+    font: *u64,
     text: RocStr,
     pos: MathVec2,
     size: f32,
@@ -3642,7 +3642,7 @@ pub const __AnonStruct_18f9d3b1fa7f9242 = if (@sizeOf(usize) == 4) extern struct
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        value.font.decref(roc_host);
+        decrefBoxWith(@ptrCast(value.font), @alignOf(u64), false, null, roc_host);
         value.text.decref(roc_host);
         value.pos.decref(roc_host);
         value.color.decref(roc_host);
@@ -3651,7 +3651,7 @@ pub const __AnonStruct_18f9d3b1fa7f9242 = if (@sizeOf(usize) == 4) extern struct
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        value.font.incref(amount);
+        increfBox(@ptrCast(value.font), amount);
         value.text.incref(amount);
         value.pos.incref(amount);
         value.color.incref(amount);
@@ -3660,18 +3660,18 @@ pub const __AnonStruct_18f9d3b1fa7f9242 = if (@sizeOf(usize) == 4) extern struct
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_18f9d3b1fa7f9242) != 64) @compileError("__AnonStruct_18f9d3b1fa7f9242 size mismatch");
+        if (@sizeOf(__AnonStruct_18f9d3b1fa7f9242) != 56) @compileError("__AnonStruct_18f9d3b1fa7f9242 size mismatch");
         if (@alignOf(__AnonStruct_18f9d3b1fa7f9242) != 8) @compileError("__AnonStruct_18f9d3b1fa7f9242 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_18f9d3b1fa7f9242) != 40) @compileError("__AnonStruct_18f9d3b1fa7f9242 size mismatch");
+        if (@sizeOf(__AnonStruct_18f9d3b1fa7f9242) != 36) @compileError("__AnonStruct_18f9d3b1fa7f9242 size mismatch");
         if (@alignOf(__AnonStruct_18f9d3b1fa7f9242) != 4) @compileError("__AnonStruct_18f9d3b1fa7f9242 alignment mismatch");
     }
 }
 
 /// Element type for __AnonStruct_f27064a2797f2406
 pub const __AnonStruct_f27064a2797f2406 = if (@sizeOf(usize) == 4) extern struct {
-    font: DefaultFontOrLoadedFont,
+    font: *u64,
     text: RocStr,
     align_x: f32,
     align_y: f32,
@@ -3682,7 +3682,7 @@ pub const __AnonStruct_f27064a2797f2406 = if (@sizeOf(usize) == 4) extern struct
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        value.font.decref(roc_host);
+        decrefBoxWith(@ptrCast(value.font), @alignOf(u64), false, null, roc_host);
         value.text.decref(roc_host);
         value.pos.decref(roc_host);
         value.color.decref(roc_host);
@@ -3691,13 +3691,13 @@ pub const __AnonStruct_f27064a2797f2406 = if (@sizeOf(usize) == 4) extern struct
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        value.font.incref(amount);
+        increfBox(@ptrCast(value.font), amount);
         value.text.incref(amount);
         value.pos.incref(amount);
         value.color.incref(amount);
     }
 } else extern struct {
-    font: DefaultFontOrLoadedFont,
+    font: *u64,
     text: RocStr,
     align_x: f32,
     align_y: f32,
@@ -3708,7 +3708,7 @@ pub const __AnonStruct_f27064a2797f2406 = if (@sizeOf(usize) == 4) extern struct
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        value.font.decref(roc_host);
+        decrefBoxWith(@ptrCast(value.font), @alignOf(u64), false, null, roc_host);
         value.text.decref(roc_host);
         value.pos.decref(roc_host);
         value.color.decref(roc_host);
@@ -3717,7 +3717,7 @@ pub const __AnonStruct_f27064a2797f2406 = if (@sizeOf(usize) == 4) extern struct
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        value.font.incref(amount);
+        increfBox(@ptrCast(value.font), amount);
         value.text.incref(amount);
         value.pos.incref(amount);
         value.color.incref(amount);
@@ -3726,11 +3726,11 @@ pub const __AnonStruct_f27064a2797f2406 = if (@sizeOf(usize) == 4) extern struct
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_f27064a2797f2406) != 72) @compileError("__AnonStruct_f27064a2797f2406 size mismatch");
+        if (@sizeOf(__AnonStruct_f27064a2797f2406) != 64) @compileError("__AnonStruct_f27064a2797f2406 size mismatch");
         if (@alignOf(__AnonStruct_f27064a2797f2406) != 8) @compileError("__AnonStruct_f27064a2797f2406 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_f27064a2797f2406) != 48) @compileError("__AnonStruct_f27064a2797f2406 size mismatch");
+        if (@sizeOf(__AnonStruct_f27064a2797f2406) != 44) @compileError("__AnonStruct_f27064a2797f2406 size mismatch");
         if (@alignOf(__AnonStruct_f27064a2797f2406) != 4) @compileError("__AnonStruct_f27064a2797f2406 alignment mismatch");
     }
 }
@@ -6352,9 +6352,11 @@ comptime {
 /// Element type for __AnonStruct_1fdbe5c9dee1b2d2
 pub const __AnonStruct_1fdbe5c9dee1b2d2 = if (@sizeOf(usize) == 4) extern struct {
     record_max_frames: u64,
+    default_font_path: RocStr,
     output_dir: RocStr,
     record_path: RocStr,
     title: RocStr,
+    default_font_size: i32,
     exit_key_code: i32,
     height: i32,
     min_height: i32,
@@ -6378,6 +6380,7 @@ pub const __AnonStruct_1fdbe5c9dee1b2d2 = if (@sizeOf(usize) == 4) extern struct
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
+        value.default_font_path.decref(roc_host);
         value.output_dir.decref(roc_host);
         value.record_path.decref(roc_host);
         value.title.decref(roc_host);
@@ -6386,15 +6389,18 @@ pub const __AnonStruct_1fdbe5c9dee1b2d2 = if (@sizeOf(usize) == 4) extern struct
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
+        value.default_font_path.incref(amount);
         value.output_dir.incref(amount);
         value.record_path.incref(amount);
         value.title.incref(amount);
     }
 } else extern struct {
     record_max_frames: u64,
+    default_font_path: RocStr,
     output_dir: RocStr,
     record_path: RocStr,
     title: RocStr,
+    default_font_size: i32,
     exit_key_code: i32,
     height: i32,
     min_height: i32,
@@ -6418,6 +6424,7 @@ pub const __AnonStruct_1fdbe5c9dee1b2d2 = if (@sizeOf(usize) == 4) extern struct
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
+        value.default_font_path.decref(roc_host);
         value.output_dir.decref(roc_host);
         value.record_path.decref(roc_host);
         value.title.decref(roc_host);
@@ -6426,6 +6433,7 @@ pub const __AnonStruct_1fdbe5c9dee1b2d2 = if (@sizeOf(usize) == 4) extern struct
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
+        value.default_font_path.incref(amount);
         value.output_dir.incref(amount);
         value.record_path.incref(amount);
         value.title.incref(amount);
@@ -6434,11 +6442,11 @@ pub const __AnonStruct_1fdbe5c9dee1b2d2 = if (@sizeOf(usize) == 4) extern struct
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_1fdbe5c9dee1b2d2) != 136) @compileError("__AnonStruct_1fdbe5c9dee1b2d2 size mismatch");
+        if (@sizeOf(__AnonStruct_1fdbe5c9dee1b2d2) != 160) @compileError("__AnonStruct_1fdbe5c9dee1b2d2 size mismatch");
         if (@alignOf(__AnonStruct_1fdbe5c9dee1b2d2) != 8) @compileError("__AnonStruct_1fdbe5c9dee1b2d2 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_1fdbe5c9dee1b2d2) != 96) @compileError("__AnonStruct_1fdbe5c9dee1b2d2 size mismatch");
+        if (@sizeOf(__AnonStruct_1fdbe5c9dee1b2d2) != 112) @compileError("__AnonStruct_1fdbe5c9dee1b2d2 size mismatch");
         if (@alignOf(__AnonStruct_1fdbe5c9dee1b2d2) != 8) @compileError("__AnonStruct_1fdbe5c9dee1b2d2 alignment mismatch");
     }
 }
@@ -6914,65 +6922,6 @@ comptime {
     if (@sizeOf(usize) == 4) {
         if (@sizeOf(__AnonStruct_225d69ea1bc0e508) != 12) @compileError("__AnonStruct_225d69ea1bc0e508 size mismatch");
         if (@alignOf(__AnonStruct_225d69ea1bc0e508) != 4) @compileError("__AnonStruct_225d69ea1bc0e508 alignment mismatch");
-    }
-}
-
-/// Tag discriminant for DefaultFontOrLoadedFont.
-pub const DefaultFontOrLoadedFontTag = enum(u8) {
-    DefaultFont = 0,
-    LoadedFont = 1,
-};
-
-/// Payload union for DefaultFontOrLoadedFont.
-pub const DefaultFontOrLoadedFontPayload = extern union {
-    default_font: [0]u8,
-    loaded_font: *u64,
-};
-
-/// Tag union: DefaultFontOrLoadedFont
-pub const DefaultFontOrLoadedFont = if (@sizeOf(usize) == 4) extern struct {
-    payload: [4]u8 align(4),
-    tag: DefaultFontOrLoadedFontTag,
-    pub fn payload_loaded_font(self: *const @This()) *u64 {
-        const ptr: *const *u64 = @ptrCast(@alignCast(&self.payload));
-        return ptr.*;
-    }
-    /// Recursively decrement Roc-owned payloads.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        decrefDefaultFontOrLoadedFont(self, roc_host);
-    }
-
-    /// Increment Roc-owned payloads.
-    pub fn incref(self: @This(), amount: isize) void {
-        increfDefaultFontOrLoadedFont(self, amount);
-    }
-} else extern struct {
-    payload: DefaultFontOrLoadedFontPayload,
-    tag: DefaultFontOrLoadedFontTag,
-    pub fn payload_loaded_font(self: *const @This()) *u64 {
-        return self.payload.loaded_font;
-    }
-    /// Recursively decrement Roc-owned payloads.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        decrefDefaultFontOrLoadedFont(self, roc_host);
-    }
-
-    /// Increment Roc-owned payloads.
-    pub fn incref(self: @This(), amount: isize) void {
-        increfDefaultFontOrLoadedFont(self, amount);
-    }
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(DefaultFontOrLoadedFont) != 16) @compileError("DefaultFontOrLoadedFont size mismatch");
-        if (@alignOf(DefaultFontOrLoadedFont) != 8) @compileError("DefaultFontOrLoadedFont alignment mismatch");
-        if (@offsetOf(DefaultFontOrLoadedFont, "tag") != 8) @compileError("DefaultFontOrLoadedFont tag offset mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(DefaultFontOrLoadedFont) != 8) @compileError("DefaultFontOrLoadedFont size mismatch");
-        if (@alignOf(DefaultFontOrLoadedFont) != 4) @compileError("DefaultFontOrLoadedFont alignment mismatch");
-        if (@offsetOf(DefaultFontOrLoadedFont, "tag") != 4) @compileError("DefaultFontOrLoadedFont tag offset mismatch");
     }
 }
 
@@ -9385,10 +9334,10 @@ comptime {
 }
 
 /// Arguments for DrawHost.font_metrics!
-/// Roc signature: [DefaultFont, LoadedFont(Font.Resource)] => { base_size : F32, fallback_index : U64, glyphs : List({ advance_x : F32, codepoint : U32, height : F32, offset_x : F32, offset_y : F32, width : F32 }), line_spacing : F32 }
+/// Roc signature: Font.Handle => { base_size : F32, fallback_index : U64, glyphs : List({ advance_x : F32, codepoint : U32, height : F32, offset_x : F32, offset_y : F32, width : F32 }), line_spacing : F32 }
 /// Refcounted fields are owned by the hosted function.
 pub const DrawHostFont_metricsArgs = extern struct {
-    arg0: DefaultFontOrLoadedFont,
+    arg0: *u64,
 };
 
 /// Arguments for DrawHost.line!
@@ -9448,7 +9397,7 @@ comptime {
 }
 
 /// Arguments for DrawHost.load_font_bytes!
-/// Roc signature: { bytes : List(U8), format : U8, size : I32 } => { err : U8, font : Font.Resource }
+/// Roc signature: { bytes : List(U8), format : U8, size : I32 } => { err : U8, font : Font.Handle }
 /// Refcounted fields are owned by the hosted function.
 pub const DrawHostLoad_font_bytesArgs = if (@sizeOf(usize) == 4) extern struct {
     bytes: RocListWith(u8, false),
@@ -9494,7 +9443,7 @@ comptime {
 }
 
 /// Arguments for DrawHost.load_store_font!
-/// Roc signature: { path : Str, size : I32, store : Assets.Store } => { err : U8, font : Font.Resource }
+/// Roc signature: { path : Str, size : I32, store : Assets.Store } => { err : U8, font : Font.Handle }
 /// Refcounted fields are owned by the hosted function.
 pub const DrawHostLoad_store_fontArgs = if (@sizeOf(usize) == 4) extern struct {
     path: RocStr,
@@ -9544,53 +9493,53 @@ comptime {
 }
 
 /// Arguments for DrawHost.prepare_text!
-/// Roc signature: { font : [DefaultFont, LoadedFont(Font.Resource)], size : F32, spacing : F32, text : Str } => { err : U8, height : F32, prepared : DrawHost.PreparedText, width : F32 }
+/// Roc signature: { font : Font.Handle, size : F32, spacing : F32, text : Str } => { err : U8, height : F32, prepared : DrawHost.PreparedText, width : F32 }
 /// Refcounted fields are owned by the hosted function.
 pub const DrawHostPrepare_textArgs = if (@sizeOf(usize) == 4) extern struct {
-    font: DefaultFontOrLoadedFont,
+    font: *u64,
     text: RocStr,
     size: f32,
     spacing: f32,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        value.font.decref(roc_host);
+        decrefBoxWith(@ptrCast(value.font), @alignOf(u64), false, null, roc_host);
         value.text.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        value.font.incref(amount);
+        increfBox(@ptrCast(value.font), amount);
         value.text.incref(amount);
     }
 } else extern struct {
-    font: DefaultFontOrLoadedFont,
+    font: *u64,
     text: RocStr,
     size: f32,
     spacing: f32,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        value.font.decref(roc_host);
+        decrefBoxWith(@ptrCast(value.font), @alignOf(u64), false, null, roc_host);
         value.text.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        value.font.incref(amount);
+        increfBox(@ptrCast(value.font), amount);
         value.text.incref(amount);
     }
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(DrawHostPrepare_textArgs) != 48) @compileError("DrawHostPrepare_textArgs size mismatch");
+        if (@sizeOf(DrawHostPrepare_textArgs) != 40) @compileError("DrawHostPrepare_textArgs size mismatch");
         if (@alignOf(DrawHostPrepare_textArgs) != 8) @compileError("DrawHostPrepare_textArgs alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(DrawHostPrepare_textArgs) != 28) @compileError("DrawHostPrepare_textArgs size mismatch");
+        if (@sizeOf(DrawHostPrepare_textArgs) != 24) @compileError("DrawHostPrepare_textArgs size mismatch");
         if (@alignOf(DrawHostPrepare_textArgs) != 4) @compileError("DrawHostPrepare_textArgs alignment mismatch");
     }
 }
@@ -10072,10 +10021,10 @@ comptime {
 }
 
 /// Arguments for DrawHost.text_aligned!
-/// Roc signature: { align_x : F32, align_y : F32, color : Color.Rgba, font : [DefaultFont, LoadedFont(Font.Resource)], pos : Math.Vec2, size : F32, spacing : F32, text : Str } => {}
+/// Roc signature: { align_x : F32, align_y : F32, color : Color.Rgba, font : Font.Handle, pos : Math.Vec2, size : F32, spacing : F32, text : Str } => {}
 /// Refcounted fields are owned by the hosted function.
 pub const DrawHostText_alignedArgs = if (@sizeOf(usize) == 4) extern struct {
-    font: DefaultFontOrLoadedFont,
+    font: *u64,
     text: RocStr,
     align_x: f32,
     align_y: f32,
@@ -10086,7 +10035,7 @@ pub const DrawHostText_alignedArgs = if (@sizeOf(usize) == 4) extern struct {
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        value.font.decref(roc_host);
+        decrefBoxWith(@ptrCast(value.font), @alignOf(u64), false, null, roc_host);
         value.text.decref(roc_host);
         value.pos.decref(roc_host);
         value.color.decref(roc_host);
@@ -10095,13 +10044,13 @@ pub const DrawHostText_alignedArgs = if (@sizeOf(usize) == 4) extern struct {
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        value.font.incref(amount);
+        increfBox(@ptrCast(value.font), amount);
         value.text.incref(amount);
         value.pos.incref(amount);
         value.color.incref(amount);
     }
 } else extern struct {
-    font: DefaultFontOrLoadedFont,
+    font: *u64,
     text: RocStr,
     align_x: f32,
     align_y: f32,
@@ -10112,7 +10061,7 @@ pub const DrawHostText_alignedArgs = if (@sizeOf(usize) == 4) extern struct {
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        value.font.decref(roc_host);
+        decrefBoxWith(@ptrCast(value.font), @alignOf(u64), false, null, roc_host);
         value.text.decref(roc_host);
         value.pos.decref(roc_host);
         value.color.decref(roc_host);
@@ -10121,7 +10070,7 @@ pub const DrawHostText_alignedArgs = if (@sizeOf(usize) == 4) extern struct {
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        value.font.incref(amount);
+        increfBox(@ptrCast(value.font), amount);
         value.text.incref(amount);
         value.pos.incref(amount);
         value.color.incref(amount);
@@ -10130,20 +10079,20 @@ pub const DrawHostText_alignedArgs = if (@sizeOf(usize) == 4) extern struct {
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(DrawHostText_alignedArgs) != 72) @compileError("DrawHostText_alignedArgs size mismatch");
+        if (@sizeOf(DrawHostText_alignedArgs) != 64) @compileError("DrawHostText_alignedArgs size mismatch");
         if (@alignOf(DrawHostText_alignedArgs) != 8) @compileError("DrawHostText_alignedArgs alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(DrawHostText_alignedArgs) != 48) @compileError("DrawHostText_alignedArgs size mismatch");
+        if (@sizeOf(DrawHostText_alignedArgs) != 44) @compileError("DrawHostText_alignedArgs size mismatch");
         if (@alignOf(DrawHostText_alignedArgs) != 4) @compileError("DrawHostText_alignedArgs alignment mismatch");
     }
 }
 
 /// Arguments for DrawHost.text!
-/// Roc signature: { color : Color.Rgba, font : [DefaultFont, LoadedFont(Font.Resource)], pos : Math.Vec2, size : F32, spacing : F32, text : Str } => {}
+/// Roc signature: { color : Color.Rgba, font : Font.Handle, pos : Math.Vec2, size : F32, spacing : F32, text : Str } => {}
 /// Refcounted fields are owned by the hosted function.
 pub const DrawHostTextArgs = if (@sizeOf(usize) == 4) extern struct {
-    font: DefaultFontOrLoadedFont,
+    font: *u64,
     text: RocStr,
     pos: MathVec2,
     size: f32,
@@ -10152,7 +10101,7 @@ pub const DrawHostTextArgs = if (@sizeOf(usize) == 4) extern struct {
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        value.font.decref(roc_host);
+        decrefBoxWith(@ptrCast(value.font), @alignOf(u64), false, null, roc_host);
         value.text.decref(roc_host);
         value.pos.decref(roc_host);
         value.color.decref(roc_host);
@@ -10161,13 +10110,13 @@ pub const DrawHostTextArgs = if (@sizeOf(usize) == 4) extern struct {
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        value.font.incref(amount);
+        increfBox(@ptrCast(value.font), amount);
         value.text.incref(amount);
         value.pos.incref(amount);
         value.color.incref(amount);
     }
 } else extern struct {
-    font: DefaultFontOrLoadedFont,
+    font: *u64,
     text: RocStr,
     pos: MathVec2,
     size: f32,
@@ -10176,7 +10125,7 @@ pub const DrawHostTextArgs = if (@sizeOf(usize) == 4) extern struct {
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        value.font.decref(roc_host);
+        decrefBoxWith(@ptrCast(value.font), @alignOf(u64), false, null, roc_host);
         value.text.decref(roc_host);
         value.pos.decref(roc_host);
         value.color.decref(roc_host);
@@ -10185,7 +10134,7 @@ pub const DrawHostTextArgs = if (@sizeOf(usize) == 4) extern struct {
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        value.font.incref(amount);
+        increfBox(@ptrCast(value.font), amount);
         value.text.incref(amount);
         value.pos.incref(amount);
         value.color.incref(amount);
@@ -10194,11 +10143,11 @@ pub const DrawHostTextArgs = if (@sizeOf(usize) == 4) extern struct {
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(DrawHostTextArgs) != 64) @compileError("DrawHostTextArgs size mismatch");
+        if (@sizeOf(DrawHostTextArgs) != 56) @compileError("DrawHostTextArgs size mismatch");
         if (@alignOf(DrawHostTextArgs) != 8) @compileError("DrawHostTextArgs alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(DrawHostTextArgs) != 40) @compileError("DrawHostTextArgs size mismatch");
+        if (@sizeOf(DrawHostTextArgs) != 36) @compileError("DrawHostTextArgs size mismatch");
         if (@alignOf(DrawHostTextArgs) != 4) @compileError("DrawHostTextArgs alignment mismatch");
     }
 }
@@ -12375,30 +12324,6 @@ pub const __AnonStruct_a31979034eec4b2eRelease = struct {
     }
 };
 
-fn decrefDefaultFontOrLoadedFont(value: DefaultFontOrLoadedFont, roc_host: *RocHost) void {
-    switch (value.tag) {
-        .DefaultFont => {},
-        .LoadedFont => {
-            decrefBoxWith(@ptrCast(value.payload_loaded_font()), @alignOf(u64), false, null, roc_host);
-        },
-    }
-}
-
-fn increfDefaultFontOrLoadedFont(value: DefaultFontOrLoadedFont, amount: isize) void {
-    switch (value.tag) {
-        .DefaultFont => {},
-        .LoadedFont => {
-            increfBox(@ptrCast(value.payload_loaded_font()), amount);
-        },
-    }
-}
-
-pub const DefaultFontOrLoadedFontRelease = struct {
-    pub fn release(value: DefaultFontOrLoadedFont, roc_host: *RocHost) void {
-        value.decref(roc_host);
-    }
-};
-
 pub const __AnonStruct_473ae8de77ee164bRelease = struct {
     pub fn release(value: __AnonStruct_473ae8de77ee164b, roc_host: *RocHost) void {
         value.decref(roc_host);
@@ -13113,7 +13038,6 @@ fn rocReleasePolicy(comptime T: type) type {
     if (T == __AnonStruct_3e85b4e878c74d96) return __AnonStruct_3e85b4e878c74d96Release;
     if (T == __AnonStruct_2bfb89334ad27c35) return __AnonStruct_2bfb89334ad27c35Release;
     if (T == RocListWith(__AnonStruct_a31979034eec4b2e, false)) return RocListSpineRelease(RocListWith(__AnonStruct_a31979034eec4b2e, false));
-    if (T == DefaultFontOrLoadedFont) return DefaultFontOrLoadedFontRelease;
     if (T == __AnonStruct_2a39039201b5023d) return __AnonStruct_2a39039201b5023dRelease;
     if (T == __AnonStruct_e7f1bd6203d0f761) return __AnonStruct_e7f1bd6203d0f761Release;
     if (T == __AnonStruct_6bff15fb6a4cb85a) return __AnonStruct_6bff15fb6a4cb85aRelease;
@@ -13487,13 +13411,23 @@ pub extern fn roc_draw_end_scissor_raw() callconv(.c) void;
 /// Roc signature: { color : Color.Rgba, pos : Math.Vec2, size : F32 } => {}
 pub extern fn roc_draw_fps(arg0: DrawHostFpsArgs) callconv(.c) void;
 
+/// Hosted symbol for DrawHost.default_font!
+/// Roc signature: {} => Font.Handle
+/// The result is owned by Roc: return exactly one owned reference.
+pub extern fn roc_draw_default_font_raw() callconv(.c) *u64;
+
+/// Hosted symbol for DrawHost.startup_default_font!
+/// Roc signature: {} => { err : U8, font : Font.Handle }
+/// The result is owned by Roc: return exactly one owned reference.
+pub extern fn roc_draw_startup_default_font_raw() callconv(.c) DrawHostLoad_font_bytesRetRecord;
+
 /// Hosted symbol for DrawHost.font_metrics!
-/// Roc signature: [DefaultFont, LoadedFont(Font.Resource)] => { base_size : F32, fallback_index : U64, glyphs : List({ advance_x : F32, codepoint : U32, height : F32, offset_x : F32, offset_y : F32, width : F32 }), line_spacing : F32 }
+/// Roc signature: Font.Handle => { base_size : F32, fallback_index : U64, glyphs : List({ advance_x : F32, codepoint : U32, height : F32, offset_x : F32, offset_y : F32, width : F32 }), line_spacing : F32 }
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_draw_font_metrics_raw(arg0: DefaultFontOrLoadedFont) callconv(.c) __AnonStruct_2bfb89334ad27c35;
+pub extern fn roc_draw_font_metrics_raw(arg0: *u64) callconv(.c) __AnonStruct_2bfb89334ad27c35;
 
 /// Hosted symbol for DrawHost.frame_size!
 /// Roc signature: {} => { height : F32, width : F32 }
@@ -13504,7 +13438,7 @@ pub extern fn roc_draw_frame_size() callconv(.c) __AnonStruct_473ae8de77ee164b;
 pub extern fn roc_draw_line_raw(arg0: DrawHostLineArgs) callconv(.c) void;
 
 /// Hosted symbol for DrawHost.load_font_bytes!
-/// Roc signature: { bytes : List(U8), format : U8, size : I32 } => { err : U8, font : Font.Resource }
+/// Roc signature: { bytes : List(U8), format : U8, size : I32 } => { err : U8, font : Font.Handle }
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
@@ -13512,7 +13446,7 @@ pub extern fn roc_draw_line_raw(arg0: DrawHostLineArgs) callconv(.c) void;
 pub extern fn roc_draw_load_font_bytes_raw(arg0: DrawHostLoad_font_bytesArgs) callconv(.c) __AnonStruct_83bbf23095f15134;
 
 /// Hosted symbol for DrawHost.load_store_font!
-/// Roc signature: { path : Str, size : I32, store : Assets.Store } => { err : U8, font : Font.Resource }
+/// Roc signature: { path : Str, size : I32, store : Assets.Store } => { err : U8, font : Font.Handle }
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
@@ -13520,7 +13454,7 @@ pub extern fn roc_draw_load_font_bytes_raw(arg0: DrawHostLoad_font_bytesArgs) ca
 pub extern fn roc_draw_load_store_font_raw(arg0: DrawHostLoad_store_fontArgs) callconv(.c) __AnonStruct_83bbf23095f15134;
 
 /// Hosted symbol for DrawHost.prepare_text!
-/// Roc signature: { font : [DefaultFont, LoadedFont(Font.Resource)], size : F32, spacing : F32, text : Str } => { err : U8, height : F32, prepared : DrawHost.PreparedText, width : F32 }
+/// Roc signature: { font : Font.Handle, size : F32, spacing : F32, text : Str } => { err : U8, height : F32, prepared : DrawHost.PreparedText, width : F32 }
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
@@ -13573,14 +13507,14 @@ pub extern fn roc_draw_rounded_rectangle_lines_raw(arg0: DrawHostRounded_rectang
 pub extern fn roc_draw_rounded_rectangle_raw(arg0: DrawHostRounded_rectangleArgs) callconv(.c) void;
 
 /// Hosted symbol for DrawHost.text_aligned!
-/// Roc signature: { align_x : F32, align_y : F32, color : Color.Rgba, font : [DefaultFont, LoadedFont(Font.Resource)], pos : Math.Vec2, size : F32, spacing : F32, text : Str } => {}
+/// Roc signature: { align_x : F32, align_y : F32, color : Color.Rgba, font : Font.Handle, pos : Math.Vec2, size : F32, spacing : F32, text : Str } => {}
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
 pub extern fn roc_draw_text_aligned_raw(arg0: DrawHostText_alignedArgs) callconv(.c) void;
 
 /// Hosted symbol for DrawHost.text!
-/// Roc signature: { color : Color.Rgba, font : [DefaultFont, LoadedFont(Font.Resource)], pos : Math.Vec2, size : F32, spacing : F32, text : Str } => {}
+/// Roc signature: { color : Color.Rgba, font : Font.Handle, pos : Math.Vec2, size : F32, spacing : F32, text : Str } => {}
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);

--- a/test/asset_store_compile.roc
+++ b/test/asset_store_compile.roc
@@ -6,8 +6,9 @@ app [Model, program] {
 import rr.App
 import rr.Assets
 import rr.Draw
+import rr.Text
 
-Model : { store : Assets.Store, texture : Assets.Texture, font : Draw.Font, shader : Draw.Shader }
+Model : { store : Assets.Store, texture : Assets.Texture, font : Text.Font, shader : Draw.Shader }
 
 program = { init!, update!, render! }
 

--- a/test/compile_fail/font_handle_manufacture.roc
+++ b/test/compile_fail/font_handle_manufacture.roc
@@ -21,15 +21,9 @@ init! : App.Init(Model, [])
 init! = App.init(
 	App.default,
 	|_startup| {
-		resource = Font.Resource.(Box.box(0))
+		handle = Font.Handle.(Box.box(0))
 		Ok({
-			font: {
-				handle: LoadedFont(resource),
-				base_size_value: 1,
-				line_spacing_value: 0,
-				fallback_index: 0,
-				glyph_values: [],
-			},
+			font: { ..Font.stub, handle },
 		})
 	},
 )

--- a/test/package_interop/README.md
+++ b/test/package_interop/README.md
@@ -5,8 +5,9 @@ that both the platform and reusable third-party packages depend on. Without
 this, any pure snapshot-to-framework translation is stuck inside the application,
 because a package cannot import from the app's chosen platform.
 
-The platform depends on `types/` and re-exports each moved module under the
-same name, so `exposes` and every existing app are unchanged.
+The platform depends on `types/` and transparently re-exports every companion
+nominal its public API mentions. Fonts are available as `Text.Font`; reusable
+packages name the identical value as `rrt.Font`.
 
 ## What moved, and what cannot
 

--- a/test/package_interop/app.roc
+++ b/test/package_interop/app.roc
@@ -24,7 +24,7 @@ Model : {
 	clicked : Bool,
 	padded : Bool,
 	age : F32,
-	font : Draw.Font,
+	font : Font,
 	layout : { label : Draw.TextSize, label_pos : { x : F32, y : F32 } },
 	layout_passes : U64,
 
@@ -74,7 +74,7 @@ init! = App.init(
 
 ## This is the UI package boundary: it names the types package's `Font`
 ## directly, so layout can run during update without host authority. The value
-## it is handed is a `Draw.Font` loaded through the platform, which compiles
+## it is handed is a `Font` loaded through the platform, which compiles
 ## only because the two are one nominal.
 solve_layout : Font, Str -> { label : Draw.TextSize, label_pos : { x : F32, y : F32 } }
 solve_layout = |font, label| {

--- a/types/App.roc
+++ b/types/App.roc
@@ -103,7 +103,7 @@ App := [].{
 		##
 		## Building the model this is called with is the other half: every host
 		## resource an app can hold has a resource-free `stub`
-		## (`Draw.Font.stub`, `Audio.Sound.stub`, `Text.Prepared.stub`,
+		## (`Text.font_stub`, `Audio.Sound.stub`, `Text.Prepared.stub`,
 		## `Assets.Texture.stub`, ...), so a `Model` full of assets can be written
 		## down in a pure test.
 		##

--- a/types/Font.roc
+++ b/types/Font.roc
@@ -1,34 +1,25 @@
 ## Font handles, metric snapshots, and pure text measurement.
 ##
-## `measure` follows the host renderer's layout rules without calling the host,
-## so packages and tests can calculate text bounds purely.
-##
-## `Font` pairs an opaque host handle with immutable scalar and glyph metrics.
-## Only the platform can load a live font; it re-exports this type as
-## `Draw.Font`.
+## A font pairs an opaque, reference-counted native resource identity with an
+## immutable scalar metric snapshot. Reusable packages can retain and measure
+## it without importing the platform or calling the host. The platform
+## re-exports this type as `Text.Font`.
 import unicode.Scalar
 
 Font := {
 	handle : Handle,
-	base_size_value : F32,
-	line_spacing_value : F32,
-	fallback_index : U64,
-	glyph_values : List(GlyphMetrics),
+	metrics : FontMetrics,
 }.{
 
-	## The native resource a loaded font holds.
-	##
-	## Opaque: only the host mints one, so a font value can be copied and
-	## measured but a handle cannot be forged from an integer.
-	Resource :: Box(U64).{
+	## Opaque native resource identity. Only a host can manufacture a live one,
+	## but applications can compare and hash handles they receive.
+	Handle :: Box(U64).{
+		is_eq : Handle, Handle -> Bool
+		is_eq = |Handle.(a), Handle.(b)| Box.unbox(a) == Box.unbox(b)
 
-		## The invalid token, as a resource-free handle. See `Font.stub`.
-		stub : Resource
-		stub = Resource.(Box.box(0))
+		to_hash : Handle, Hasher -> Hasher
+		to_hash = |Handle.(value), hasher| U64.to_hash(Box.unbox(value), hasher)
 	}
-
-	## Which font a value names: raylib's built-in one, or a loaded resource.
-	Handle : [DefaultFont, LoadedFont(Resource)]
 
 	## Scalar metrics for one glyph, in the atlas's own units.
 	GlyphMetrics : {
@@ -40,247 +31,250 @@ Font := {
 		height : F32,
 	}
 
-	## What to measure: the string, the size to draw it at, and the extra space
-	## between scalars.
+	## Immutable atlas and glyph metrics captured when a font is loaded.
+	FontMetrics : {
+		base_size : F32,
+		line_spacing : F32,
+		fallback_index : U64,
+		glyphs : List(GlyphMetrics),
+	}
+
+	## What to measure: text, draw size, and extra spacing between codepoints.
 	Measure : {
 		text : Str,
 		size : F32,
 		spacing : F32,
 	}
 
-	## Text measurement result, in the units the size was given in.
+	## Text measurement result, in the units the requested size was given in.
 	Size : {
 		width : F32,
 		height : F32,
 	}
 
-	## The pixel size this font's glyph atlas was rasterized at.
+	## Resource-free synthetic monospace font for pure layout tests.
 	##
-	## Drawing at this size is one atlas texel per screen pixel. Drawing much
-	## larger scales the atlas up rather than re-rasterizing, so load the
-	## font again at the size wanted instead.
-	base_size : Font -> F32
-	base_size = |font| font.base_size_value
-
-	## Extra vertical space between lines, on top of the drawn size. Adding
-	## it to the text size is the distance from one baseline to the next.
-	line_spacing : Font -> F32
-	line_spacing = |font| font.line_spacing_value
-
-	## Every glyph the font rasterized, with its advance and its box. This is
-	## the table `measure` walks; an app rarely needs it directly.
-	glyphs : Font -> List(GlyphMetrics)
-	glyphs = |font| font.glyph_values
-
-	## Where a codepoint sits in `glyphs`, or the fallback glyph's index when
-	## the font has no glyph for it. Answers an index rather than a `Try`, so
-	## measurement stays total.
-	get_glyph_index : Font, U32 -> U64
-	get_glyph_index = |font, codepoint|
-		glyph_index(font.glyph_values, codepoint, 0, List.len(font.glyph_values), font.fallback_index)
-
-	## Measure a valid Roc string against this font's metric snapshot.
-	##
-	## Pure: it reads the snapshot taken when the font loaded and never calls
-	## the host, so a layout pass can run in `update!`, in a helper, or in an
-	## `expect`. The platform's `Text` is the fuller interface built on it.
-	##
-	## This follows raylib 6 `MeasureTextEx`: embedded NUL ends the input,
-	## newline advances by font size plus line spacing, missing codepoints use
-	## the fallback glyph, and spacing counts Unicode scalars.
-	measure : Font, Measure -> Size
-	measure = |font, cfg| {
-		state = {
-			line_width: 0,
-			widest_width: 0,
-			line_count: 0,
-			widest_count: 0,
-			height: cfg.size,
-			seen: Bool.False,
-		}
-		# TODO(compiler): the fold takes the scalar metrics rather than the
-		# `Font` itself. Passing the whole value into the recursion, while also
-		# reading its glyph list, makes the compiler's ARC certification panic
-		# with "consumed partially dismantled local" on the refcounted handle
-		# field. The metrics are all the fold reads anyway; restore the direct
-		# `Font` argument once that is fixed.
-		metrics = {
-			base_size: font.base_size_value,
-			line_spacing: font.line_spacing_value,
-			fallback_index: font.fallback_index,
-		}
-		measure_scalars(metrics, cfg, font.glyph_values, Scalar.iter(cfg.text), state)
-	}
-
-	## Resource-free font value for pure tests.
-	##
-	## The handle never resolves to a host resource, so every host path it
-	## reaches treats it as an invalid one: drawing falls back to raylib's
-	## built-in font, and the platform's `Text.prepare!` refuses it. Its metric
-	## snapshot is a fiction rather than a measurement -- no glyphs, no line
-	## spacing, and a `base_size` of 1 so that `measure` stays finite instead of
-	## dividing by zero. Put it in a model to reach the app's real `update!`
-	## from an `expect`. Do not use it to test drawing, layout, or resource
-	## lifetime.
+	## Its handle never resolves to a host resource, so drawing falls back to
+	## the platform's built-in font. One fallback glyph advances one unit at a
+	## base size of one, making measurements deterministic. Do not use it to
+	## test drawing, loading, resource lifetime, or rasterized-font parity.
 	stub : Font
 	stub = {
-		handle: LoadedFont(Resource.stub),
-		base_size_value: 1,
-		line_spacing_value: 0,
-		fallback_index: 0,
-		glyph_values: [],
+		handle: Handle.(Box.box(U64.highest)),
+		metrics: {
+			base_size: 1,
+			line_spacing: 0,
+			fallback_index: 0,
+			glyphs: [{ codepoint: 0, advance_x: 1, offset_x: 0, offset_y: 0, width: 1, height: 1 }],
+		},
 	}
-}
 
-## The scalar metrics `measure` reads, without the handle beside them.
-Metrics : {
-	base_size : F32,
-	line_spacing : F32,
-	fallback_index : U64,
-}
-
-## The running line, the widest line seen, and the height accumulated so far.
-MeasureState : {
-	line_width : F32,
-	widest_width : F32,
-	line_count : U64,
-	widest_count : U64,
-	height : F32,
-	seen : Bool,
-}
-
-## One step of `measure`, folding the next Unicode scalar into the running
-## line and answering the finished `Size` when the string runs out.
-measure_scalars : Metrics, Font.Measure, List(Font.GlyphMetrics), Iter(Scalar.LocatedScalar), MeasureState -> Font.Size
-measure_scalars = |metrics, cfg, glyphs, scalars, state| {
-	match Iter.next(scalars) {
-		Done => finish(metrics, cfg, state)
-		Skip({ rest }) => measure_scalars(metrics, cfg, glyphs, rest, state)
-		One({ item, rest }) => {
-			codepoint = item.scalar.to_u32()
-			if codepoint == 0 {
-				finish(metrics, cfg, state)
-			} else if codepoint == 10 {
-				measure_scalars(
-					metrics,
-					cfg,
-					glyphs,
-					rest,
-					{
-						line_width: 0,
-						widest_width: max_f32(state.widest_width, state.line_width),
-						line_count: 0,
-						widest_count: max_u64(state.widest_count, state.line_count),
-						height: state.height + cfg.size + metrics.line_spacing,
-						seen: Bool.True,
-					},
-				)
-			} else {
-				index = glyph_index(glyphs, codepoint, 0, List.len(glyphs), metrics.fallback_index)
-				advance = match List.get(glyphs, index) {
-					Ok(glyph) => if glyph.advance_x > 0 glyph.advance_x else glyph.width + glyph.offset_x
-					Err(_) => 0
-				}
-				measure_scalars(
-					metrics,
-					cfg,
-					glyphs,
-					rest,
-					{ ..state, line_width: state.line_width + advance, line_count: state.line_count + 1, seen: Bool.True },
-				)
+	## Measure a valid Roc string against the font's immutable metric snapshot.
+	##
+	## Pure: this never calls the host, so layout can run in `update!`, in a
+	## package, or in an `expect`. Newlines advance by the requested size plus
+	## line spacing, missing codepoints use the fallback glyph, and spacing
+	## counts Unicode codepoints. U+0000 is an ordinary Roc string codepoint.
+	measure : Font, Measure -> Size
+	measure = |font, { text, size, spacing }| {
+		if Str.is_empty(text) {
+			{ width: 0, height: 0 }
+		} else {
+			var $state = {
+				# Codepoint count on the current line.
+				line_count: 0,
+				# Unscaled glyph-advance total for the current line.
+				line_width: 0,
+				# Greatest codepoint count among completed lines.
+				widest_count: 0,
+				# Greatest unscaled width among completed lines.
+				widest_width: 0,
+				# Accumulated height across all lines.
+				height: size,
+			}
+			$state = text_codepoints(text).fold(
+				$state,
+				|current, codepoint| {
+					if codepoint == 10 {
+						# Line Feed ("\n"):
+						# - Width preserves the widest completed line.
+						# - Height increases by font size plus line spacing.
+						{
+							line_width: 0,
+							widest_width: max_f32(current.widest_width, current.line_width),
+							line_count: 0,
+							widest_count: max_u64(current.widest_count, current.line_count),
+							height: current.height + size + font.metrics.line_spacing,
+						}
+					} else {
+						# Other codepoints:
+						# - width: accumulates glyph advance (use the fallback for a missing glyph).
+						# - height: unchanged.
+						glyph_result = match binary_search_by(font.metrics.glyphs, codepoint, |glyph| glyph.codepoint) {
+							Ok(found) => Ok(found)
+							Err(NotFound) => List.get(font.metrics.glyphs, font.metrics.fallback_index)
+						}
+						advance_x = match glyph_result {
+							Ok(glyph) => if glyph.advance_x > 0 glyph.advance_x else glyph.width + glyph.offset_x
+							Err(_) => 0
+						}
+						{ ..current, line_width: current.line_width + advance_x, line_count: current.line_count + 1 }
+					}
+				},
+			)
+			# Finalize width/height:
+			# - width: scale the widest line and add spacing from the greatest line count.
+			# - height: use the accumulated line height.
+			width = max_f32($state.widest_width, $state.line_width)
+			count = max_u64($state.widest_count, $state.line_count)
+			spacing_width = if count > 0 (U64.to_f32(count) - 1) * spacing else 0
+			{
+				width: width * (size / font.metrics.base_size) + spacing_width,
+				height: $state.height,
 			}
 		}
 	}
 }
 
-## Turn `measure`'s accumulated state into the `Size` it answers with, once
-## every scalar has been folded in.
-finish : Metrics, Font.Measure, MeasureState -> Font.Size
-finish = |metrics, cfg, state| {
-	if !state.seen {
-		{ width: 0, height: 0 }
+## Iterate over the Unicode codepoints in a valid Roc string.
+text_codepoints : Str -> Iter(U32)
+text_codepoints = |text| Scalar.iter(text).map(|located| located.scalar.to_u32())
+
+## Iterate over bytes as codepoints when the text is known to be ASCII.
+text_codepoints_ascii : Str -> Iter(U32)
+text_codepoints_ascii = |text| Str.to_utf8(text).iter().map(|byte| byte.to_u32())
+
+binary_search_by : List(a), key, (a -> key) -> Try(a, [NotFound]) where [key.is_eq : key, key -> Bool, key.is_lt : key, key -> Bool]
+binary_search_by = |items, needle, key_of| binary_search_range(items, needle, key_of, 0, List.len(items))
+
+binary_search_range : List(a), key, (a -> key), U64, U64 -> Try(a, [NotFound]) where [key.is_eq : key, key -> Bool, key.is_lt : key, key -> Bool]
+binary_search_range = |items, needle, key_of, low, high| {
+	if low >= high {
+		Err(NotFound)
 	} else {
-		width = max_f32(state.widest_width, state.line_width)
-		count = max_u64(state.widest_count, state.line_count)
-		spacing_width = if count > 0 (U64.to_f32(count) - 1) * cfg.spacing else 0
-		{
-			width: width * (cfg.size / metrics.base_size) + spacing_width,
-			height: state.height,
+		middle = low + (high - low) / 2
+		match List.get(items, middle) {
+			Err(_) => Err(NotFound)
+			Ok(item) => {
+				key = key_of(item)
+				if key.is_eq(needle) {
+					Ok(item)
+				} else if key.is_lt(needle) {
+					binary_search_range(items, needle, key_of, middle + 1, high)
+				} else {
+					binary_search_range(items, needle, key_of, low, middle)
+				}
+			}
 		}
 	}
 }
 
-## The larger of two `F32` values, used to keep the widest line seen so far.
 max_f32 : F32, F32 -> F32
 max_f32 = |a, b| if a > b a else b
 
-## The larger of two `U64` values, used to keep the longest line seen so far.
 max_u64 : U64, U64 -> U64
 max_u64 = |a, b| if a > b a else b
 
-## Binary search the glyph table, which the host builds sorted by codepoint.
-##
-## Answers the fallback index rather than a `Try` for a codepoint the font has
-## no glyph for, which is what keeps `measure` total.
-glyph_index : List(Font.GlyphMetrics), U32, U64, U64, U64 -> U64
-glyph_index = |glyphs, codepoint, start, end, fallback| {
-	if start >= end {
-		fallback
-	} else {
-		middle = start + (end - start) / 2
-		match List.get(glyphs, middle) {
-			Err(_) => fallback
-			Ok(glyph) => if glyph.codepoint == codepoint {
-				middle
-			} else if codepoint < glyph.codepoint {
-				glyph_index(glyphs, codepoint, start, middle, fallback)
-			} else {
-				glyph_index(glyphs, codepoint, middle + 1, end, fallback)
+iterator_done : Iter(a) -> Bool
+iterator_done = |iter| match Iter.next(iter) {
+	Done => Bool.True
+	_ => Bool.False
+}
+
+test_font : Font
+test_font = {
+	handle: Font.stub.handle,
+	metrics: {
+		base_size: 10,
+		line_spacing: 3,
+		fallback_index: 0,
+		glyphs: [
+			{ codepoint: 0, advance_x: 5, offset_x: 0, offset_y: 0, width: 5, height: 10 }, # "\u(0000)"
+			{ codepoint: 97, advance_x: 10, offset_x: 0, offset_y: 0, width: 10, height: 10 }, # "a"
+			{ codepoint: 98, advance_x: 4, offset_x: 0, offset_y: 0, width: 4, height: 10 }, # "b"
+			{ codepoint: 99, advance_x: 4, offset_x: 0, offset_y: 0, width: 4, height: 10 }, # "c"
+			{ codepoint: 122, advance_x: 0, offset_x: 2, offset_y: 0, width: 6, height: 10 }, # "z"
+		],
+	},
+}
+
+# Font.measure
+
+# Empty text has no bounds, regardless of requested size or spacing.
+expect Font.stub.measure({ text: "", size: 20, spacing: 1 }) == { width: 0, height: 0 }
+
+# The synthetic fallback advances once per codepoint and spaces adjacent codepoints.
+expect Font.stub.measure({ text: "abc", size: 20, spacing: 1 }) == { width: 62, height: 20 }
+
+# A newline starts another font-sized line without contributing horizontal advance.
+expect Font.stub.measure({ text: "a\nb", size: 20, spacing: 0 }) == { width: 20, height: 40 }
+
+# Raylib combines the greatest glyph width and greatest codepoint count across lines.
+expect test_font.measure({ text: "a\nbc", size: 10, spacing: 3 }) == { width: 13, height: 23 }
+
+# A present glyph is selected by codepoint while an absent glyph uses the fallback.
+expect test_font.measure({ text: "a?", size: 10, spacing: 0 }) == { width: 15, height: 10 }
+
+# A zero glyph advance falls back to glyph width plus horizontal offset.
+expect test_font.measure({ text: "z", size: 10, spacing: 0 }) == { width: 8, height: 10 }
+
+# Glyph advances scale from the font's base size before spacing is added.
+expect test_font.measure({ text: "ab", size: 20, spacing: 3 }) == { width: 31, height: 20 }
+
+# A leading newline includes an empty first line and configured line spacing.
+expect test_font.measure({ text: "\na", size: 10, spacing: 0 }) == { width: 10, height: 23 }
+
+# A trailing newline includes an empty final line and configured line spacing.
+expect test_font.measure({ text: "a\n", size: 10, spacing: 0 }) == { width: 10, height: 23 }
+
+# Consecutive newlines include every intervening empty line.
+expect test_font.measure({ text: "a\n\nb", size: 10, spacing: 0 }) == { width: 10, height: 36 }
+
+# A multibyte Unicode scalar is measured as one missing codepoint, not UTF-8 bytes.
+expect test_font.measure({ text: "é", size: 10, spacing: 2 }) == { width: 5, height: 10 }
+
+# text_codepoints
+
+# A multibyte UTF-8 sequence produces one Unicode codepoint.
+expect match Iter.next(text_codepoints("é")) {
+	One({ item, rest }) => item == 233 and iterator_done(rest)
+	_ => Bool.False
+}
+
+# U+0000 is an ordinary Roc string codepoint rather than a terminator.
+expect match Iter.next(text_codepoints("a\u(0000)b")) {
+	One({ item, rest }) =>
+		item == 97 and match Iter.next(rest) {
+			One({ item: nul, rest: after_nul }) => nul == 0 and match Iter.next(after_nul) {
+				One({ item: final, rest: done }) => final == 98 and iterator_done(done)
+				_ => Bool.False
 			}
+			_ => Bool.False
 		}
-	}
+	_ => Bool.False
 }
 
-## A synthetic font, which is what a layout package's own tests are written
-## against: real-looking metrics, no host, and a handle that resolves to
-## nothing.
-sample : Font
-sample = {
-	handle: DefaultFont,
-	base_size_value: 10,
-	line_spacing_value: 2,
-	fallback_index: 0,
-	glyph_values: [
-		{ codepoint: 32, advance_x: 4, offset_x: 0, offset_y: 0, width: 0, height: 0 },
-		{ codepoint: 97, advance_x: 6, offset_x: 0, offset_y: 0, width: 5, height: 7 },
-		{ codepoint: 98, advance_x: 8, offset_x: 0, offset_y: 0, width: 7, height: 7 },
-	],
+# text_codepoints_ascii
+
+# Known ASCII text can be iterated directly from its UTF-8 bytes.
+expect match Iter.next(text_codepoints_ascii("A\n")) {
+	One({ item, rest }) =>
+		item == 65 and match Iter.next(rest) {
+			One({ item: newline, rest: done }) => newline == 10 and iterator_done(done)
+			_ => Bool.False
+		}
+	_ => Bool.False
 }
 
-expect Font.base_size(Font.stub) == 1
-expect Font.line_spacing(Font.stub) == 0
-expect List.is_empty(Font.glyphs(Font.stub))
+# binary_search_by
 
-## A font with no glyphs measures every string as zero-wide. The height is the
-## requested size because that is one line of it, and the `base_size` of 1 is
-## what keeps the scale factor finite rather than dividing by zero.
-expect Font.measure(Font.stub, { text: "", size: 20, spacing: 1 }) == { width: 0, height: 0 }
-expect Font.measure(Font.stub, { text: "inert", size: 20, spacing: 0 }) == { width: 0, height: 20 }
+# A sorted collection returns the element whose extracted key matches.
+expect binary_search_by([{ key: 1 }, { key: 3 }, { key: 5 }], 3, |item| item.key) == Ok({ key: 3 })
 
-## The glyph table is searched by codepoint, and a codepoint the font does not
-## have measures as the fallback glyph rather than as an error.
-expect Font.get_glyph_index(sample, 97) == 1
-expect Font.get_glyph_index(sample, 98) == 2
-expect Font.get_glyph_index(sample, 9731) == 0
+# A key absent from a sorted collection reports NotFound.
+expect binary_search_by([{ key: 1 }, { key: 3 }, { key: 5 }], 4, |item| item.key) == Err(NotFound)
 
-## Drawn at the atlas's own base size, a string is exactly the sum of its
-## advances plus one gap per pair of scalars.
-expect Font.measure(sample, { text: "ab", size: 10, spacing: 0 }) == { width: 14, height: 10 }
-expect Font.measure(sample, { text: "ab", size: 10, spacing: 3 }) == { width: 17, height: 10 }
+# Font.Handle
 
-## Drawn at twice the base size, the advances scale but the spacing does not.
-expect Font.measure(sample, { text: "ab", size: 20, spacing: 0 }) == { width: 28, height: 20 }
-
-## A newline starts a second line: the width is the widest of the two, and the
-## height is two sizes plus one line spacing.
-expect Font.measure(sample, { text: "a\nab", size: 10, spacing: 0 }) == { width: 14, height: 22 }
+# Handle equality and hashing support keyed collections.
+expect Dict.single(Font.stub.handle, 42).get(Font.stub.handle) == Ok(42)

--- a/types/Texture.roc
+++ b/types/Texture.roc
@@ -8,7 +8,13 @@ Texture := {
 	width : F32,
 	height : F32,
 }.{
-	Handle :: Box(U64)
+	Handle :: Box(U64).{
+		is_eq : Handle, Handle -> Bool
+		is_eq = |Handle.(a), Handle.(b)| Box.unbox(a) == Box.unbox(b)
+
+		to_hash : Handle, Hasher -> Hasher
+		to_hash = |Handle.(value), hasher| U64.to_hash(Box.unbox(value), hasher)
+	}
 
 	## Resource-free texture value for pure tests.
 	##

--- a/types/Texture.roc
+++ b/types/Texture.roc
@@ -17,7 +17,7 @@ Texture := {
 	## sampling configuration, or resource lifetime.
 	stub : Texture
 	stub = {
-		handle: Handle.(Box.box(0)),
+		handle: Handle.(Box.box(U64.highest)),
 		width: 0,
 		height: 0,
 	}


### PR DESCRIPTION
# Share fonts across the platform and reusable packages

# Motivation

Reusable packages had to make their APIs generic over a `font.Measureable` interface because
the concrete font type was platform-private. Fonts are now shared resources (like `Texture`), so a
single concrete type is simpler to store, pass, and measure across package
boundaries.

## Summary

- Replace `Draw.Font` with a shared `Font` value containing an opaque handle and
  immutable metrics, re-exported by the platform as `Text.Font`.
- Support pure text measurement from both platform applications and reusable
  packages.
- Add `App.Config.with_default_font` and `Startup.default_font!` to load a
  configured font once during startup, or return the built-in font by default. Replaces `[LoadedFont(Font), DefaultFont]`
  ```
  init! = {
      config: App.default.with_default_font({ path: "assets/body.ttf", size: 32 })
      run! : |startup| {
           {
              font: startup.default_font!()?
           }
      }
  }
  ```
- Reserve font token `0` for the built-in font and use `U64.highest` as the
  invalid token for every resource (Font, Texture, Shader, Store, etc.).
- Update the native host, ABI, examples, and tests for the shared font model.

## Validation

- Platform and native test suites pass.
- Graphical smoke tests cover font measurement parity.
