### PR TITLE
Free Draw from text alignment

### DIFF
--- a/.types-version
+++ b/.types-version
@@ -7,4 +7,4 @@
 #
 # Produced by .github/workflows/release-types.yml. Empty until the first
 # roc-ray-types release is cut.
-https://github.com/lukewilliamboswell/roc-ray/releases/download/types-0.7.0/DWjJtKpk4QZWZcuafPm7gg9WGLxaeS1hetkYZMeboWQE.tar.zst
+https://github.com/lukewilliamboswell/roc-ray/releases/download/types-0.8.0/3akQjTNsQGrAM5WP6Q2t1wHfPYitrMH1EHZ4dK7F4mHX.tar.zst

--- a/examples/async_read/main.roc
+++ b/examples/async_read/main.roc
@@ -162,15 +162,15 @@ expect
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])
 render! = |model, frame| {
 	size = draw_backdrop!(frame)
-	model.title.draw!(frame, { pos: { x: 44, y: 40 }, color: ink, align: Text.align_top_left })
-	model.subtitle.draw!(frame, { pos: { x: 44, y: 76 }, color: muted, align: Text.align_top_left })
+	model.title.draw!(frame, { pos: { x: 44, y: 40 }, color: ink })
+	model.subtitle.draw!(frame, { pos: { x: 44, y: 76 }, color: muted })
 
 	card_width = size.width - 88
 	draw_row!(frame, { y: 128, width: card_width, accent: accent_read, label: "Files.read_text!", path: small_path, phase: string_phase(model.small), value: describe_string(model.small), elapsed: model.elapsed })
 	draw_row!(frame, { y: 216, width: card_width, accent: accent_bytes, label: "Files.read_bytes!", path: large_path, phase: bytes_phase(model.large), value: describe_bytes(model.large), elapsed: model.elapsed })
 	draw_row!(frame, { y: 304, width: card_width, accent: accent_meta, label: "Files.metadata!", path: small_path, phase: meta_phase(model.meta), value: describe_meta(model.meta), elapsed: model.elapsed })
 
-	model.hint.draw!(frame, { pos: { x: 44, y: size.height - 40 }, color: faint, align: Text.align_top_left })
+	model.hint.draw!(frame, { pos: { x: 44, y: size.height - 40 }, color: faint })
 	Ok({})
 }
 

--- a/examples/breakout/main.roc
+++ b/examples/breakout/main.roc
@@ -590,8 +590,8 @@ draw_bodies! = |frame, game| {
 draw_hud! : Draw.Frame, Model => {}
 draw_hud! = |frame, model| {
 	model.title.draw!(frame, { pos: { x: 44, y: 22 }, color: paddle_neon, align: Text.align_top_left })
-	frame.text!({ pos: { x: 330, y: 26 }, text: "SCORE ${U64.to_str(model.game.score)}", size: 22, spacing: Draw.default_spacing, color: hud_color, font: model.font, align: Draw.align_top_left })
-	frame.text!({ pos: { x: 560, y: 26 }, text: "LIVES ${U64.to_str(model.game.lives)}", size: 22, spacing: Draw.default_spacing, color: hud_color, font: model.font, align: Draw.align_top_left })
+	frame.text!({ pos: { x: 330, y: 26 }, text: "SCORE ${U64.to_str(model.game.score)}", size: 22, spacing: Draw.default_spacing, color: hud_color, font: model.font })
+	frame.text!({ pos: { x: 560, y: 26 }, text: "LIVES ${U64.to_str(model.game.lives)}", size: 22, spacing: Draw.default_spacing, color: hud_color, font: model.font })
 	if model.demo {} else frame.fps!({ pos: { x: 730, y: 28 }, size: 18, color: hint_color })
 	frame.line!({ start: { x: 44, y: top_wall_y }, end: { x: screen_w - 44, y: top_wall_y }, stroke: Draw.stroke(Color.from_hex_rgb(0x2a3566), 2) })
 	model.hint.draw!(frame, { pos: { x: screen_w * 0.5, y: screen_h - 20 }, color: hint_color, align: Text.align_center })

--- a/examples/breakout/main.roc
+++ b/examples/breakout/main.roc
@@ -589,12 +589,12 @@ draw_bodies! = |frame, game| {
 
 draw_hud! : Draw.Frame, Model => {}
 draw_hud! = |frame, model| {
-	model.title.draw!(frame, { pos: { x: 44, y: 22 }, color: paddle_neon, align: Text.align_top_left })
+	model.title.draw!(frame, { pos: { x: 44, y: 22 }, color: paddle_neon })
 	frame.text!({ pos: { x: 330, y: 26 }, text: "SCORE ${U64.to_str(model.game.score)}", size: 22, spacing: Draw.default_spacing, color: hud_color, font: model.font })
 	frame.text!({ pos: { x: 560, y: 26 }, text: "LIVES ${U64.to_str(model.game.lives)}", size: 22, spacing: Draw.default_spacing, color: hud_color, font: model.font })
 	if model.demo {} else frame.fps!({ pos: { x: 730, y: 28 }, size: 18, color: hint_color })
 	frame.line!({ start: { x: 44, y: top_wall_y }, end: { x: screen_w - 44, y: top_wall_y }, stroke: Draw.stroke(Color.from_hex_rgb(0x2a3566), 2) })
-	model.hint.draw!(frame, { pos: { x: screen_w * 0.5, y: screen_h - 20 }, color: hint_color, align: Text.align_center })
+	model.hint.draw!(frame, { pos: { x: screen_w * 0.5, y: screen_h - 20 }, color: hint_color, align: (Middle, Center) })
 }
 
 # A prompt that fades in and out on its own clock, so a waiting screen still has
@@ -606,7 +606,7 @@ draw_state_overlay! : Draw.Frame, Model => {}
 draw_state_overlay! = |frame, model|
 	match model.game.state {
 		Ready =>
-			model.launch_line.draw!(frame, { pos: { x: screen_w * 0.5, y: 350 }, color: Color.with_alpha(hud_color, prompt_alpha(model)), align: Text.align_center })
+			model.launch_line.draw!(frame, { pos: { x: screen_w * 0.5, y: 350 }, color: Color.with_alpha(hud_color, prompt_alpha(model)), align: (Middle, Center) })
 		Playing => {}
 		Won => draw_banner!(frame, model, model.won_line, Color.from_hex_rgb(0x4ce0b3))
 		GameOver => draw_banner!(frame, model, model.over_line, Color.from_hex_rgb(0xff4f7d))
@@ -615,6 +615,6 @@ draw_state_overlay! = |frame, model|
 draw_banner! : Draw.Frame, Model, Text.Prepared, Color.Rgba => {}
 draw_banner! = |frame, model, line, accent| {
 	frame.rounded_rectangle!({ x: 190, y: 276, width: 420, height: 124, radius: 0.14, segments: 8, style: Draw.filled_and_outlined(Color.with_alpha(field_bottom, 232), Color.with_alpha(accent, 120), 2) })
-	line.draw!(frame, { pos: { x: screen_w * 0.5, y: 318 }, color: accent, align: Text.align_center })
-	model.restart_line.draw!(frame, { pos: { x: screen_w * 0.5, y: 362 }, color: Color.with_alpha(hint_color, prompt_alpha(model)), align: Text.align_center })
+	line.draw!(frame, { pos: { x: screen_w * 0.5, y: 318 }, color: accent, align: (Middle, Center) })
+	model.restart_line.draw!(frame, { pos: { x: screen_w * 0.5, y: 362 }, color: Color.with_alpha(hint_color, prompt_alpha(model)), align: (Middle, Center) })
 }

--- a/examples/camera/main.roc
+++ b/examples/camera/main.roc
@@ -175,12 +175,12 @@ draw_hud! : Draw.Frame, Model, Math.Vec2 => {}
 draw_hud! = |frame, model, mouse_world| {
 	hud = Box.unbox(model.hud)
 	frame.rounded_rectangle!({ x: 16, y: 16, width: 340, height: 122, radius: 12, segments: 8, style: Draw.filled_and_outlined(Color.with_alpha(Color.from_hex_rgb(0x0b1219), 215), Color.with_alpha(Color.white, 40), 1) })
-	hud.title.draw!(frame, { pos: { x: 32, y: 28 }, color: Color.white, align: Text.align_top_left })
-	hud.subtitle.draw!(frame, { pos: { x: 32, y: 60 }, color: Color.from_hex_rgb(0x8fa3b8), align: Text.align_top_left })
+	hud.title.draw!(frame, { pos: { x: 32, y: 28 }, color: Color.white })
+	hud.subtitle.draw!(frame, { pos: { x: 32, y: 60 }, color: Color.from_hex_rgb(0x8fa3b8) })
 	frame.line!({ start: { x: 32, y: 84 }, end: { x: 340, y: 84 }, stroke: Draw.stroke(Color.with_alpha(Color.white, 30), 1) })
 	# Show the pointer coordinates in both spaces for direct comparison.
 	frame.text_at!({ pos: { x: 32, y: 92 }, text: "world ${coord(mouse_world.x)}, ${coord(mouse_world.y)}   zoom ${coord(model.zoom * 100)}%", size: 14, color: Color.from_hex_rgb(0xffd166) })
-	hud.help.draw!(frame, { pos: { x: 32, y: 114 }, color: Color.from_hex_rgb(0x8fa3b8), align: Text.align_top_left })
+	hud.help.draw!(frame, { pos: { x: 32, y: 114 }, color: Color.from_hex_rgb(0x8fa3b8) })
 }
 
 ## Whole units, so the readout does not jitter its own width every frame.

--- a/examples/capture_plot/main.roc
+++ b/examples/capture_plot/main.roc
@@ -86,13 +86,13 @@ render! = |model, frame| {
 	size = frame.size!()
 	frame.rectangle_gradient_v!({ x: 0, y: 0, width: size.width, height: size.height, color_top: bg_top, color_bottom: bg_bottom })
 
-	model.title.draw!(frame, { pos: { x: 32, y: 26 }, color: ink, align: Text.align_top_left })
+	model.title.draw!(frame, { pos: { x: 32, y: 26 }, color: ink })
 
 	# A recording indicator that reads at a glance in the finished file: the
 	# dot pulses on the same fixed step the frames are captured on.
 	pulse = 4 + 2 * F32.sin(model.elapsed * 6)
 	frame.circle!({ center: { x: 38, y: 66 }, radius: pulse, style: Draw.filled(rec) })
-	model.status.draw!(frame, { pos: { x: 52, y: 58 }, color: muted, align: Text.align_top_left })
+	model.status.draw!(frame, { pos: { x: 52, y: 58 }, color: muted })
 
 	draw_progress!(frame, { x: size.width - 232, y: 34, width: 200 }, model.frames)
 	draw_bars!(frame, model.elapsed, size)

--- a/examples/capture_screenshot/main.roc
+++ b/examples/capture_screenshot/main.roc
@@ -149,8 +149,8 @@ render! = |model, frame| {
 	frame.circle!({ center: center, radius: 94, style: Draw.outlined(Color.with_alpha(accent, 45), 1) })
 	frame.circle!({ center: { x: center.x + 56, y: center.y - 56 }, radius: 7, style: Draw.filled(accent) })
 
-	model.title.draw!(frame, { pos: { x: 36, y: 34 }, color: ink, align: Text.align_top_left })
-	model.subtitle.draw!(frame, { pos: { x: 36, y: 68 }, color: muted, align: Text.align_top_left })
+	model.title.draw!(frame, { pos: { x: 36, y: 34 }, color: ink })
+	model.subtitle.draw!(frame, { pos: { x: 36, y: 68 }, color: muted })
 
 	# The outcome card. Its accent is the whole report: green for a file on
 	# disk, amber for the sandbox refusing a path, red for a write that failed.
@@ -160,9 +160,9 @@ render! = |model, frame| {
 	frame.circle!({ center: { x: 78, y: 272 }, radius: 11, style: Draw.outlined(Color.with_alpha(color, 70), 1.5) })
 	frame.circle!({ center: { x: 78, y: 272 }, radius: 5, style: Draw.filled(color) })
 	frame.text_at!({ pos: { x: 108, y: 250 }, text: outcome_label(model.outcome), size: 13, color: faint })
-	outcome_text(model).draw!(frame, { pos: { x: 108, y: 270 }, color: color, align: Text.align_top_left })
+	outcome_text(model).draw!(frame, { pos: { x: 108, y: 270 }, color: color })
 
-	model.help.draw!(frame, { pos: { x: 36, y: size.height - 38 }, color: faint, align: Text.align_top_left })
+	model.help.draw!(frame, { pos: { x: 36, y: size.height - 38 }, color: faint })
 	Ok({})
 }
 

--- a/examples/capture_ui_demo/main.roc
+++ b/examples/capture_ui_demo/main.roc
@@ -282,7 +282,7 @@ render! = |model, frame| {
 	over_toggle = inside(model.mouse, toggle_button)
 
 	frame.clear!(theme.bg)
-	model.title.draw!(frame, { pos: { x: 40, y: 22 }, color: theme.ink, align: Text.align_top_left })
+	model.title.draw!(frame, { pos: { x: 40, y: 22 }, color: theme.ink })
 	frame.text_at!({ pos: { x: 40, y: 54 }, text: "A scripted pointer and keyboard on the real input path", size: 13, color: theme.muted })
 	frame.rounded_rectangle!({ x: widget_panel.x, y: widget_panel.y, width: widget_panel.width, height: widget_panel.height, radius: 12, segments: 8, style: Draw.filled_and_outlined(theme.panel, theme.edge, 1) })
 
@@ -293,7 +293,7 @@ render! = |model, frame| {
 
 	match List.get(model.field_labels, model.typed) {
 		Ok(label) => {
-			label.draw!(frame, { pos: field_text_origin, color: theme.ink, align: Text.align_top_left })
+			label.draw!(frame, { pos: field_text_origin, color: theme.ink })
 			if model.focused and caret_visible(model.frame) {
 				draw_caret!(frame, field_text_origin.x + label.bounds().width + 3)
 			}
@@ -303,7 +303,7 @@ render! = |model, frame| {
 	}
 
 	match List.get(model.counter_labels, U64.to_u64(model.clicks)) {
-		Ok(label) => label.draw!(frame, { pos: { x: 40, y: 92 }, color: Color.from_hex_rgb(0x3ddc97), align: Text.align_top_left })
+		Ok(label) => label.draw!(frame, { pos: { x: 40, y: 92 }, color: Color.from_hex_rgb(0x3ddc97) })
 		Err(_) => {}
 	}
 
@@ -430,7 +430,7 @@ draw_button! = |frame, box, hovered, active, label| {
 		{
 			pos: { x: box.x + box.width / 2, y: box.y + box.height / 2 - 10 },
 			color: if active Color.from_hex_rgb(0x08131f) else theme.ink,
-			align: Text.align_top_center,
+			align: (Top, Center),
 		},
 	)
 }

--- a/examples/cave_climb/main.roc
+++ b/examples/cave_climb/main.roc
@@ -1070,8 +1070,8 @@ draw_modal! : Draw.Frame, Text.Font, Str, Str, Color.Rgba => {}
 draw_modal! = |frame, font, title, subtitle, accent| {
 	frame.rectangle!({ x: 0, y: 0, width: screen_w, height: screen_h, style: Draw.filled(Color.with_alpha(Color.black, 125)) })
 	frame.rounded_rectangle!({ x: 182, y: 226, width: 436, height: 152, radius: 8, segments: 8, style: Draw.filled_and_outlined(Color.with_alpha(Color.black, 232), accent, 4) })
-	Text.from(title, font).size(30).draw!(frame, { pos: { x: screen_w * 0.5, y: 276 }, color: Color.white, align: Text.align_center })
-	Text.from(subtitle, font).size(21).draw!(frame, { pos: { x: screen_w * 0.5, y: 326 }, color: Color.light_gray, align: Text.align_center })
+	Text.from(title, font).size(30).draw!(frame, { pos: { x: screen_w * 0.5, y: 276 }, color: Color.white, align: (Middle, Center) })
+	Text.from(subtitle, font).size(21).draw!(frame, { pos: { x: screen_w * 0.5, y: 326 }, color: Color.light_gray, align: (Middle, Center) })
 }
 
 expect physics_distance(Physics.point_xy(0, 0), Physics.point_xy(3, 4)) == 5

--- a/examples/cave_climb/main.roc
+++ b/examples/cave_climb/main.roc
@@ -1049,10 +1049,10 @@ draw_player! = |frame, characters, player| {
 draw_hud! : Draw.Frame, Level, World, Text.Font => {}
 draw_hud! = |frame, level, world, font| {
 	frame.rectangle_gradient_v!({ x: 0, y: 0, width: screen_w, height: 76, color_top: Color.with_alpha(Color.black, 220), color_bottom: Color.with_alpha(Color.black, 110) })
-	frame.text!({ pos: { x: 22, y: 16 }, text: "Cave Climb", size: 27, spacing: Draw.default_spacing, color: Color.white, font: font, align: Draw.align_top_left })
-	frame.text!({ pos: { x: 220, y: 18 }, text: Str.concat("Gems ", Str.concat(U64.to_str(world.collected), Str.concat("/", U64.to_str(List.len(level.gems))))), size: 20, spacing: Draw.default_spacing, color: Color.from_hex_rgb(0x55c7ff), font: font, align: Draw.align_top_left })
-	frame.text!({ pos: { x: 380, y: 18 }, text: Str.concat("Lives ", U64.to_str(world.lives)), size: 20, spacing: Draw.default_spacing, color: Color.light_gray, font: font, align: Draw.align_top_left })
-	frame.text!({ pos: { x: 505, y: 18 }, text: if world.collected == List.len(level.gems) "Goal open" else "Collect every gem", size: 20, spacing: Draw.default_spacing, color: if world.collected == List.len(level.gems) Color.from_hex_rgb(0x90be6d) else Color.light_gray, font: font, align: Draw.align_top_left })
+	frame.text!({ pos: { x: 22, y: 16 }, text: "Cave Climb", size: 27, spacing: Draw.default_spacing, color: Color.white, font: font })
+	frame.text!({ pos: { x: 220, y: 18 }, text: Str.concat("Gems ", Str.concat(U64.to_str(world.collected), Str.concat("/", U64.to_str(List.len(level.gems))))), size: 20, spacing: Draw.default_spacing, color: Color.from_hex_rgb(0x55c7ff), font: font })
+	frame.text!({ pos: { x: 380, y: 18 }, text: Str.concat("Lives ", U64.to_str(world.lives)), size: 20, spacing: Draw.default_spacing, color: Color.light_gray, font: font })
+	frame.text!({ pos: { x: 505, y: 18 }, text: if world.collected == List.len(level.gems) "Goal open" else "Collect every gem", size: 20, spacing: Draw.default_spacing, color: if world.collected == List.len(level.gems) Color.from_hex_rgb(0x90be6d) else Color.light_gray, font: font })
 	frame.fps!({ pos: { x: 735, y: 20 }, size: 18, color: Color.gray })
 
 	if world.flash > 0 {
@@ -1061,17 +1061,17 @@ draw_hud! = |frame, level, world, font| {
 
 	match world.state {
 		Playing => {}
-		Won => draw_modal!(frame, "Summit reached", "Press SPACE to climb again", Color.from_hex_rgb(0x90be6d))
-		GameOver => draw_modal!(frame, "Climb failed", "Press SPACE to restart", Color.from_hex_rgb(0xf94144))
+		Won => draw_modal!(frame, font, "Summit reached", "Press SPACE to climb again", Color.from_hex_rgb(0x90be6d))
+		GameOver => draw_modal!(frame, font, "Climb failed", "Press SPACE to restart", Color.from_hex_rgb(0xf94144))
 	}
 }
 
-draw_modal! : Draw.Frame, Str, Str, Color.Rgba => {}
-draw_modal! = |frame, title, subtitle, accent| {
+draw_modal! : Draw.Frame, Text.Font, Str, Str, Color.Rgba => {}
+draw_modal! = |frame, font, title, subtitle, accent| {
 	frame.rectangle!({ x: 0, y: 0, width: screen_w, height: screen_h, style: Draw.filled(Color.with_alpha(Color.black, 125)) })
 	frame.rounded_rectangle!({ x: 182, y: 226, width: 436, height: 152, radius: 8, segments: 8, style: Draw.filled_and_outlined(Color.with_alpha(Color.black, 232), accent, 4) })
-	frame.text_centered!({ pos: { x: screen_w * 0.5, y: 276 }, text: title, size: 30, color: Color.white })
-	frame.text_centered!({ pos: { x: screen_w * 0.5, y: 326 }, text: subtitle, size: 21, color: Color.light_gray })
+	Text.from(title, font).size(30).draw!(frame, { pos: { x: screen_w * 0.5, y: 276 }, color: Color.white, align: Text.align_center })
+	Text.from(subtitle, font).size(21).draw!(frame, { pos: { x: screen_w * 0.5, y: 326 }, color: Color.light_gray, align: Text.align_center })
 }
 
 expect physics_distance(Physics.point_xy(0, 0), Physics.point_xy(3, 4)) == 5

--- a/examples/drop_viewer/main.roc
+++ b/examples/drop_viewer/main.roc
@@ -227,7 +227,7 @@ expect status_color(Refused("x")) == theme.warn
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])
 render! = |model, frame| {
 	frame.clear!(theme.bg)
-	model.title.draw!(frame, { pos: { x: 40, y: 34 }, color: theme.ink, align: Text.align_top_left })
+	model.title.draw!(frame, { pos: { x: 40, y: 34 }, color: theme.ink })
 	frame.text_at!({ pos: { x: 40, y: 70 }, text: "A dropped path, read off the frame thread and decoded into a texture", size: 15, color: theme.muted })
 
 	# The drop target: a card first, an outline second, so an empty viewer still
@@ -238,7 +238,7 @@ render! = |model, frame| {
 		NoImage =>
 			Text.from("Drop a PNG, JPEG, GIF, QOI or BMP file here", model.font)
 				.size(18)
-				.draw!(frame, { pos: { x: canvas.x + canvas.width / 2, y: canvas.y + canvas.height / 2 }, color: theme.faint, align: Text.align_center })
+				.draw!(frame, { pos: { x: canvas.x + canvas.width / 2, y: canvas.y + canvas.height / 2 }, color: theme.faint, align: (Middle, Center) })
 
 		Shown(texture) =>
 			frame.texture!({

--- a/examples/drop_viewer/main.roc
+++ b/examples/drop_viewer/main.roc
@@ -13,9 +13,11 @@ import rr.Task
 import rr.Text
 
 ## The Model keeps the current status, decoded texture, overflow warning, and
-## prepared title between updates. The dropped path itself is handled when it
-## arrives; only information needed for later progress and drawing is retained.
+## font and prepared title between updates. The dropped path itself is handled
+## when it arrives; only information needed for later progress and drawing is
+## retained.
 Model : {
+	font : Text.Font,
 	title : Text.Prepared,
 	status : Status,
 	image : [NoImage, Shown(Assets.Texture)],
@@ -46,6 +48,7 @@ init! = App.init(
 	|_startup| {
 		font = Draw.default_font!()
 		Ok({
+			font,
 			title: Text.from("Drop Viewer", font).size(28).prepare!()?,
 			status: WaitingForDrop,
 			image: NoImage,
@@ -233,7 +236,9 @@ render! = |model, frame| {
 
 	match model.image {
 		NoImage =>
-			frame.text_centered!({ pos: { x: canvas.x + canvas.width / 2, y: canvas.y + canvas.height / 2 }, text: "Drop a PNG, JPEG, GIF, QOI or BMP file here", size: 18, color: theme.faint })
+			Text.from("Drop a PNG, JPEG, GIF, QOI or BMP file here", model.font)
+				.size(18)
+				.draw!(frame, { pos: { x: canvas.x + canvas.width / 2, y: canvas.y + canvas.height / 2 }, color: theme.faint, align: Text.align_center })
 
 		Shown(texture) =>
 			frame.texture!({

--- a/examples/generated_assets/main.roc
+++ b/examples/generated_assets/main.roc
@@ -291,7 +291,7 @@ draw_swatch! = |frame, font, index, selected, mouse| {
 	}
 	frame.rounded_rectangle!({ x: bounds.x, y: bounds.y, width: bounds.width, height: bounds.height, radius: 8, segments: 8, style: Draw.filled_and_outlined(palette_color(index), edge, if chosen 3 else 2) })
 	Text.from(U64.to_str(index + 1), font)
-		.draw!(frame, { pos: { x: 752, y: bounds.y + 25 }, color: if chosen theme.ink else theme.faint, align: Text.align_center })
+		.draw!(frame, { pos: { x: 752, y: bounds.y + 25 }, color: if chosen theme.ink else theme.faint, align: (Middle, Center) })
 }
 
 ## Perform one edit. A mismatched upload is a programmer error -- the editor
@@ -357,7 +357,7 @@ render! = |model, frame| {
 	ui = Box.unbox(model.ui)
 
 	frame.clear!(theme.bg)
-	ui.title.draw!(frame, { pos: { x: canvas_x, y: 12 }, color: theme.ink, align: Text.align_top_left })
+	ui.title.draw!(frame, { pos: { x: canvas_x, y: 12 }, color: theme.ink })
 	frame.text_at!({ pos: { x: canvas_x, y: 42 }, text: "Canvas, palette and brush sound all generated at startup", size: 13, color: theme.muted })
 
 	# A card under the canvas, so the pixel art sits on a surface instead of
@@ -383,12 +383,12 @@ render! = |model, frame| {
 	}
 
 	frame.rounded_rectangle!({ x: 594, y: 108, width: 150, height: 348, radius: 12, segments: 8, style: Draw.filled_and_outlined(theme.panel, theme.edge, 1) })
-	ui.palette.draw!(frame, { pos: { x: 610, y: 126 }, color: theme.ink, align: Text.align_top_left })
+	ui.palette.draw!(frame, { pos: { x: 610, y: 126 }, color: theme.ink })
 	draw_swatch!(frame, model.font, 0, model.palette, model.mouse)
 	draw_swatch!(frame, model.font, 1, model.palette, model.mouse)
 	draw_swatch!(frame, model.font, 2, model.palette, model.mouse)
 	draw_swatch!(frame, model.font, 3, model.palette, model.mouse)
-	ui.help.draw!(frame, { pos: { x: canvas_x, y: 562 }, color: theme.faint, align: Text.align_top_left })
+	ui.help.draw!(frame, { pos: { x: canvas_x, y: 562 }, color: theme.faint })
 
 	Ok({})
 }

--- a/examples/generated_assets/main.roc
+++ b/examples/generated_assets/main.roc
@@ -24,11 +24,12 @@ PaintState := [Idle, Painted(U64)].{
 	is_eq : _
 }
 
-## State kept between updates: the canvas pixels and texture, the selected
+## State kept between updates: the font, canvas pixels and texture, the selected
 ## colour and last painted cell, the generated sound, and the small amount of
 ## input and demo state needed for the next update. Prepared labels are kept so
 ## they do not need to be rebuilt every frame.
 Model : {
+	font : Text.Font,
 	texture : Assets.Texture,
 	pixels : List(Color.Rgba),
 	paint_sound : Audio.Sound,
@@ -124,6 +125,7 @@ init! = App.init_for_args(
 		Assets.set_texture_wrap!(texture, Clamp)
 		paint_sound = Audio.gen_tone!({ freq: 520, ms: 35 })?
 		Ok({
+			font,
 			texture,
 			pixels: initial_pixels,
 			paint_sound,
@@ -276,8 +278,8 @@ theme = {
 swatch_bounds : U64 -> Math.Rect
 swatch_bounds = |index| Math.rect(610, 180 + U64.to_f32(index) * 70, 118, 50)
 
-draw_swatch! : Draw.Frame, U64, U64, Math.Vec2 => {}
-draw_swatch! = |frame, index, selected, mouse| {
+draw_swatch! : Draw.Frame, Text.Font, U64, U64, Math.Vec2 => {}
+draw_swatch! = |frame, font, index, selected, mouse| {
 	bounds = swatch_bounds(index)
 	chosen = index == selected
 	hovered = bounds.contains(mouse)
@@ -288,7 +290,8 @@ draw_swatch! = |frame, index, selected, mouse| {
 		frame.rounded_rectangle!({ x: bounds.x - 5, y: bounds.y - 5, width: bounds.width + 10, height: bounds.height + 10, radius: 11, segments: 8, style: Draw.outlined(theme.accent, 2) })
 	}
 	frame.rounded_rectangle!({ x: bounds.x, y: bounds.y, width: bounds.width, height: bounds.height, radius: 8, segments: 8, style: Draw.filled_and_outlined(palette_color(index), edge, if chosen 3 else 2) })
-	frame.text_centered!({ pos: { x: 752, y: bounds.y + 25 }, text: U64.to_str(index + 1), size: 20, color: if chosen theme.ink else theme.faint })
+	Text.from(U64.to_str(index + 1), font)
+		.draw!(frame, { pos: { x: 752, y: bounds.y + 25 }, color: if chosen theme.ink else theme.faint, align: Text.align_center })
 }
 
 ## Perform one edit. A mismatched upload is a programmer error -- the editor
@@ -381,10 +384,10 @@ render! = |model, frame| {
 
 	frame.rounded_rectangle!({ x: 594, y: 108, width: 150, height: 348, radius: 12, segments: 8, style: Draw.filled_and_outlined(theme.panel, theme.edge, 1) })
 	ui.palette.draw!(frame, { pos: { x: 610, y: 126 }, color: theme.ink, align: Text.align_top_left })
-	draw_swatch!(frame, 0, model.palette, model.mouse)
-	draw_swatch!(frame, 1, model.palette, model.mouse)
-	draw_swatch!(frame, 2, model.palette, model.mouse)
-	draw_swatch!(frame, 3, model.palette, model.mouse)
+	draw_swatch!(frame, model.font, 0, model.palette, model.mouse)
+	draw_swatch!(frame, model.font, 1, model.palette, model.mouse)
+	draw_swatch!(frame, model.font, 2, model.palette, model.mouse)
+	draw_swatch!(frame, model.font, 3, model.palette, model.mouse)
 	ui.help.draw!(frame, { pos: { x: canvas_x, y: 562 }, color: theme.faint, align: Text.align_top_left })
 
 	Ok({})

--- a/examples/hello_world/main.roc
+++ b/examples/hello_world/main.roc
@@ -101,9 +101,9 @@ render! = |model, frame| {
 	frame.rounded_rectangle!({ x: panel.x + 6, y: panel.y + 10, width: panel.width, height: panel.height, radius: 22, segments: 12, style: Draw.filled(Color.with_alpha(Color.black, 90)) })
 	frame.rounded_rectangle!({ x: panel.x, y: panel.y, width: panel.width, height: panel.height, radius: 22, segments: 12, style: Draw.filled_and_outlined(Color.from_hex_rgb(0x18243b), Color.with_alpha(Color.white, 55), 2) })
 
-	model.title.draw!(frame, { pos: { x: 400, y: 230 }, color: Color.white, align: Text.align_top_center })
+	model.title.draw!(frame, { pos: { x: 400, y: 230 }, color: Color.white, align: (Top, Center) })
 	frame.line!({ start: { x: 400 - title_size.width * 0.5, y: 288 }, end: { x: 400 + title_size.width * 0.5, y: 288 }, stroke: Draw.stroke(Color.with_alpha(accent, 170), 3) })
-	model.help.draw!(frame, { pos: { x: 400, y: 310 }, color: Color.from_hex_rgb(0xa8b4cc), align: Text.align_top_center })
+	model.help.draw!(frame, { pos: { x: 400, y: 310 }, color: Color.from_hex_rgb(0xa8b4cc), align: (Top, Center) })
 
 	# The pointer gets a halo that pulses with the same clock as the backdrop.
 	frame.circle!({ center: model.pointer, radius: 26 + 8 * pulse, style: Draw.filled(Color.with_alpha(accent, 40)) })

--- a/examples/http_fetch/main.roc
+++ b/examples/http_fetch/main.roc
@@ -182,8 +182,8 @@ render! = |model, frame| {
 	frame.rectangle_gradient_v!({ x: 0, y: 0, width: size.width, height: size.height, color_top: bg_top, color_bottom: bg_bottom })
 	frame.circle_gradient!({ center: { x: size.width * 0.5, y: -40 }, radius: size.height, color_inner: Color.from_hex_rgba(0x3a5f9c33), color_outer: Color.from_hex_rgba(0x00000000) })
 
-	model.title.draw!(frame, { pos: { x: 44, y: 36 }, color: ink, align: Text.align_top_left })
-	model.subtitle.draw!(frame, { pos: { x: 44, y: 72 }, color: muted, align: Text.align_top_left })
+	model.title.draw!(frame, { pos: { x: 44, y: 36 }, color: ink })
+	model.subtitle.draw!(frame, { pos: { x: 44, y: 72 }, color: muted })
 
 	width = size.width - 88
 	accent = state_color(model.state)
@@ -213,7 +213,7 @@ render! = |model, frame| {
 		},
 	)?
 
-	model.hint.draw!(frame, { pos: { x: 44, y: size.height - 40 }, color: faint, align: Text.align_top_left })
+	model.hint.draw!(frame, { pos: { x: 44, y: size.height - 40 }, color: faint })
 	Ok({})
 }
 

--- a/examples/input_inspector/main.roc
+++ b/examples/input_inspector/main.roc
@@ -249,7 +249,7 @@ chip! = |frame, font, cfg| {
 	frame.rounded_rectangle!({ x: cfg.x, y: cfg.y, width: cfg.width, height: 30, radius: 8, segments: 6, style: Draw.filled_and_outlined(fill, edge, 1) })
 	Text.from(cfg.label, font)
 		.size(17)
-		.draw!(frame, { pos: { x: cfg.x + cfg.width / 2, y: cfg.y + 15 }, color: ink, align: Text.align_center })
+		.draw!(frame, { pos: { x: cfg.x + cfg.width / 2, y: cfg.y + 15 }, color: ink, align: (Middle, Center) })
 }
 
 ## A small square light next to a label, for the signals that are on or off

--- a/examples/input_inspector/main.roc
+++ b/examples/input_inspector/main.roc
@@ -237,7 +237,7 @@ theme = {
 panel! : Draw.Frame, Text.Font, { x : F32, y : F32, width : F32, height : F32, label : Str } => {}
 panel! = |frame, font, cfg| {
 	frame.rounded_rectangle!({ x: cfg.x, y: cfg.y, width: cfg.width, height: cfg.height, radius: 12, segments: 8, style: Draw.filled_and_outlined(theme.panel, theme.edge, 1) })
-	frame.text!({ pos: { x: cfg.x + 18, y: cfg.y + 12 }, text: cfg.label, size: 14, spacing: Draw.default_spacing, color: theme.muted, font: font, align: Draw.align_top_left })
+	frame.text!({ pos: { x: cfg.x + 18, y: cfg.y + 12 }, text: cfg.label, size: 14, spacing: Draw.default_spacing, color: theme.muted, font: font })
 }
 
 ## One indicator chip, lit while the snapshot says its input is active.
@@ -247,14 +247,16 @@ chip! = |frame, font, cfg| {
 	edge = if cfg.on theme.active else theme.edge
 	ink = if cfg.on theme.active_ink else theme.idle_ink
 	frame.rounded_rectangle!({ x: cfg.x, y: cfg.y, width: cfg.width, height: 30, radius: 8, segments: 6, style: Draw.filled_and_outlined(fill, edge, 1) })
-	frame.text!({ pos: { x: cfg.x + cfg.width / 2, y: cfg.y + 15 }, text: cfg.label, size: 17, spacing: Draw.default_spacing, color: ink, font: font, align: Draw.align_center })
+	Text.from(cfg.label, font)
+		.size(17)
+		.draw!(frame, { pos: { x: cfg.x + cfg.width / 2, y: cfg.y + 15 }, color: ink, align: Text.align_center })
 }
 
 ## A small square light next to a label, for the signals that are on or off
 ## rather than named keys.
 light! : Draw.Frame, Text.Font, { x : F32, y : F32, label : Str, on : Bool } => {}
 light! = |frame, font, cfg| {
-	frame.text!({ pos: { x: cfg.x, y: cfg.y + 3 }, text: cfg.label, size: 16, spacing: Draw.default_spacing, color: theme.muted, font: font, align: Draw.align_top_left })
+	frame.text!({ pos: { x: cfg.x, y: cfg.y + 3 }, text: cfg.label, size: 16, spacing: Draw.default_spacing, color: theme.muted, font: font })
 	fill = if cfg.on theme.active else theme.idle
 	frame.rounded_rectangle!({ x: cfg.x + 130, y: cfg.y, width: 22, height: 22, radius: 6, segments: 6, style: Draw.filled_and_outlined(fill, if cfg.on theme.active else theme.edge, 1) })
 }
@@ -262,7 +264,7 @@ light! = |frame, font, cfg| {
 ## A line of body text inside a panel.
 line! : Draw.Frame, Text.Font, { x : F32, y : F32, text : Str, color : Color.Rgba } => {}
 line! = |frame, font, cfg|
-	frame.text!({ pos: { x: cfg.x, y: cfg.y }, text: cfg.text, size: 16, spacing: Draw.default_spacing, color: cfg.color, font: font, align: Draw.align_top_left })
+	frame.text!({ pos: { x: cfg.x, y: cfg.y }, text: cfg.text, size: 16, spacing: Draw.default_spacing, color: cfg.color, font: font })
 
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])
 render! = |model, frame| {
@@ -300,8 +302,8 @@ render! = |model, frame| {
 	stick_moved = F32.abs(left_stick.x) > 0.1 or F32.abs(left_stick.y) > 0.1
 
 	frame.clear!(theme.bg)
-	frame.text!({ pos: { x: 30, y: 26 }, text: title, size: 26, spacing: Draw.default_spacing, color: theme.ink, font: font, align: Draw.align_top_left })
-	frame.text!({ pos: { x: 30, y: 58 }, text: "Every field of one Devices.Snapshot, live", size: 15, spacing: Draw.default_spacing, color: theme.muted, font: font, align: Draw.align_top_left })
+	frame.text!({ pos: { x: 30, y: 26 }, text: title, size: 26, spacing: Draw.default_spacing, color: theme.ink, font: font })
+	frame.text!({ pos: { x: 30, y: 58 }, text: "Every field of one Devices.Snapshot, live", size: 15, spacing: Draw.default_spacing, color: theme.muted, font: font })
 
 	panel!(frame, font, { x: 20, y: 84, width: 780, height: 258, label: "KEYS AND BUTTONS" })
 	chip!(frame, font, { x: 70, y: 126, width: 30, label: "W", on: w_down })
@@ -339,6 +341,6 @@ render! = |model, frame| {
 	frame.rounded_rectangle!({ x: 30, y: 632, width: 22, height: 22, radius: 6, segments: 6, style: Draw.filled_and_outlined(eyedropper_swatch(model.picked), theme.edge, 1) })
 	line!(frame, font, { x: 62, y: 634, text: eyedropper_label(model.picked), color: theme.muted })
 
-	frame.text!({ pos: { x: 30, y: 676 }, text: "Q exits  |  Esc is a normal key  |  hold left mouse for a crosshair", size: 14, spacing: Draw.default_spacing, color: Color.from_hex_rgb(0x5c6b87), font: font, align: Draw.align_top_left })
+	frame.text!({ pos: { x: 30, y: 676 }, text: "Q exits  |  Esc is a normal key  |  hold left mouse for a crosshair", size: 14, spacing: Draw.default_spacing, color: Color.from_hex_rgb(0x5c6b87), font: font })
 	Ok({})
 }

--- a/examples/live_plot/main.roc
+++ b/examples/live_plot/main.roc
@@ -2312,9 +2312,9 @@ draw_masthead! : Draw.Frame, Model => {}
 draw_masthead! = |frame, model| {
 	fade = ease_out(model.entrance)
 
-	model.eyebrow.draw!(frame, { pos: { x: margin, y: 26 }, color: fade_to(ink_faint, fade), align: Text.align_top_left })
-	model.title.draw!(frame, { pos: { x: margin, y: 40 }, color: fade_to(ink, fade), align: Text.align_top_left })
-	model.deck.draw!(frame, { pos: { x: margin, y: 84 }, color: fade_to(ink_dim, fade), align: Text.align_top_left })
+	model.eyebrow.draw!(frame, { pos: { x: margin, y: 26 }, color: fade_to(ink_faint, fade) })
+	model.title.draw!(frame, { pos: { x: margin, y: 40 }, color: fade_to(ink, fade) })
+	model.deck.draw!(frame, { pos: { x: margin, y: 84 }, color: fade_to(ink_dim, fade) })
 
 	draw_graphs!(frame, model, fade)
 
@@ -2706,7 +2706,7 @@ draw_footer! = |frame, model| {
 
 	frame.line!({ start: { x: margin, y: bottom - 46 }, end: { x: model.screen.x - margin, y: bottom - 46 }, stroke: Draw.stroke(rule, 1) })
 
-	model.hint.draw!(frame, { pos: { x: margin, y: bottom - 34 }, color: fade_to(ink_faint, fade), align: Text.align_top_left })
+	model.hint.draw!(frame, { pos: { x: margin, y: bottom - 34 }, color: fade_to(ink_faint, fade) })
 	text_right!(
 		frame,
 		model.small,
@@ -2728,7 +2728,7 @@ text_left! = |frame, font, pos, content, size, spacing, color|
 
 text_right! : Draw.Frame, Text.Font, Math.Vec2, Str, F32, F32, Color.Rgba => {}
 text_right! = |frame, font, pos, content, size, spacing, color|
-	Text.from(content, font).size(size).spacing(spacing).draw!(frame, { pos, color, align: Text.align_top_right })
+	Text.from(content, font).size(size).spacing(spacing).draw!(frame, { pos, color, align: (Top, Right) })
 
 ## The entrance fades the furniture up rather than sliding it, so nothing in the
 ## figure ever moves except the data.

--- a/examples/live_plot/main.roc
+++ b/examples/live_plot/main.roc
@@ -2724,11 +2724,11 @@ draw_footer! = |frame, model| {
 
 text_left! : Draw.Frame, Text.Font, Math.Vec2, Str, F32, F32, Color.Rgba => {}
 text_left! = |frame, font, pos, content, size, spacing, color|
-	frame.text!({ pos: pos, text: content, size: size, spacing: spacing, color: color, font: font, align: Draw.align_top_left })
+	frame.text!({ pos: pos, text: content, size: size, spacing: spacing, color: color, font: font })
 
 text_right! : Draw.Frame, Text.Font, Math.Vec2, Str, F32, F32, Color.Rgba => {}
 text_right! = |frame, font, pos, content, size, spacing, color|
-	frame.text!({ pos: pos, text: content, size: size, spacing: spacing, color: color, font: font, align: Draw.align_top_right })
+	Text.from(content, font).size(size).spacing(spacing).draw!(frame, { pos, color, align: Text.align_top_right })
 
 ## The entrance fades the furniture up rather than sliding it, so nothing in the
 ## figure ever moves except the data.

--- a/examples/particles/main.roc
+++ b/examples/particles/main.roc
@@ -209,7 +209,7 @@ render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])
 render! = |model, frame| {
 	frame.clear!(Color.from_hex_rgb(0x0d1425))
 	frame.texture_instances!(model.sprite, model.instances)
-	model.hud.draw!(frame, { pos: { x: 24, y: 24 }, color: Color.from_hex_rgb(0xa8b4cc), align: Text.align_top_left })
+	model.hud.draw!(frame, { pos: { x: 24, y: 24 }, color: Color.from_hex_rgb(0xa8b4cc) })
 
 	Ok({})
 }

--- a/examples/pong/main.roc
+++ b/examples/pong/main.roc
@@ -277,13 +277,13 @@ render! = |model, frame| {
 		winner_index = if model.left_score >= win_score 0 else 1
 		winner_color = if winner_index == 0 left_neon else right_neon
 		match List.get(model.win_lines, winner_index) {
-			Ok(line) => line.draw!(frame, { pos: { x: screen_w * 0.5, y: 268 }, color: winner_color, align: Text.align_center })
+			Ok(line) => line.draw!(frame, { pos: { x: screen_w * 0.5, y: 268 }, color: winner_color, align: (Middle, Center) })
 			Err(_) => {}
 		}
-		model.restart_line.draw!(frame, { pos: { x: screen_w * 0.5, y: 326 }, color: hint_color, align: Text.align_center })
+		model.restart_line.draw!(frame, { pos: { x: screen_w * 0.5, y: 326 }, color: hint_color, align: (Middle, Center) })
 	} else {}
 
-	model.hint.draw!(frame, { pos: { x: screen_w * 0.5, y: screen_h - 26 }, color: hint_color, align: Text.align_center })
+	model.hint.draw!(frame, { pos: { x: screen_w * 0.5, y: screen_h - 26 }, color: hint_color, align: (Middle, Center) })
 
 	Ok({})
 }
@@ -344,7 +344,7 @@ draw_scores! : Draw.Frame, Model => {}
 draw_scores! = |frame, model| {
 	draw_score! = |score, x, color|
 		match List.get(model.digits, score) {
-			Ok(glyph) => glyph.draw!(frame, { pos: { x: x, y: 30 }, color: color, align: Text.align_top_center })
+			Ok(glyph) => glyph.draw!(frame, { pos: { x: x, y: 30 }, color: color, align: (Top, Center) })
 			Err(_) => {}
 		}
 

--- a/examples/post_process/main.roc
+++ b/examples/post_process/main.roc
@@ -10,11 +10,13 @@ import rr.Assets
 import rr.Color
 import rr.Draw
 import rr.Math
+import rr.Text
 
-## State kept between updates: the offscreen drawing target, shader, and its
-## prepared time setting, plus the elapsed time that animates the scene. These
-## resources are created once and reused for every frame.
+## State kept between updates: the font, offscreen drawing target, shader, and
+## its prepared time setting, plus the elapsed time that animates the scene.
+## These resources are created once and reused for every frame.
 Model : {
+	font : Text.Font,
 	target : Draw.RenderTexture,
 	shader : Draw.Shader,
 
@@ -36,10 +38,11 @@ init! = App.init(
 		## This source tree example deliberately opts into CWD-relative assets.
 		## Packaged applications normally use `Assets.beside_executable("assets")`.
 		assets = Assets.Store.open!(Assets.working_directory("examples/post_process/assets"))?
+		font = Draw.default_font!()
 		target = Draw.RenderTexture.load!({ width: 800, height: 600 })?
 		shader = Draw.Shader.from_store!(assets, { vertex_path: "", fragment_path: "post_process.fs" })?
 		time_uniform = shader.uniform_f32!("time")?
-		Ok({ target, shader, time_uniform, seconds: 0 })
+		Ok({ font, target, shader, time_uniform, seconds: 0 })
 	},
 )
 
@@ -68,8 +71,12 @@ render! = |model, frame| {
 			offscreen = target_frame.size!()
 			center = { x: offscreen.width * 0.5, y: offscreen.height * 0.62 }
 			target_frame.rectangle_gradient_v!({ x: 0, y: 0, width: offscreen.width, height: offscreen.height, color_top: Color.from_hex_rgb(0x1a1140), color_bottom: Color.from_hex_rgb(0x060716) })
-			target_frame.text_centered!({ pos: { x: center.x, y: 96 }, text: "offscreen + shader", size: 48, color: Color.ray_white })
-			target_frame.text_centered!({ pos: { x: center.x, y: 152 }, text: "render texture -> additive blend -> fragment shader   (ESC quits)", size: 18, color: Color.from_hex_rgb(0x9d8fd0) })
+			Text.from("offscreen + shader", model.font)
+				.size(48)
+				.draw!(target_frame, { pos: { x: center.x, y: 96 }, color: Color.ray_white, align: Text.align_center })
+			Text.from("render texture -> additive blend -> fragment shader   (ESC quits)", model.font)
+				.size(18)
+				.draw!(target_frame, { pos: { x: center.x, y: 152 }, color: Color.from_hex_rgb(0x9d8fd0), align: Text.align_center })
 			target_frame.with_blend_mode!(
 				Draw.additive_blend,
 				|blend_frame| {

--- a/examples/post_process/main.roc
+++ b/examples/post_process/main.roc
@@ -73,10 +73,10 @@ render! = |model, frame| {
 			target_frame.rectangle_gradient_v!({ x: 0, y: 0, width: offscreen.width, height: offscreen.height, color_top: Color.from_hex_rgb(0x1a1140), color_bottom: Color.from_hex_rgb(0x060716) })
 			Text.from("offscreen + shader", model.font)
 				.size(48)
-				.draw!(target_frame, { pos: { x: center.x, y: 96 }, color: Color.ray_white, align: Text.align_center })
+				.draw!(target_frame, { pos: { x: center.x, y: 96 }, color: Color.ray_white, align: (Middle, Center) })
 			Text.from("render texture -> additive blend -> fragment shader   (ESC quits)", model.font)
 				.size(18)
-				.draw!(target_frame, { pos: { x: center.x, y: 152 }, color: Color.from_hex_rgb(0x9d8fd0), align: Text.align_center })
+				.draw!(target_frame, { pos: { x: center.x, y: 152 }, color: Color.from_hex_rgb(0x9d8fd0), align: (Middle, Center) })
 			target_frame.with_blend_mode!(
 				Draw.additive_blend,
 				|blend_frame| {

--- a/examples/postcard_studio/main.roc
+++ b/examples/postcard_studio/main.roc
@@ -201,8 +201,8 @@ render! = |model, frame| {
 				},
 			)
 
-			card.title.draw!(poster, { pos: { x: 84, y: 80 }, color: colors.ink, align: Text.align_top_left })
-			card.subtitle.draw!(poster, { pos: { x: 88, y: 172 }, color: Color.with_alpha(colors.ink, 210), align: Text.align_top_left })
+			card.title.draw!(poster, { pos: { x: 84, y: 80 }, color: colors.ink })
+			card.subtitle.draw!(poster, { pos: { x: 88, y: 172 }, color: Color.with_alpha(colors.ink, 210) })
 			Ok({})
 		},
 	)?
@@ -224,8 +224,8 @@ render! = |model, frame| {
 	frame.rectangle!({ x: 0, y: window_height - 46, width: window_width, height: 1, style: Draw.filled(Color.with_alpha(colors.ink, 60)) })
 
 	chrome = Box.unbox(model.chrome)
-	chrome.help.draw!(frame, { pos: { x: 24, y: window_height - 23 }, color: Color.with_alpha(colors.ink, 170), align: Text.align_middle_left })
-	model.status.draw!(frame, { pos: { x: 696, y: window_height - 23 }, color: colors.ink, align: Text.align_middle_right })
+	chrome.help.draw!(frame, { pos: { x: 24, y: window_height - 23 }, color: Color.with_alpha(colors.ink, 170), align: (Middle, Left) })
+	model.status.draw!(frame, { pos: { x: 696, y: window_height - 23 }, color: colors.ink, align: (Middle, Right) })
 
 	Ok({})
 }

--- a/examples/projective_texture/main.roc
+++ b/examples/projective_texture/main.roc
@@ -134,7 +134,7 @@ render! = |model, frame| {
 	frame.circle!({ center: model.corners.top_right, radius: 13, style: Draw.filled_and_outlined(Color.from_hex_rgb(0x2f80ed), Color.white, 3) })
 
 	frame.rounded_rectangle!({ x: 150, y: 552, width: 500, height: 34, radius: 10, segments: 8, style: Draw.filled(Color.with_alpha(Color.black, 130)) })
-	model.guide.draw!(frame, { pos: { x: 400, y: 559 }, color: Color.ray_white, align: Text.align_top_center })
+	model.guide.draw!(frame, { pos: { x: 400, y: 559 }, color: Color.ray_white, align: (Top, Center) })
 
 	Ok({})
 }

--- a/examples/responsive_ui/main.roc
+++ b/examples/responsive_ui/main.roc
@@ -222,13 +222,13 @@ draw_menu_item! = |frame, bounds, label, selected, hovered| {
 	if selected {
 		frame.rounded_rectangle!({ x: bounds.x + 8, y: bounds.y + 10, width: 4, height: bounds.height - 20, radius: 2, segments: 4, style: Draw.filled(theme.accent) })
 	}
-	label.draw!(frame, { pos: { x: bounds.x + 22, y: bounds.y + bounds.height * 0.5 }, color: if selected theme.ink else theme.muted, align: Text.align_middle_left })
+	label.draw!(frame, { pos: { x: bounds.x + 22, y: bounds.y + bounds.height * 0.5 }, color: if selected theme.ink else theme.muted, align: (Middle, Left) })
 }
 
 draw_key! : Draw.Frame, Text.Font, F32, F32, Str => {}
 draw_key! = |frame, font, x, y, label| {
 	frame.rounded_rectangle!({ x, y, width: 68, height: 44, radius: 8, segments: 8, style: Draw.filled_and_outlined(theme.panel_high, theme.edge, 2) })
-	Text.from(label, font).size(18).draw!(frame, { pos: { x: x + 34, y: y + 22 }, color: theme.ink, align: Text.align_center })
+	Text.from(label, font).size(18).draw!(frame, { pos: { x: x + 34, y: y + 22 }, color: theme.ink, align: (Middle, Center) })
 }
 
 draw_preview! : Draw.Frame, Math.Rect, Selection, UiCopy, Draw.FrameSize, Model => {}
@@ -243,7 +243,7 @@ draw_preview! = |frame, bounds, selection, ui, screen, model| {
 	}
 	# The preview reads as a card of its own, not as a hole in the background.
 	frame.rectangle!({ x: bounds.x, y: bounds.y, width: bounds.width, height: bounds.height, style: Draw.outlined(theme.edge, 2) })
-	body.draw!(frame, { pos: { x: bounds.x + 28, y: bounds.y + 28 }, color: theme.ink, align: Text.align_top_left })
+	body.draw!(frame, { pos: { x: bounds.x + 28, y: bounds.y + 28 }, color: theme.ink })
 
 	match selection {
 		Display => {
@@ -382,8 +382,8 @@ render! = |model, frame| {
 	hover_controls = view.controls_bounds.contains(model.mouse)
 
 	frame.clear!(theme.bg)
-	ui.title.draw!(frame, { pos: { x: view.margin, y: 24 }, color: theme.ink, align: Text.align_top_left })
-	ui.subtitle.draw!(frame, { pos: { x: view.margin, y: 70 }, color: theme.muted, align: Text.align_top_left })
+	ui.title.draw!(frame, { pos: { x: view.margin, y: 24 }, color: theme.ink })
+	ui.subtitle.draw!(frame, { pos: { x: view.margin, y: 70 }, color: theme.muted })
 	# A hairline under the header, drawn to the live width so it follows a resize.
 	frame.rectangle!({ x: view.margin, y: 96, width: screen.width - view.margin * 2, height: 1, style: Draw.filled(theme.edge) })
 	frame.rounded_rectangle!({ x: view.nav.x, y: view.nav.y, width: view.nav.width, height: view.nav.height, radius: 14, segments: 8, style: Draw.filled_and_outlined(theme.panel, theme.edge, 1) })
@@ -397,7 +397,7 @@ render! = |model, frame| {
 			Ok({})
 		},
 	)?
-	ui.help.draw!(frame, { pos: { x: view.margin, y: view.screen_h - 24 }, color: theme.faint, align: Text.align_bottom_left })
+	ui.help.draw!(frame, { pos: { x: view.margin, y: view.screen_h - 24 }, color: theme.faint, align: (Bottom, Left) })
 
 	Ok({})
 }

--- a/examples/responsive_ui/main.roc
+++ b/examples/responsive_ui/main.roc
@@ -53,6 +53,7 @@ Selection := [Display, AudioSettings, Controls].{
 }
 
 UiCopy : {
+	font : Text.Font,
 	title : Text.Prepared,
 	subtitle : Text.Prepared,
 	display : Text.Prepared,
@@ -64,10 +65,10 @@ UiCopy : {
 	help : Text.Prepared,
 }
 
-## State retained between updates: prepared labels, the selected panel and
-## pointer position, animation time, monitor choices, and demo mode. Window
-## size is intentionally omitted because `update!` and `render!` each receive
-## the current size when they need it.
+## State retained between updates: the font and prepared labels, the selected
+## panel and pointer position, animation time, monitor choices, and demo mode.
+## Window size is intentionally omitted because `update!` and `render!` each
+## receive the current size when they need it.
 Model : {
 	ui : Box(UiCopy),
 	selection : Selection,
@@ -120,6 +121,7 @@ init! = App.init_for_args(
 		font = Draw.default_font!()
 		Ok({
 			ui: Box.box({
+				font,
 				title: Text.from("Settings", font).size(38).prepare!()?,
 				subtitle: Text.from("A resizable, input-aware application screen", font).size(18).prepare!()?,
 				display: Text.from("Display", font).size(22).prepare!()?,
@@ -223,10 +225,10 @@ draw_menu_item! = |frame, bounds, label, selected, hovered| {
 	label.draw!(frame, { pos: { x: bounds.x + 22, y: bounds.y + bounds.height * 0.5 }, color: if selected theme.ink else theme.muted, align: Text.align_middle_left })
 }
 
-draw_key! : Draw.Frame, F32, F32, Str => {}
-draw_key! = |frame, x, y, label| {
+draw_key! : Draw.Frame, Text.Font, F32, F32, Str => {}
+draw_key! = |frame, font, x, y, label| {
 	frame.rounded_rectangle!({ x, y, width: 68, height: 44, radius: 8, segments: 8, style: Draw.filled_and_outlined(theme.panel_high, theme.edge, 2) })
-	frame.text_centered!({ pos: { x: x + 34, y: y + 22 }, text: label, size: 18, color: theme.ink })
+	Text.from(label, font).size(18).draw!(frame, { pos: { x: x + 34, y: y + 22 }, color: theme.ink, align: Text.align_center })
 }
 
 draw_preview! : Draw.Frame, Math.Rect, Selection, UiCopy, Draw.FrameSize, Model => {}
@@ -267,9 +269,9 @@ draw_preview! = |frame, bounds, selection, ui, screen, model| {
 		}
 		Controls => {
 			frame.text_at!({ pos: { x: bounds.x + 28, y: bounds.y + 76 }, text: "Move", size: 18, color: theme.muted })
-			draw_key!(frame, bounds.x + 28, bounds.y + 112, "WASD")
+			draw_key!(frame, ui.font, bounds.x + 28, bounds.y + 112, "WASD")
 			frame.text_at!({ pos: { x: bounds.x + 28, y: bounds.y + 182 }, text: "Command", size: 18, color: theme.muted })
-			draw_key!(frame, bounds.x + 28, bounds.y + 218, "SPACE")
+			draw_key!(frame, ui.font, bounds.x + 28, bounds.y + 218, "SPACE")
 		}
 	}
 }

--- a/examples/snake/main.roc
+++ b/examples/snake/main.roc
@@ -545,11 +545,11 @@ draw_board! = |frame| {
 
 draw_hud! : Draw.Frame, Model => {}
 draw_hud! = |frame, model| {
-	model.title.draw!(frame, { pos: { x: board_x, y: 26 }, color: snake_head, align: Text.align_top_left })
+	model.title.draw!(frame, { pos: { x: board_x, y: 26 }, color: snake_head })
 	Text.from("SCORE ${U64.to_str(model.score)}", model.font)
 		.size(24)
-		.draw!(frame, { pos: { x: screen_w - board_x, y: 30 }, color: Color.from_hex_rgb(0xd7e3ff), align: Text.align_top_right })
-	model.hint.draw!(frame, { pos: { x: screen_w * 0.5, y: screen_h - 20 }, color: hint_color, align: Text.align_center })
+		.draw!(frame, { pos: { x: screen_w - board_x, y: 30 }, color: Color.from_hex_rgb(0xd7e3ff), align: (Top, Right) })
+	model.hint.draw!(frame, { pos: { x: screen_w * 0.5, y: screen_h - 20 }, color: hint_color, align: (Middle, Center) })
 }
 
 draw_game_over! : Draw.Frame, Model => {}
@@ -559,10 +559,10 @@ draw_game_over! = |frame, model|
 		GameOver => {
 			board_w = I32.to_f32(grid_cols) * cell_size
 			frame.rectangle!({ x: board_x - 8, y: 236, width: board_w + 16, height: 140, style: Draw.filled(Color.with_alpha(field_bottom, 225)) })
-			model.over_title.draw!(frame, { pos: { x: screen_w * 0.5, y: 282 }, color: food_neon, align: Text.align_center })
+			model.over_title.draw!(frame, { pos: { x: screen_w * 0.5, y: 282 }, color: food_neon, align: (Middle, Center) })
 			# The prompt breathes on the same clock as the food, so a waiting
 			# screen still has a heartbeat.
 			prompt_alpha = F32.to_u8_wrap(150 + 105 * food_pulse(model))
-			model.over_hint.draw!(frame, { pos: { x: screen_w * 0.5, y: 336 }, color: Color.with_alpha(hint_color, prompt_alpha), align: Text.align_center })
+			model.over_hint.draw!(frame, { pos: { x: screen_w * 0.5, y: 336 }, color: Color.with_alpha(hint_color, prompt_alpha), align: (Middle, Center) })
 		}
 	}

--- a/examples/snake/main.roc
+++ b/examples/snake/main.roc
@@ -546,7 +546,9 @@ draw_board! = |frame| {
 draw_hud! : Draw.Frame, Model => {}
 draw_hud! = |frame, model| {
 	model.title.draw!(frame, { pos: { x: board_x, y: 26 }, color: snake_head, align: Text.align_top_left })
-	frame.text!({ pos: { x: screen_w - board_x, y: 30 }, text: "SCORE ${U64.to_str(model.score)}", size: 24, spacing: Draw.default_spacing, color: Color.from_hex_rgb(0xd7e3ff), font: model.font, align: Draw.align_top_right })
+	Text.from("SCORE ${U64.to_str(model.score)}", model.font)
+		.size(24)
+		.draw!(frame, { pos: { x: screen_w - board_x, y: 30 }, color: Color.from_hex_rgb(0xd7e3ff), align: Text.align_top_right })
 	model.hint.draw!(frame, { pos: { x: screen_w * 0.5, y: screen_h - 20 }, color: hint_color, align: Text.align_center })
 }
 

--- a/examples/sqlite_scores/main.roc
+++ b/examples/sqlite_scores/main.roc
@@ -316,8 +316,8 @@ render! = |model, frame| {
 	frame.rectangle_gradient_v!({ x: 0, y: 0, width: size.width, height: size.height, color_top: bg_top, color_bottom: bg_bottom })
 	frame.circle_gradient!({ center: { x: size.width * 0.5, y: -40 }, radius: size.height, color_inner: Color.from_hex_rgba(0x3a5f9c33), color_outer: Color.from_hex_rgba(0x00000000) })
 
-	model.title.draw!(frame, { pos: { x: 44, y: 36 }, color: ink, align: Text.align_top_left })
-	model.subtitle.draw!(frame, { pos: { x: 44, y: 72 }, color: muted, align: Text.align_top_left })
+	model.title.draw!(frame, { pos: { x: 44, y: 36 }, color: ink })
+	model.subtitle.draw!(frame, { pos: { x: 44, y: 72 }, color: muted })
 
 	width = size.width - 88
 	frame.rounded_rectangle!({ x: 44, y: 112, width: width, height: 388, radius: 0.05, segments: 8, style: Draw.filled_and_outlined(panel, card_edge, 1) })
@@ -338,7 +338,7 @@ render! = |model, frame| {
 	}
 
 	draw_status!(frame, model.status, model.elapsed, size.height - 46)
-	model.hint.draw!(frame, { pos: { x: 44, y: size.height - 40 }, color: faint, align: Text.align_top_left })
+	model.hint.draw!(frame, { pos: { x: 44, y: size.height - 40 }, color: faint })
 	Ok({})
 }
 

--- a/examples/task_sleep/main.roc
+++ b/examples/task_sleep/main.roc
@@ -125,10 +125,10 @@ render! = |model, frame| {
 	frame.rectangle_gradient_v!({ x: 0, y: 0, width: 800, height: 600, color_top: Color.from_hex_rgb(0x1b2136), color_bottom: Color.from_hex_rgb(0x0a0c15) })
 	frame.circle_gradient!({ center, radius: 260, color_inner: Color.with_alpha(Color.from_hex_rgb(0x5e81ac), 40), color_outer: Color.with_alpha(Color.from_hex_rgb(0x5e81ac), 0) })
 
-	model.title.draw!(frame, { pos: { x: 40, y: 40 }, color: Color.white, align: Text.align_top_left })
+	model.title.draw!(frame, { pos: { x: 40, y: 40 }, color: Color.white })
 	frame.text_at!({ pos: { x: 40, y: 78 }, text: Str.concat("cycle ", U64.to_str(model.cycle)), size: 20, color: Color.from_hex_rgb(0x88c0d0) })
 	frame.text_at!({ pos: { x: 40, y: 106 }, text: describe(model.state), size: 20, color: Color.from_hex_rgb(0xa3be8c) })
-	model.hint.draw!(frame, { pos: { x: 40, y: 552 }, color: Color.from_hex_rgb(0x6b7590), align: Text.align_top_left })
+	model.hint.draw!(frame, { pos: { x: 40, y: 552 }, color: Color.from_hex_rgb(0x6b7590) })
 
 	# The track, then the arc the sleeper has used up so far.
 	frame.circle!({ center, radius: 150, style: Draw.outlined(Color.with_alpha(Color.white, 35), 3) })

--- a/examples/top_down/main.roc
+++ b/examples/top_down/main.roc
@@ -1273,7 +1273,7 @@ draw_spawn! = |frame, level, font| {
 	frame.circle!({ center: level.spawn, radius: 42, style: Draw.filled_and_outlined(Color.from_hex_rgb(0x2a9d8f), Color.white, 4) })
 	Text.from("START", font)
 		.size(18)
-		.draw!(frame, { pos: { x: level.spawn.x, y: level.spawn.y + 63 }, color: Color.with_alpha(Color.white, 190), align: Text.align_top_center })
+		.draw!(frame, { pos: { x: level.spawn.x, y: level.spawn.y + 63 }, color: Color.with_alpha(Color.white, 190), align: (Top, Center) })
 }
 
 draw_exit! : Draw.Frame, Level, World, Text.Font => {}
@@ -1285,7 +1285,7 @@ draw_exit! = |frame, level, world, font| {
 	frame.circle!({ center: level.exit_center, radius: level.exit_radius, style: Draw.filled_and_outlined(Color.with_alpha(color, 190), Color.white, 4) })
 	Text.from(if is_open "EXIT OPEN" else "LOCKED EXIT", font)
 		.size(19)
-		.draw!(frame, { pos: { x: level.exit_center.x, y: level.exit_center.y + 74 }, color: Color.white, align: Text.align_top_center })
+		.draw!(frame, { pos: { x: level.exit_center.x, y: level.exit_center.y + 74 }, color: Color.white, align: (Top, Center) })
 }
 
 draw_obstacle! : Draw.Frame, Draw.Texture, World.Obstacle => {}
@@ -1468,8 +1468,8 @@ draw_modal! : Draw.Frame, Text.Font, Str, Str, Color.Rgba => {}
 draw_modal! = |frame, font, title, subtitle, accent| {
 	frame.rectangle!({ x: 0, y: 0, width: screen_w, height: screen_h, style: Draw.filled(Color.with_alpha(Color.black, 120)) })
 	frame.rounded_rectangle!({ x: 185, y: 226, width: 430, height: 152, radius: 8, segments: 8, style: Draw.filled_and_outlined(Color.with_alpha(Color.black, 230), accent, 4) })
-	Text.from(title, font).size(30).draw!(frame, { pos: { x: screen_w * 0.5, y: 276 }, color: Color.white, align: Text.align_center })
-	Text.from(subtitle, font).size(21).draw!(frame, { pos: { x: screen_w * 0.5, y: 326 }, color: Color.light_gray, align: Text.align_center })
+	Text.from(title, font).size(30).draw!(frame, { pos: { x: screen_w * 0.5, y: 276 }, color: Color.white, align: (Middle, Center) })
+	Text.from(subtitle, font).size(21).draw!(frame, { pos: { x: screen_w * 0.5, y: 326 }, color: Color.light_gray, align: (Middle, Center) })
 }
 
 approx : F32, F32 -> Bool

--- a/examples/top_down/main.roc
+++ b/examples/top_down/main.roc
@@ -1271,7 +1271,9 @@ draw_spawn! : Draw.Frame, Level, Text.Font => {}
 draw_spawn! = |frame, level, font| {
 	frame.circle_gradient!({ center: level.spawn, radius: 72, color_inner: Color.with_alpha(Color.from_hex_rgb(0x2a9d8f), 120), color_outer: Color.with_alpha(Color.from_hex_rgb(0x2a9d8f), 0) })
 	frame.circle!({ center: level.spawn, radius: 42, style: Draw.filled_and_outlined(Color.from_hex_rgb(0x2a9d8f), Color.white, 4) })
-	frame.text!({ pos: { x: level.spawn.x, y: level.spawn.y + 63 }, text: "START", size: 18, spacing: Draw.default_spacing, color: Color.with_alpha(Color.white, 190), font, align: Draw.align_top_center })
+	Text.from("START", font)
+		.size(18)
+		.draw!(frame, { pos: { x: level.spawn.x, y: level.spawn.y + 63 }, color: Color.with_alpha(Color.white, 190), align: Text.align_top_center })
 }
 
 draw_exit! : Draw.Frame, Level, World, Text.Font => {}
@@ -1281,7 +1283,9 @@ draw_exit! = |frame, level, world, font| {
 	halo = if is_open Color.with_alpha(color, 95) else Color.with_alpha(Color.black, 70)
 	frame.circle_gradient!({ center: level.exit_center, radius: 82 + world.gate_flash * 28, color_inner: halo, color_outer: Color.with_alpha(color, 0) })
 	frame.circle!({ center: level.exit_center, radius: level.exit_radius, style: Draw.filled_and_outlined(Color.with_alpha(color, 190), Color.white, 4) })
-	frame.text!({ pos: { x: level.exit_center.x, y: level.exit_center.y + 74 }, text: if is_open "EXIT OPEN" else "LOCKED EXIT", size: 19, spacing: Draw.default_spacing, color: Color.white, font, align: Draw.align_top_center })
+	Text.from(if is_open "EXIT OPEN" else "LOCKED EXIT", font)
+		.size(19)
+		.draw!(frame, { pos: { x: level.exit_center.x, y: level.exit_center.y + 74 }, color: Color.white, align: Text.align_top_center })
 }
 
 draw_obstacle! : Draw.Frame, Draw.Texture, World.Obstacle => {}
@@ -1438,14 +1442,14 @@ draw_hud! = |frame, level, world, font| {
 	is_open = gate_is_open(world.gate)
 
 	frame.rectangle_gradient_v!({ x: 0, y: 0, width: screen_w, height: 76, color_top: Color.with_alpha(Color.black, 220), color_bottom: Color.with_alpha(Color.black, 125) })
-	frame.text!({ pos: { x: 22, y: 16 }, text: "Spark Run", size: 27, spacing: Draw.default_spacing, color: Color.white, font: font, align: Draw.align_top_left })
-	frame.text!({ pos: { x: 195, y: 18 }, text: Str.concat("Sparks ", Str.concat(U64.to_str(world.score), Str.concat("/", U64.to_str(level.spark_total)))), size: 20, spacing: Draw.default_spacing, color: Color.from_hex_rgb(0xf9c74f), font: font, align: Draw.align_top_left })
-	frame.text!({ pos: { x: 382, y: 18 }, text: Str.concat("Lives ", U64.to_str(world.lives)), size: 20, spacing: Draw.default_spacing, color: Color.light_gray, font: font, align: Draw.align_top_left })
-	frame.text!({ pos: { x: 510, y: 18 }, text: if is_open "Gate open" else "Collect all sparks", size: 20, spacing: Draw.default_spacing, color: if is_open Color.from_hex_rgb(0x90be6d) else Color.light_gray, font: font, align: Draw.align_top_left })
+	frame.text!({ pos: { x: 22, y: 16 }, text: "Spark Run", size: 27, spacing: Draw.default_spacing, color: Color.white, font: font })
+	frame.text!({ pos: { x: 195, y: 18 }, text: Str.concat("Sparks ", Str.concat(U64.to_str(world.score), Str.concat("/", U64.to_str(level.spark_total)))), size: 20, spacing: Draw.default_spacing, color: Color.from_hex_rgb(0xf9c74f), font: font })
+	frame.text!({ pos: { x: 382, y: 18 }, text: Str.concat("Lives ", U64.to_str(world.lives)), size: 20, spacing: Draw.default_spacing, color: Color.light_gray, font: font })
+	frame.text!({ pos: { x: 510, y: 18 }, text: if is_open "Gate open" else "Collect all sparks", size: 20, spacing: Draw.default_spacing, color: if is_open Color.from_hex_rgb(0x90be6d) else Color.light_gray, font: font })
 	frame.fps!({ pos: { x: 735, y: 20 }, size: 18, color: Color.gray })
 	draw_bar!(frame, 196, 48, 170, 9, U64.to_f32(world.score) / U64.to_f32(level.spark_total), Color.from_hex_rgb(0xf9c74f))
 	draw_bar!(frame, 510, 48, 120, 9, world.player.dash_charge(), Color.from_hex_rgb(0x43aa8b))
-	frame.text!({ pos: { x: 640, y: 43 }, text: if world.player.dash_ready() "SPACE dash" else "charging", size: 16, spacing: Draw.default_spacing, color: Color.light_gray, font: font, align: Draw.align_top_left })
+	frame.text!({ pos: { x: 640, y: 43 }, text: if world.player.dash_ready() "SPACE dash" else "charging", size: 16, spacing: Draw.default_spacing, color: Color.light_gray, font: font })
 
 	if world.flash > 0 {
 		frame.rectangle!({ x: 0, y: 0, width: screen_w, height: screen_h, style: Draw.filled(Color.with_alpha(Color.red, if world.flash > 0.45 120 else 70)) })
@@ -1455,17 +1459,17 @@ draw_hud! = |frame, level, world, font| {
 
 	match world.state {
 		Playing => {}
-		Won => draw_modal!(frame, "All sparks recovered", "Press SPACE to run again", Color.from_hex_rgb(0x43aa8b))
-		GameOver => draw_modal!(frame, "Spark Run ended", "Press SPACE to restart", Color.from_hex_rgb(0xf94144))
+		Won => draw_modal!(frame, font, "All sparks recovered", "Press SPACE to run again", Color.from_hex_rgb(0x43aa8b))
+		GameOver => draw_modal!(frame, font, "Spark Run ended", "Press SPACE to restart", Color.from_hex_rgb(0xf94144))
 	}
 }
 
-draw_modal! : Draw.Frame, Str, Str, Color.Rgba => {}
-draw_modal! = |frame, title, subtitle, accent| {
+draw_modal! : Draw.Frame, Text.Font, Str, Str, Color.Rgba => {}
+draw_modal! = |frame, font, title, subtitle, accent| {
 	frame.rectangle!({ x: 0, y: 0, width: screen_w, height: screen_h, style: Draw.filled(Color.with_alpha(Color.black, 120)) })
 	frame.rounded_rectangle!({ x: 185, y: 226, width: 430, height: 152, radius: 8, segments: 8, style: Draw.filled_and_outlined(Color.with_alpha(Color.black, 230), accent, 4) })
-	frame.text_centered!({ pos: { x: screen_w * 0.5, y: 276 }, text: title, size: 30, color: Color.white })
-	frame.text_centered!({ pos: { x: screen_w * 0.5, y: 326 }, text: subtitle, size: 21, color: Color.light_gray })
+	Text.from(title, font).size(30).draw!(frame, { pos: { x: screen_w * 0.5, y: 276 }, color: Color.white, align: Text.align_center })
+	Text.from(subtitle, font).size(21).draw!(frame, { pos: { x: screen_w * 0.5, y: 326 }, color: Color.light_gray, align: Text.align_center })
 }
 
 approx : F32, F32 -> Bool

--- a/examples/udp_cursor/main.roc
+++ b/examples/udp_cursor/main.roc
@@ -207,8 +207,8 @@ render! = |model, frame| {
 	}
 	draw_pointer!(frame, model.pointer, accent_local, "you", 13)
 
-	model.title.draw!(frame, { pos: { x: 44, y: 36 }, color: ink, align: Text.align_top_left })
-	model.subtitle.draw!(frame, { pos: { x: 44, y: 72 }, color: muted, align: Text.align_top_left })
+	model.title.draw!(frame, { pos: { x: 44, y: 36 }, color: ink })
+	model.subtitle.draw!(frame, { pos: { x: 44, y: 72 }, color: muted })
 
 	local = Udp.Socket.local_address(model.socket)
 	frame.rounded_rectangle!({ x: 44, y: 112, width: 384, height: 96, radius: 0.12, segments: 8, style: Draw.filled_and_outlined(card, card_edge, 1) })
@@ -219,7 +219,7 @@ render! = |model, frame| {
 	frame.text_at!({ pos: { x: 64, y: 178 }, text: "${U64.to_str(model.received)} received", size: 14, color: muted })
 	frame.text_at!({ pos: { x: 232, y: 178 }, text: "${U64.to_str(model.dropped)} not sent", size: 14, color: if model.dropped == 0 muted else accent_bad })
 
-	model.hint.draw!(frame, { pos: { x: 44, y: size.height - 40 }, color: faint, align: Text.align_top_left })
+	model.hint.draw!(frame, { pos: { x: 44, y: size.height - 40 }, color: faint })
 	Ok({})
 }
 

--- a/platform/Draw.roc
+++ b/platform/Draw.roc
@@ -30,8 +30,8 @@
 ## Most shapes support equivalent receiver and free-function forms, such as
 ## `frame.circle!(cfg)` and `Draw.circle!(frame, cfg)`.
 ##
-## `Draw.text!` draws without a layout pass. Use `Text` to measure, wrap, align,
-## or prepare text.
+## `Draw.text!` draws at an already-resolved top-left origin without a layout
+## pass. Use `Text` for optional anchor alignment or prepared text.
 import Assets
 import Camera
 import Color
@@ -367,19 +367,7 @@ Draw := [].{
 	## Text measurement result.
 	TextSize : Font.Size
 
-	## Horizontal text anchor.
-	HAlign : [Left, Center, Right]
-
-	## Vertical text anchor.
-	VAlign : [Top, Middle, Bottom]
-
-	## Horizontal and vertical text anchor.
-	TextAlign : {
-		horizontal : HAlign,
-		vertical : VAlign,
-	}
-
-	## Fully configured text draw.
+	## Fully configured text draw at a resolved top-left origin.
 	Text : {
 		pos : Vector2,
 		text : Str,
@@ -387,7 +375,6 @@ Draw := [].{
 		spacing : F32,
 		color : Color.Rgba,
 		font : Font,
-		align : TextAlign,
 	}
 
 	## Built-in-font text intended for quick diagnostics.
@@ -882,90 +869,6 @@ Draw := [].{
 	default_spacing : F32
 	default_spacing = 1
 
-	## Top-left text anchor.
-	##
-	## These nine constants and `align_offset` are the older alignment set, for
-	## `Draw.text_at!`. `Text.align_top_left` and its siblings are the ones to
-	## reach for: they are the same nine anchors, and they are what
-	## `Text.Prepared.draw!` takes.
-	align_top_left : TextAlign
-	align_top_left = { horizontal: Left, vertical: Top }
-
-	## Top-center text anchor.
-	align_top_center : TextAlign
-	align_top_center = { horizontal: Center, vertical: Top }
-
-	## Top-right text anchor.
-	align_top_right : TextAlign
-	align_top_right = { horizontal: Right, vertical: Top }
-
-	## Centered text anchor.
-	align_center : TextAlign
-	align_center = { horizontal: Center, vertical: Middle }
-
-	## Middle-left text anchor.
-	align_middle_left : TextAlign
-	align_middle_left = { horizontal: Left, vertical: Middle }
-
-	## Middle-right text anchor.
-	align_middle_right : TextAlign
-	align_middle_right = { horizontal: Right, vertical: Middle }
-
-	## Bottom-left text anchor.
-	align_bottom_left : TextAlign
-	align_bottom_left = { horizontal: Left, vertical: Bottom }
-
-	## Bottom-center text anchor.
-	align_bottom_center : TextAlign
-	align_bottom_center = { horizontal: Center, vertical: Bottom }
-
-	## Bottom-right text anchor.
-	align_bottom_right : TextAlign
-	align_bottom_right = { horizontal: Right, vertical: Bottom }
-
-	## Convert a measured size and alignment into an anchor offset.
-	align_offset : TextSize, TextAlign -> Vector2
-	align_offset = |size, align| {
-		x = match align.horizontal {
-			Left => 0
-			Center => size.width * 0.5
-			Right => size.width
-		}
-
-		y = match align.vertical {
-			Top => 0
-			Middle => size.height * 0.5
-			Bottom => size.height
-		}
-
-		{ x, y }
-	}
-
-	## Find the top-left text origin for an anchored position.
-	origin_for : Vector2, TextSize, TextAlign -> Vector2
-	origin_for = |pos, size, align| {
-		offset = Draw.align_offset(size, align)
-		{ x: pos.x - offset.x, y: pos.y - offset.y }
-	}
-
-	## Convert text alignment into horizontal and vertical factors from 0 to 1.
-	align_factor : TextAlign -> Vector2
-	align_factor = |align| {
-		x = match align.horizontal {
-			Left => 0
-			Center => 0.5
-			Right => 1
-		}
-
-		y = match align.vertical {
-			Top => 0
-			Middle => 0.5
-			Bottom => 1
-		}
-
-		{ x, y }
-	}
-
 	## Find the top-left position that centers measured text in a rectangle.
 	center_in_rect : Rectangle, TextSize -> Vector2
 	center_in_rect = |rect, size| {
@@ -1364,71 +1267,54 @@ Draw := [].{
 		}
 	}
 
-	## Draw text using explicit font, spacing, color, and anchor alignment.
+	## Draw text using an explicit font, spacing, color, and resolved top-left
+	## origin. This performs no measurement or alignment pass.
 	##
 	## Legal in `render!` only.
 	text! : Frame, Text => {}
-	text! = |_frame, cfg| {
-		align = Draw.align_factor(cfg.align)
-		DrawHost.text_aligned!({
+	text! = |_frame, cfg|
+		DrawHost.text!({
 			pos: cfg.pos,
 			text: cfg.text,
 			size: cfg.size,
 			spacing: cfg.spacing,
 			color: cfg.color,
 			font: cfg.font.handle,
-			align_x: align.x,
-			align_y: align.y,
 		})
-	}
 
 	## Draw top-left aligned text with the built-in font and default spacing.
 	##
 	## Legal in `render!` only.
 	debug_text! : Frame, DebugText => {}
-	debug_text! = |_frame, cfg|
-		DrawHost.text_aligned!({
-			pos: cfg.pos,
-			text: cfg.text,
-			size: cfg.size,
-			spacing: Draw.default_spacing,
-			color: cfg.color,
-			font: Font.stub.handle,
-			align_x: 0,
-			align_y: 0,
-		})
+	debug_text! = |frame, cfg|
+		Draw.text!(
+			frame,
+			{
+				pos: cfg.pos,
+				text: cfg.text,
+				size: cfg.size,
+				spacing: Draw.default_spacing,
+				color: cfg.color,
+				font: Font.stub,
+			},
+		)
 
 	## Draw simple top-left aligned text with the built-in font.
 	##
 	## Legal in `render!` only.
 	text_at! : Frame, SimpleText => {}
-	text_at! = |_frame, cfg|
-		DrawHost.text_aligned!({
-			pos: cfg.pos,
-			text: cfg.text,
-			size: cfg.size,
-			spacing: Draw.default_spacing,
-			color: cfg.color,
-			font: Font.stub.handle,
-			align_x: 0,
-			align_y: 0,
-		})
-
-	## Draw simple text centered on its position.
-	##
-	## Legal in `render!` only.
-	text_centered! : Frame, SimpleText => {}
-	text_centered! = |_frame, cfg|
-		DrawHost.text_aligned!({
-			pos: cfg.pos,
-			text: cfg.text,
-			size: cfg.size,
-			spacing: Draw.default_spacing,
-			color: cfg.color,
-			font: Font.stub.handle,
-			align_x: 0.5,
-			align_y: 0.5,
-		})
+	text_at! = |frame, cfg|
+		Draw.text!(
+			frame,
+			{
+				pos: cfg.pos,
+				text: cfg.text,
+				size: cfg.size,
+				spacing: Draw.default_spacing,
+				color: cfg.color,
+				font: Font.stub,
+			},
+		)
 
 }
 
@@ -1486,9 +1372,6 @@ normalized_color = |color| {
 	w: U8.to_f32(color.a) / 255,
 }
 
-expect Draw.align_factor(Draw.align_top_left) == { x: 0, y: 0 }
-expect Draw.align_factor(Draw.align_center) == { x: 0.5, y: 0.5 }
-expect Draw.align_factor(Draw.align_bottom_right) == { x: 1, y: 1 }
 expect blend_mode_code(Draw.alpha_blend) == 0
 expect blend_mode_code(Draw.premultiplied_alpha_blend) == 5
 expect match Draw.ProjectiveQuad.from_corners({

--- a/platform/DrawHost.roc
+++ b/platform/DrawHost.roc
@@ -64,7 +64,6 @@ DrawHost := [].{
 	PolygonLines : { points : List(Math.Vec2), color : Color.Rgba, thickness : F32 }
 	Fps : { pos : Math.Vec2, size : F32, color : Color.Rgba }
 	Text : { pos : Math.Vec2, text : Str, size : F32, spacing : F32, color : Color.Rgba, font : Font.Handle }
-	TextAligned : { pos : Math.Vec2, text : Str, size : F32, spacing : F32, color : Color.Rgba, font : Font.Handle, align_x : F32, align_y : F32 }
 	GlyphMetric : { codepoint : U32, advance_x : F32, offset_x : F32, offset_y : F32, width : F32, height : F32 }
 	FontMetrics : { base_size : F32, line_spacing : F32, fallback_index : U64, glyphs : List(GlyphMetric) }
 	FrameSize : { width : F32, height : F32 }
@@ -130,7 +129,6 @@ DrawHost := [].{
 	rounded_rectangle! : RoundedRectangle => {}
 	rounded_rectangle_lines! : RoundedRectangleLines => {}
 	text! : Text => {}
-	text_aligned! : TextAligned => {}
 	draw_texture! : TextureDraw => {}
 	draw_texture_instances! : TextureInstances => {}
 	draw_texture_quad! : TextureQuad => {}

--- a/platform/Text.roc
+++ b/platform/Text.roc
@@ -1,7 +1,12 @@
-## Prepare text once, then measure and draw it without per-frame allocation.
+## Align and draw immediate text, or prepare it once to draw repeatedly without
+## per-frame allocation.
 ##
 ## ```roc
 ## title = Text.from("Hello", font).size(38).prepare!()?
+## ```
+##
+## ```roc
+## Text.from("Score", font).size(24).draw!(frame, { pos, color: Color.white, align: Text.align_top_right })
 ## ```
 ##
 ## ```roc
@@ -57,11 +62,13 @@ Text := [].{
 		align : Align,
 	}
 
-	## A string and the style to prepare it with. Start one with `Text.from`,
-	## adjust it with the receivers below, and finish it with `prepare!`.
+	## A string and its drawing style. Start one with `Text.from`, adjust it with
+	## the receivers below, then draw it immediately or finish it with
+	## `prepare!` for repeated drawing.
 	##
-	## A builder is a plain description, so building one costs nothing and it
-	## can be assembled anywhere. Only `prepare!` reaches the host.
+	## A builder is a plain description, so building and measuring one costs
+	## nothing and it can be assembled anywhere. `draw!` and `prepare!` are the
+	## operations that reach the host.
 	Builder :: {
 		content : Str,
 		size : F32,
@@ -85,6 +92,29 @@ Text := [].{
 		## Draw this text in a different font.
 		font : Builder, RrtFont.Font -> Builder
 		font = |builder, value| { ..builder, font: value }
+
+		## Measure this description from the font's immutable metric snapshot,
+		## resolve `placement.align`, and draw it immediately.
+		##
+		## Legal in `render!` only. This is an alignment convenience for text
+		## that does not need a retained `Prepared` resource; `Draw.text!` is the
+		## lower-level operation for callers that already resolved the origin.
+		draw! : Builder, Draw.Frame, Placement => {}
+		draw! = |builder, frame, placement| {
+			measured = builder.font.measure({ text: builder.content, size: builder.size, spacing: builder.spacing })
+			pos = Text.origin_for(placement.pos, measured, placement.align)
+			Draw.text!(
+				frame,
+				{
+					pos,
+					text: builder.content,
+					size: builder.size,
+					spacing: builder.spacing,
+					color: placement.color,
+					font: builder.font,
+				},
+			)
+		}
 
 		## Cache immutable UTF-8 text, font and style, and measurement in the
 		## host.
@@ -194,9 +224,7 @@ Text := [].{
 
 	## Anchor `pos` at the top-left corner of the text.
 	##
-	## These nine constants are the ones to use with `Placement`. `Draw` has a
-	## set under the same names for `Draw.text_at!`, which draws an unprepared
-	## string.
+	## These nine constants are the ones to use with `Placement`.
 	align_top_left : Align
 	align_top_left = { horizontal: Left, vertical: Top }
 

--- a/platform/Text.roc
+++ b/platform/Text.roc
@@ -6,11 +6,11 @@
 ## ```
 ##
 ## ```roc
-## Text.from("Score", font).size(24).draw!(frame, { pos, color: Color.white, align: Text.align_top_right })
+## Text.from("Score", font).size(24).draw!(frame, { pos, color: Color.white, align: (Top, Right) })
 ## ```
 ##
 ## ```roc
-## model.title.draw!(frame, { pos: { x: 400, y: 60 }, color: Color.white, align: Text.align_top_center })
+## model.title.draw!(frame, { pos: { x: 400, y: 60 }, color: Color.white, align: (Top, Center) })
 ## ```
 ##
 ## `Prepared.bounds` returns the measured size. `Placement.align` selects which
@@ -38,12 +38,8 @@ Text := [].{
 	## Which vertical edge or centre of the text `pos` names.
 	VAlign : [Top, Middle, Bottom]
 
-	## Where `pos` sits within the text, in both axes at once. The nine
-	## `align_*` values below are every combination, named.
-	Align : {
-		horizontal : HAlign,
-		vertical : VAlign,
-	}
+	## Where `pos` sits within the text, as `(vertical, horizontal)`.
+	Align : (VAlign, HAlign)
 
 	## A measured width and height, in the same logical units as every drawing
 	## call. This is `Draw.TextSize` and the types package's `Font.Size` under a
@@ -59,7 +55,7 @@ Text := [].{
 	Placement : {
 		pos : Math.Vec2,
 		color : Color.Rgba,
-		align : Align,
+		align : Align ?? (Top, Left),
 	}
 
 	## A string and its drawing style. Start one with `Text.from`, adjust it with
@@ -186,7 +182,7 @@ Text := [].{
 	default_spacing = Draw.default_spacing
 
 	## Start describing a string drawn in a font. Adjust the result with
-	## `size`, `spacing` and `font`, then call `prepare!`.
+	## `size`, `spacing` and `font`, then draw or prepare it.
 	from : Str, RrtFont.Font -> Builder
 	from = |content, font| {
 		content,
@@ -222,56 +218,21 @@ Text := [].{
 		}
 	}
 
-	## Anchor `pos` at the top-left corner of the text.
-	##
-	## These nine constants are the ones to use with `Placement`.
-	align_top_left : Align
-	align_top_left = { horizontal: Left, vertical: Top }
-
-	## Anchor `pos` at the top edge, centred horizontally.
-	align_top_center : Align
-	align_top_center = { horizontal: Center, vertical: Top }
-
-	## Anchor `pos` at the top-right corner of the text.
-	align_top_right : Align
-	align_top_right = { horizontal: Right, vertical: Top }
-
-	## Anchor `pos` at the centre of the text, in both axes.
-	align_center : Align
-	align_center = { horizontal: Center, vertical: Middle }
-
-	## Anchor `pos` at the left edge, centred vertically.
-	align_middle_left : Align
-	align_middle_left = { horizontal: Left, vertical: Middle }
-
-	## Anchor `pos` at the right edge, centred vertically.
-	align_middle_right : Align
-	align_middle_right = { horizontal: Right, vertical: Middle }
-
-	## Anchor `pos` at the bottom-left corner of the text.
-	align_bottom_left : Align
-	align_bottom_left = { horizontal: Left, vertical: Bottom }
-
-	## Anchor `pos` at the bottom edge, centred horizontally.
-	align_bottom_center : Align
-	align_bottom_center = { horizontal: Center, vertical: Bottom }
-
-	## Anchor `pos` at the bottom-right corner of the text.
-	align_bottom_right : Align
-	align_bottom_right = { horizontal: Right, vertical: Bottom }
-
 	## How far the anchor named by an `Align` sits from the text's top-left
 	## corner, for a text of this size. `origin_for` is what a draw uses; this
 	## is the piece it is built from.
 	align_offset : Size, Align -> Math.Vec2
 	align_offset = |size, align| {
-		x = match align.horizontal {
+		vertical = align.0
+		horizontal = align.1
+
+		x = match horizontal {
 			Left => 0
 			Center => size.width * 0.5
 			Right => size.width
 		}
 
-		y = match align.vertical {
+		y = match vertical {
 			Top => 0
 			Middle => size.height * 0.5
 			Bottom => size.height
@@ -296,7 +257,7 @@ Text := [].{
 	## Prefer the receiver. This form takes the frame first, like every other
 	## free drawing function, and takes the text as a field of its config
 	## record rather than as its own argument.
-	draw_prepared! : Draw.Frame, { text : Prepared, pos : Math.Vec2, color : Color.Rgba, align : Align } => {}
+	draw_prepared! : Draw.Frame, { text : Prepared, pos : Math.Vec2, color : Color.Rgba, align : Align ?? (Top, Left) } => {}
 	draw_prepared! = |_frame, cfg| {
 		Prepared.(prepared) = cfg.text
 		pos = Text.origin_for(cfg.pos, prepared.measured, cfg.align)
@@ -304,7 +265,12 @@ Text := [].{
 	}
 }
 
-expect Text.align_offset({ width: 100, height: 40 }, Text.align_center) == { x: 50, y: 20 }
+expect Text.align_offset({ width: 100, height: 40 }, (Middle, Center)) == { x: 50, y: 20 }
+
+default_placement : Text.Placement
+default_placement = { pos: { x: 0, y: 0 }, color: Color.white }
+
+expect default_placement.align == (Top, Left)
 
 ## Prepared text keeps the size the host measured while preparing it, and the
 ## stub has no measurement to keep. Zeroed bounds are the honest answer: they
@@ -313,5 +279,5 @@ expect Text.Prepared.stub.bounds() == { width: 0, height: 0 }
 
 ## With no bounds, every alignment resolves to the placement point itself, which
 ## is what makes drawing a stub harmless in a layout that does happen to run.
-expect Text.origin_for({ x: 40, y: 12 }, Text.Prepared.stub.bounds(), Text.align_center) == { x: 40, y: 12 }
-expect Text.origin_for({ x: 40, y: 12 }, Text.Prepared.stub.bounds(), Text.align_bottom_right) == { x: 40, y: 12 }
+expect Text.origin_for({ x: 40, y: 12 }, Text.Prepared.stub.bounds(), (Middle, Center)) == { x: 40, y: 12 }
+expect Text.origin_for({ x: 40, y: 12 }, Text.Prepared.stub.bounds(), (Bottom, Right)) == { x: 40, y: 12 }

--- a/platform/main-wayland.roc
+++ b/platform/main-wayland.roc
@@ -134,7 +134,6 @@ platform ""
 		"roc_draw_rectangle_raw": DrawHost.rectangle!,
 		"roc_draw_rounded_rectangle_lines_raw": DrawHost.rounded_rectangle_lines!,
 		"roc_draw_rounded_rectangle_raw": DrawHost.rounded_rectangle!,
-		"roc_draw_text_aligned_raw": DrawHost.text_aligned!,
 		"roc_draw_text_raw": DrawHost.text!,
 		"roc_draw_triangle_lines_raw": DrawHost.triangle_lines!,
 		"roc_draw_triangle_raw": DrawHost.triangle!,

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -134,7 +134,6 @@ platform ""
 		"roc_draw_rectangle_raw": DrawHost.rectangle!,
 		"roc_draw_rounded_rectangle_lines_raw": DrawHost.rounded_rectangle_lines!,
 		"roc_draw_rounded_rectangle_raw": DrawHost.rounded_rectangle!,
-		"roc_draw_text_aligned_raw": DrawHost.text_aligned!,
 		"roc_draw_text_raw": DrawHost.text!,
 		"roc_draw_triangle_lines_raw": DrawHost.triangle_lines!,
 		"roc_draw_triangle_raw": DrawHost.triangle!,

--- a/src/backend_raylib.zig
+++ b/src/backend_raylib.zig
@@ -815,32 +815,6 @@ pub fn drawTextZ(text: [*:0]const u8, font: Font, pos: rl.Vector2, size: f32, sp
     rl.DrawTextEx(font, text, pos, size, spacing, colorToRl(color));
 }
 
-/// Draw text anchored at a fractional point within its measured bounds.
-/// Top-left alignment ({ 0, 0 }) skips measurement entirely.
-pub fn drawTextAlignedZ(text: [*:0]const u8, font: Font, pos: rl.Vector2, size: f32, spacing: f32, color: Color, alignment: rl.Vector2) void {
-    const origin = if (alignment.x == 0 and alignment.y == 0) pos else blk: {
-        const measured = rl.MeasureTextEx(font, text, size, spacing);
-        break :blk textOrigin(pos, measured, alignment);
-    };
-    rl.DrawTextEx(font, text, origin, size, spacing, colorToRl(color));
-}
-
-/// Resolve an anchor position to the top-left drawing origin for measured text.
-pub fn textOrigin(pos: rl.Vector2, measured: rl.Vector2, alignment: rl.Vector2) rl.Vector2 {
-    return .{
-        .x = pos.x - measured.x * alignment.x,
-        .y = pos.y - measured.y * alignment.y,
-    };
-}
-
-test "textOrigin applies fractional alignment" {
-    const pos = rl.Vector2{ .x = 100, .y = 80 };
-    const measured = rl.Vector2{ .x = 40, .y = 20 };
-    try std.testing.expectEqual(rl.Vector2{ .x = 100, .y = 80 }, textOrigin(pos, measured, .{ .x = 0, .y = 0 }));
-    try std.testing.expectEqual(rl.Vector2{ .x = 80, .y = 70 }, textOrigin(pos, measured, .{ .x = 0.5, .y = 0.5 }));
-    try std.testing.expectEqual(rl.Vector2{ .x = 60, .y = 60 }, textOrigin(pos, measured, .{ .x = 1, .y = 1 }));
-}
-
 /// Draw a texture region into a destination rectangle.
 pub fn drawTexture(texture: Texture, args: anytype) void {
     rl.DrawTexturePro(

--- a/src/host_native.zig
+++ b/src/host_native.zig
@@ -5671,32 +5671,6 @@ fn exportedDrawTextRaw(args: abi.DrawHostTextArgs) callconv(.c) void {
     hostedDrawTextRaw(activeHost(), args);
 }
 
-fn hostedDrawTextAlignedRaw(host: *RocHost, args: abi.DrawHostText_alignedArgs) callconv(.c) void {
-    enforcePhase("Draw.text_at!", during_render);
-    defer args.text.decref(host);
-    defer releaseResourceBox(host, args.font);
-    if (active_headless) return;
-
-    const text_slice = args.text.asSlice();
-    var stack: [CSTRING_STACK_CAPACITY:0]u8 = undefined;
-    var text = makeTempCString(allocatorFromHost(host), &stack, text_slice) catch return;
-    defer text.deinit();
-
-    raylib.drawTextAlignedZ(
-        text.ptr,
-        fontForHandle(args.font),
-        .{ .x = args.pos.x, .y = args.pos.y },
-        args.size,
-        args.spacing,
-        args.color,
-        .{ .x = args.align_x, .y = args.align_y },
-    );
-}
-
-fn exportedDrawTextAlignedRaw(args: abi.DrawHostText_alignedArgs) callconv(.c) void {
-    hostedDrawTextAlignedRaw(activeHost(), args);
-}
-
 fn hostedDrawTextureRaw(args: abi.DrawHostDraw_textureArgs) callconv(.c) void {
     enforcePhase("Draw.texture!", during_render);
     defer args.texture.decref(activeHost());
@@ -7299,7 +7273,6 @@ comptime {
         @export(&hostedDrawRectangleRaw, .{ .name = "roc_draw_rectangle_raw" });
         @export(&hostedDrawRoundedRectangleLinesRaw, .{ .name = "roc_draw_rounded_rectangle_lines_raw" });
         @export(&hostedDrawRoundedRectangleRaw, .{ .name = "roc_draw_rounded_rectangle_raw" });
-        @export(&exportedDrawTextAlignedRaw, .{ .name = "roc_draw_text_aligned_raw" });
         @export(&exportedDrawTextRaw, .{ .name = "roc_draw_text_raw" });
         @export(&hostedDrawTriangleLinesRaw, .{ .name = "roc_draw_triangle_lines_raw" });
         @export(&hostedDrawTriangleRaw, .{ .name = "roc_draw_triangle_raw" });

--- a/src/roc_platform_abi.zig
+++ b/src/roc_platform_abi.zig
@@ -3099,8 +3099,8 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct_e7f1bd6203d0f761
-pub const __AnonStruct_e7f1bd6203d0f761 = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct_7f4d6dac6c3eef5e
+pub const __AnonStruct_7f4d6dac6c3eef5e = if (@sizeOf(usize) == 4) extern struct {
     font: *u64,
     text: RocStr,
     size: f32,
@@ -3140,12 +3140,12 @@ pub const __AnonStruct_e7f1bd6203d0f761 = if (@sizeOf(usize) == 4) extern struct
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_e7f1bd6203d0f761) != 40) @compileError("__AnonStruct_e7f1bd6203d0f761 size mismatch");
-        if (@alignOf(__AnonStruct_e7f1bd6203d0f761) != 8) @compileError("__AnonStruct_e7f1bd6203d0f761 alignment mismatch");
+        if (@sizeOf(__AnonStruct_7f4d6dac6c3eef5e) != 40) @compileError("__AnonStruct_7f4d6dac6c3eef5e size mismatch");
+        if (@alignOf(__AnonStruct_7f4d6dac6c3eef5e) != 8) @compileError("__AnonStruct_7f4d6dac6c3eef5e alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_e7f1bd6203d0f761) != 24) @compileError("__AnonStruct_e7f1bd6203d0f761 size mismatch");
-        if (@alignOf(__AnonStruct_e7f1bd6203d0f761) != 4) @compileError("__AnonStruct_e7f1bd6203d0f761 alignment mismatch");
+        if (@sizeOf(__AnonStruct_7f4d6dac6c3eef5e) != 24) @compileError("__AnonStruct_7f4d6dac6c3eef5e size mismatch");
+        if (@alignOf(__AnonStruct_7f4d6dac6c3eef5e) != 4) @compileError("__AnonStruct_7f4d6dac6c3eef5e alignment mismatch");
     }
 }
 
@@ -3607,8 +3607,8 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct_18f9d3b1fa7f9242
-pub const __AnonStruct_18f9d3b1fa7f9242 = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct_a794ed9ee3bc5d8d
+pub const __AnonStruct_a794ed9ee3bc5d8d = if (@sizeOf(usize) == 4) extern struct {
     font: *u64,
     text: RocStr,
     pos: MathVec2,
@@ -3660,78 +3660,12 @@ pub const __AnonStruct_18f9d3b1fa7f9242 = if (@sizeOf(usize) == 4) extern struct
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_18f9d3b1fa7f9242) != 56) @compileError("__AnonStruct_18f9d3b1fa7f9242 size mismatch");
-        if (@alignOf(__AnonStruct_18f9d3b1fa7f9242) != 8) @compileError("__AnonStruct_18f9d3b1fa7f9242 alignment mismatch");
+        if (@sizeOf(__AnonStruct_a794ed9ee3bc5d8d) != 56) @compileError("__AnonStruct_a794ed9ee3bc5d8d size mismatch");
+        if (@alignOf(__AnonStruct_a794ed9ee3bc5d8d) != 8) @compileError("__AnonStruct_a794ed9ee3bc5d8d alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_18f9d3b1fa7f9242) != 36) @compileError("__AnonStruct_18f9d3b1fa7f9242 size mismatch");
-        if (@alignOf(__AnonStruct_18f9d3b1fa7f9242) != 4) @compileError("__AnonStruct_18f9d3b1fa7f9242 alignment mismatch");
-    }
-}
-
-/// Element type for __AnonStruct_f27064a2797f2406
-pub const __AnonStruct_f27064a2797f2406 = if (@sizeOf(usize) == 4) extern struct {
-    font: *u64,
-    text: RocStr,
-    align_x: f32,
-    align_y: f32,
-    pos: MathVec2,
-    size: f32,
-    spacing: f32,
-    color: ColorRgba,
-    /// Recursively decrement Roc-owned fields.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        const value = self;
-        decrefBoxWith(@ptrCast(value.font), @alignOf(u64), false, null, roc_host);
-        value.text.decref(roc_host);
-        value.pos.decref(roc_host);
-        value.color.decref(roc_host);
-    }
-
-    /// Increment Roc-owned fields.
-    pub fn incref(self: @This(), amount: isize) void {
-        const value = self;
-        increfBox(@ptrCast(value.font), amount);
-        value.text.incref(amount);
-        value.pos.incref(amount);
-        value.color.incref(amount);
-    }
-} else extern struct {
-    font: *u64,
-    text: RocStr,
-    align_x: f32,
-    align_y: f32,
-    pos: MathVec2,
-    size: f32,
-    spacing: f32,
-    color: ColorRgba,
-    /// Recursively decrement Roc-owned fields.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        const value = self;
-        decrefBoxWith(@ptrCast(value.font), @alignOf(u64), false, null, roc_host);
-        value.text.decref(roc_host);
-        value.pos.decref(roc_host);
-        value.color.decref(roc_host);
-    }
-
-    /// Increment Roc-owned fields.
-    pub fn incref(self: @This(), amount: isize) void {
-        const value = self;
-        increfBox(@ptrCast(value.font), amount);
-        value.text.incref(amount);
-        value.pos.incref(amount);
-        value.color.incref(amount);
-    }
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_f27064a2797f2406) != 64) @compileError("__AnonStruct_f27064a2797f2406 size mismatch");
-        if (@alignOf(__AnonStruct_f27064a2797f2406) != 8) @compileError("__AnonStruct_f27064a2797f2406 alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_f27064a2797f2406) != 44) @compileError("__AnonStruct_f27064a2797f2406 size mismatch");
-        if (@alignOf(__AnonStruct_f27064a2797f2406) != 4) @compileError("__AnonStruct_f27064a2797f2406 alignment mismatch");
+        if (@sizeOf(__AnonStruct_a794ed9ee3bc5d8d) != 36) @compileError("__AnonStruct_a794ed9ee3bc5d8d size mismatch");
+        if (@alignOf(__AnonStruct_a794ed9ee3bc5d8d) != 4) @compileError("__AnonStruct_a794ed9ee3bc5d8d alignment mismatch");
     }
 }
 
@@ -6349,8 +6283,8 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct_1fdbe5c9dee1b2d2
-pub const __AnonStruct_1fdbe5c9dee1b2d2 = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct_a868748fcc059834
+pub const __AnonStruct_a868748fcc059834 = if (@sizeOf(usize) == 4) extern struct {
     record_max_frames: u64,
     default_font_path: RocStr,
     output_dir: RocStr,
@@ -6442,12 +6376,12 @@ pub const __AnonStruct_1fdbe5c9dee1b2d2 = if (@sizeOf(usize) == 4) extern struct
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_1fdbe5c9dee1b2d2) != 160) @compileError("__AnonStruct_1fdbe5c9dee1b2d2 size mismatch");
-        if (@alignOf(__AnonStruct_1fdbe5c9dee1b2d2) != 8) @compileError("__AnonStruct_1fdbe5c9dee1b2d2 alignment mismatch");
+        if (@sizeOf(__AnonStruct_a868748fcc059834) != 160) @compileError("__AnonStruct_a868748fcc059834 size mismatch");
+        if (@alignOf(__AnonStruct_a868748fcc059834) != 8) @compileError("__AnonStruct_a868748fcc059834 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_1fdbe5c9dee1b2d2) != 112) @compileError("__AnonStruct_1fdbe5c9dee1b2d2 size mismatch");
-        if (@alignOf(__AnonStruct_1fdbe5c9dee1b2d2) != 8) @compileError("__AnonStruct_1fdbe5c9dee1b2d2 alignment mismatch");
+        if (@sizeOf(__AnonStruct_a868748fcc059834) != 112) @compileError("__AnonStruct_a868748fcc059834 size mismatch");
+        if (@alignOf(__AnonStruct_a868748fcc059834) != 8) @compileError("__AnonStruct_a868748fcc059834 alignment mismatch");
     }
 }
 
@@ -7455,6 +7389,27 @@ comptime {
     if (@sizeOf(usize) == 4) {
         if (@sizeOf(AudioHostLoad_musicRetRecord) != 8) @compileError("AudioHostLoad_musicRetRecord size mismatch");
         if (@alignOf(AudioHostLoad_musicRetRecord) != 4) @compileError("AudioHostLoad_musicRetRecord alignment mismatch");
+    }
+}
+
+/// Return type record for DrawHost.startup_default_font!
+/// Fields ordered by compiler-emitted ABI offsets.
+pub const DrawHostStartup_default_fontRetRecord = if (@sizeOf(usize) == 4) extern struct {
+    font: *u64,
+    err: u8,
+} else extern struct {
+    font: *u64,
+    err: u8,
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(DrawHostStartup_default_fontRetRecord) != 16) @compileError("DrawHostStartup_default_fontRetRecord size mismatch");
+        if (@alignOf(DrawHostStartup_default_fontRetRecord) != 8) @compileError("DrawHostStartup_default_fontRetRecord alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(DrawHostStartup_default_fontRetRecord) != 8) @compileError("DrawHostStartup_default_fontRetRecord size mismatch");
+        if (@alignOf(DrawHostStartup_default_fontRetRecord) != 4) @compileError("DrawHostStartup_default_fontRetRecord alignment mismatch");
     }
 }
 
@@ -10020,74 +9975,6 @@ comptime {
     }
 }
 
-/// Arguments for DrawHost.text_aligned!
-/// Roc signature: { align_x : F32, align_y : F32, color : Color.Rgba, font : Font.Handle, pos : Math.Vec2, size : F32, spacing : F32, text : Str } => {}
-/// Refcounted fields are owned by the hosted function.
-pub const DrawHostText_alignedArgs = if (@sizeOf(usize) == 4) extern struct {
-    font: *u64,
-    text: RocStr,
-    align_x: f32,
-    align_y: f32,
-    pos: MathVec2,
-    size: f32,
-    spacing: f32,
-    color: ColorRgba,
-    /// Recursively decrement Roc-owned fields.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        const value = self;
-        decrefBoxWith(@ptrCast(value.font), @alignOf(u64), false, null, roc_host);
-        value.text.decref(roc_host);
-        value.pos.decref(roc_host);
-        value.color.decref(roc_host);
-    }
-
-    /// Increment Roc-owned fields.
-    pub fn incref(self: @This(), amount: isize) void {
-        const value = self;
-        increfBox(@ptrCast(value.font), amount);
-        value.text.incref(amount);
-        value.pos.incref(amount);
-        value.color.incref(amount);
-    }
-} else extern struct {
-    font: *u64,
-    text: RocStr,
-    align_x: f32,
-    align_y: f32,
-    pos: MathVec2,
-    size: f32,
-    spacing: f32,
-    color: ColorRgba,
-    /// Recursively decrement Roc-owned fields.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        const value = self;
-        decrefBoxWith(@ptrCast(value.font), @alignOf(u64), false, null, roc_host);
-        value.text.decref(roc_host);
-        value.pos.decref(roc_host);
-        value.color.decref(roc_host);
-    }
-
-    /// Increment Roc-owned fields.
-    pub fn incref(self: @This(), amount: isize) void {
-        const value = self;
-        increfBox(@ptrCast(value.font), amount);
-        value.text.incref(amount);
-        value.pos.incref(amount);
-        value.color.incref(amount);
-    }
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(DrawHostText_alignedArgs) != 64) @compileError("DrawHostText_alignedArgs size mismatch");
-        if (@alignOf(DrawHostText_alignedArgs) != 8) @compileError("DrawHostText_alignedArgs alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(DrawHostText_alignedArgs) != 44) @compileError("DrawHostText_alignedArgs size mismatch");
-        if (@alignOf(DrawHostText_alignedArgs) != 4) @compileError("DrawHostText_alignedArgs alignment mismatch");
-    }
-}
-
 /// Arguments for DrawHost.text!
 /// Roc signature: { color : Color.Rgba, font : Font.Handle, pos : Math.Vec2, size : F32, spacing : F32, text : Str } => {}
 /// Refcounted fields are owned by the hosted function.
@@ -11925,6 +11812,7 @@ pub const DrawHostDraw_texture_instancesArg0 = __AnonStruct_a819339c8fa68dd6;
 pub const DrawHostDraw_texture_instancesArg0Instances = __AnonStruct_1b47e50f7d442c7;
 pub const DrawHostDraw_texture_quadArg0 = __AnonStruct_81a2561bb748cfff;
 pub const DrawHostFpsArg0 = __AnonStruct_477f59604acc661e;
+pub const DrawHostStartup_default_font = __AnonStruct_83bbf23095f15134;
 pub const DrawHostFont_metrics = __AnonStruct_2bfb89334ad27c35;
 pub const DrawHostFont_metricsGlyphs = __AnonStruct_a31979034eec4b2e;
 pub const DrawHostFrame_size = __AnonStruct_473ae8de77ee164b;
@@ -11933,7 +11821,7 @@ pub const DrawHostLoad_font_bytesArg0 = __AnonStruct_5cba559c3a07b56a;
 pub const DrawHostLoad_font_bytes = __AnonStruct_83bbf23095f15134;
 pub const DrawHostLoad_store_fontArg0 = __AnonStruct_80c864420ea33e1e;
 pub const DrawHostLoad_store_font = __AnonStruct_83bbf23095f15134;
-pub const DrawHostPrepare_textArg0 = __AnonStruct_e7f1bd6203d0f761;
+pub const DrawHostPrepare_textArg0 = __AnonStruct_7f4d6dac6c3eef5e;
 pub const DrawHostPrepare_text = __AnonStruct_2a39039201b5023d;
 pub const DrawHostDraw_prepared_textArg0 = __AnonStruct_6bff15fb6a4cb85a;
 pub const DrawHostPolygon_linesArg0 = __AnonStruct_2dcd38bc772d0799;
@@ -11946,8 +11834,7 @@ pub const DrawHostRectangle_linesArg0 = __AnonStruct_dfc92600a2569f3d;
 pub const DrawHostRectangleArg0 = __AnonStruct_3b378fd867c0b9f1;
 pub const DrawHostRounded_rectangle_linesArg0 = __AnonStruct_8edd1366fc9f1a8b;
 pub const DrawHostRounded_rectangleArg0 = __AnonStruct_2b98c437f1796b13;
-pub const DrawHostText_alignedArg0 = __AnonStruct_f27064a2797f2406;
-pub const DrawHostTextArg0 = __AnonStruct_18f9d3b1fa7f9242;
+pub const DrawHostTextArg0 = __AnonStruct_a794ed9ee3bc5d8d;
 pub const DrawHostTriangle_linesArg0 = __AnonStruct_563f890a3b4ea7a0;
 pub const DrawHostTriangleArg0 = __AnonStruct_d48cb861dff2afaa;
 pub const FilesHostRead_text = __AnonStruct_e98c7d72bcd7a610;
@@ -12022,7 +11909,7 @@ pub const SqliteHostExec_script = __AnonStruct_e7ff50a9dfab1a8d;
 pub const CmdHostRunArg0 = __AnonStruct_3fe396bc5ba0c31c;
 pub const CmdHostRunArg0Envs = __AnonStruct_82a96c5d55d63488;
 pub const CmdHostRun = __AnonStruct_fa110e8829dc221b;
-pub const App_config_for_host = __AnonStruct_1fdbe5c9dee1b2d2;
+pub const App_config_for_host = __AnonStruct_a868748fcc059834;
 pub const Update_for_hostArg1 = __AnonStruct_9c901b89b0293b6b;
 pub const Update_for_hostArg1Capture = __AnonStruct_681b090756070ab0;
 pub const Update_for_hostArg1Time = __AnonStruct_db5a281b648e1efe;
@@ -12336,8 +12223,8 @@ pub const __AnonStruct_2a39039201b5023dRelease = struct {
     }
 };
 
-pub const __AnonStruct_e7f1bd6203d0f761Release = struct {
-    pub fn release(value: __AnonStruct_e7f1bd6203d0f761, roc_host: *RocHost) void {
+pub const __AnonStruct_7f4d6dac6c3eef5eRelease = struct {
+    pub fn release(value: __AnonStruct_7f4d6dac6c3eef5e, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -12396,14 +12283,8 @@ pub const __AnonStruct_8edd1366fc9f1a8bRelease = struct {
     }
 };
 
-pub const __AnonStruct_18f9d3b1fa7f9242Release = struct {
-    pub fn release(value: __AnonStruct_18f9d3b1fa7f9242, roc_host: *RocHost) void {
-        value.decref(roc_host);
-    }
-};
-
-pub const __AnonStruct_f27064a2797f2406Release = struct {
-    pub fn release(value: __AnonStruct_f27064a2797f2406, roc_host: *RocHost) void {
+pub const __AnonStruct_a794ed9ee3bc5d8dRelease = struct {
+    pub fn release(value: __AnonStruct_a794ed9ee3bc5d8d, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -12778,8 +12659,8 @@ pub const __AnonStruct_8fd71e3705bdb8b5Release = struct {
     }
 };
 
-pub const __AnonStruct_1fdbe5c9dee1b2d2Release = struct {
-    pub fn release(value: __AnonStruct_1fdbe5c9dee1b2d2, roc_host: *RocHost) void {
+pub const __AnonStruct_a868748fcc059834Release = struct {
+    pub fn release(value: __AnonStruct_a868748fcc059834, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -13039,13 +12920,12 @@ fn rocReleasePolicy(comptime T: type) type {
     if (T == __AnonStruct_2bfb89334ad27c35) return __AnonStruct_2bfb89334ad27c35Release;
     if (T == RocListWith(__AnonStruct_a31979034eec4b2e, false)) return RocListSpineRelease(RocListWith(__AnonStruct_a31979034eec4b2e, false));
     if (T == __AnonStruct_2a39039201b5023d) return __AnonStruct_2a39039201b5023dRelease;
-    if (T == __AnonStruct_e7f1bd6203d0f761) return __AnonStruct_e7f1bd6203d0f761Release;
+    if (T == __AnonStruct_7f4d6dac6c3eef5e) return __AnonStruct_7f4d6dac6c3eef5eRelease;
     if (T == __AnonStruct_6bff15fb6a4cb85a) return __AnonStruct_6bff15fb6a4cb85aRelease;
     if (T == __AnonStruct_16cb9af61afe2d08) return __AnonStruct_16cb9af61afe2d08Release;
     if (T == RocListWith(MathVec2, false)) return RocListSpineRelease(RocListWith(MathVec2, false));
     if (T == __AnonStruct_2dcd38bc772d0799) return __AnonStruct_2dcd38bc772d0799Release;
-    if (T == __AnonStruct_18f9d3b1fa7f9242) return __AnonStruct_18f9d3b1fa7f9242Release;
-    if (T == __AnonStruct_f27064a2797f2406) return __AnonStruct_f27064a2797f2406Release;
+    if (T == __AnonStruct_a794ed9ee3bc5d8d) return __AnonStruct_a794ed9ee3bc5d8dRelease;
     if (T == __AnonStruct_f942b11a3b075f2d) return __AnonStruct_f942b11a3b075f2dRelease;
     if (T == __AnonStruct_a819339c8fa68dd6) return __AnonStruct_a819339c8fa68dd6Release;
     if (T == RocListWith(__AnonStruct_1b47e50f7d442c7, false)) return RocListSpineRelease(RocListWith(__AnonStruct_1b47e50f7d442c7, false));
@@ -13098,7 +12978,7 @@ fn rocReleasePolicy(comptime T: type) type {
     if (T == __AnonStruct_3d573c3bcb10a375) return __AnonStruct_3d573c3bcb10a375Release;
     if (T == __AnonStruct_def8e181e644dca4) return __AnonStruct_def8e181e644dca4Release;
     if (T == __AnonStruct_8fd71e3705bdb8b5) return __AnonStruct_8fd71e3705bdb8b5Release;
-    if (T == __AnonStruct_1fdbe5c9dee1b2d2) return __AnonStruct_1fdbe5c9dee1b2d2Release;
+    if (T == __AnonStruct_a868748fcc059834) return __AnonStruct_a868748fcc059834Release;
     if (T == __AnonStruct_9c901b89b0293b6b) return __AnonStruct_9c901b89b0293b6bRelease;
     if (T == __AnonStruct_74da537dd9780edf) return __AnonStruct_74da537dd9780edfRelease;
     if (T == __AnonStruct_1c8617e96852f779) return __AnonStruct_1c8617e96852f779Release;
@@ -13419,13 +13299,13 @@ pub extern fn roc_draw_default_font_raw() callconv(.c) *u64;
 /// Hosted symbol for DrawHost.startup_default_font!
 /// Roc signature: {} => { err : U8, font : Font.Handle }
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_draw_startup_default_font_raw() callconv(.c) DrawHostLoad_font_bytesRetRecord;
+pub extern fn roc_draw_startup_default_font_raw() callconv(.c) __AnonStruct_83bbf23095f15134;
 
 /// Hosted symbol for DrawHost.font_metrics!
 /// Roc signature: Font.Handle => { base_size : F32, fallback_index : U64, glyphs : List({ advance_x : F32, codepoint : U32, height : F32, offset_x : F32, offset_y : F32, width : F32 }), line_spacing : F32 }
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg0.decref(roc_host);
+///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
 pub extern fn roc_draw_font_metrics_raw(arg0: *u64) callconv(.c) __AnonStruct_2bfb89334ad27c35;
 
@@ -13505,13 +13385,6 @@ pub extern fn roc_draw_rounded_rectangle_lines_raw(arg0: DrawHostRounded_rectang
 /// Hosted symbol for DrawHost.rounded_rectangle!
 /// Roc signature: { color : Color.Rgba, height : F32, radius : F32, segments : I32, width : F32, x : F32, y : F32 } => {}
 pub extern fn roc_draw_rounded_rectangle_raw(arg0: DrawHostRounded_rectangleArgs) callconv(.c) void;
-
-/// Hosted symbol for DrawHost.text_aligned!
-/// Roc signature: { align_x : F32, align_y : F32, color : Color.Rgba, font : Font.Handle, pos : Math.Vec2, size : F32, spacing : F32, text : Str } => {}
-/// Owned arguments. Release each exactly once before returning, unless it is
-/// moved into storage or into the result:
-///     arg0.decref(roc_host);
-pub extern fn roc_draw_text_aligned_raw(arg0: DrawHostText_alignedArgs) callconv(.c) void;
 
 /// Hosted symbol for DrawHost.text!
 /// Roc signature: { color : Color.Rgba, font : Font.Handle, pos : Math.Vec2, size : F32, spacing : F32, text : Str } => {}
@@ -14118,7 +13991,7 @@ pub fn makeRocHost(env: *RocEnv) RocHost {
 // Roc exports these symbols from the app with their natural C ABI signatures.
 
 /// Entrypoint: app_config_for_host!
-pub extern fn app_config_for_host() callconv(.c) __AnonStruct_1fdbe5c9dee1b2d2;
+pub extern fn app_config_for_host() callconv(.c) __AnonStruct_a868748fcc059834;
 
 /// Entrypoint: init_for_host!
 pub extern fn init_for_host() callconv(.c) Init_for_hostResult;

--- a/test/package_interop/app.roc
+++ b/test/package_interop/app.roc
@@ -155,7 +155,7 @@ update! = |model, program_input| {
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])
 render! = |model, frame| {
 	frame.clear!(if model.clicked Color.blue else Color.ray_white)
-	frame.text!({ pos: model.layout.label_pos, text: model.label, size: 20, spacing: Draw.default_spacing, color: Color.black, font: model.font, align: Draw.align_top_left })
+	frame.text!({ pos: model.layout.label_pos, text: model.label, size: 20, spacing: Draw.default_spacing, color: Color.black, font: model.font })
 	frame.text_at!({ pos: { x: 10, y: 40 }, text: F32.to_str(model.age), size: 20, color: Color.black })
 	frame.text_at!({ pos: { x: 10, y: 70 }, text: if model.padded "pad" else "no pad", size: 20, color: Color.black })
 

--- a/types/Drawing.roc
+++ b/types/Drawing.roc
@@ -13,7 +13,7 @@ frame.Drawable :
 		frame.clear! : frame, Color.Rgba => {},
 		frame.rectangle! : frame, { x : F32, y : F32, width : F32, height : F32, style : { fill : [NoFill, Fill(Color.Rgba)], stroke : [NoStroke, Stroke({ color : Color.Rgba, thickness : F32 })] } } => {},
 		frame.rounded_rectangle! : frame, { x : F32, y : F32, width : F32, height : F32, radius : F32, segments : I32, style : { fill : [NoFill, Fill(Color.Rgba)], stroke : [NoStroke, Stroke({ color : Color.Rgba, thickness : F32 })] } } => {},
-		frame.text! : frame, { pos : Math.Vec2, text : Str, size : F32, spacing : F32, color : Color.Rgba, font : Font, align : { horizontal : [Left, Center, Right], vertical : [Top, Middle, Bottom] } } => {},
+		frame.text! : frame, { pos : Math.Vec2, text : Str, size : F32, spacing : F32, color : Color.Rgba, font : Font } => {},
 		frame.texture! : frame, Drawing.TextureDraw => {},
 		frame.with_scissor! : frame, Math.Rect, (frame => Try({}, [ScopeLimit])) => Try({}, [ScopeLimit]),
 	]
@@ -39,17 +39,8 @@ Drawing := [].{
 	## approximate each corner arc.
 	RoundedRectangle : { x : F32, y : F32, width : F32, height : F32, radius : F32, segments : I32, style : ShapeStyle }
 
-	## Which horizontal edge or center of a text box `pos` refers to.
-	HAlign : [Left, Center, Right]
-
-	## Which vertical edge or center of a text box `pos` refers to.
-	VAlign : [Top, Middle, Bottom]
-
-	## Where `pos` sits within the text it places, in both axes at once.
-	TextAlign : { horizontal : HAlign, vertical : VAlign }
-
-	## A string, where to put it, and how to paint it.
-	Text : { pos : Math.Vec2, text : Str, size : F32, spacing : F32, color : Color.Rgba, font : Font, align : TextAlign }
+	## A string, its resolved top-left origin, and how to paint it.
+	Text : { pos : Math.Vec2, text : Str, size : F32, spacing : F32, color : Color.Rgba, font : Font }
 
 	## One textured quad: which part of the texture to read (`source`), where to
 	## put it (`dest`), the point within `dest` that `rotation` turns around


### PR DESCRIPTION
# Separate text drawing from alignment policy

## Summary

Make `Draw.text!` the primitive immediate text draw: `pos` is the resolved
top-left origin, no measurement occurs, and the call delegates to the raw
`DrawHost.text!` operation.

Alignment remains optional higher-level policy. Convenience APIs may measure
and align text for demos, while UI and layout packages can submit positions
they have already computed.

The obsolete built-in-font `Draw.text_centered!` shortcut, the `Draw` alignment
API, and the dedicated aligned host transport are removed. Optional immediate
alignment now has one home: `Text.Builder.draw!` with an explicit `Font`.

`Text.Placement` defaults to top-left when `align` is omitted. Other anchors use
an explicit `(vertical, horizontal)` tuple such as `(Middle, Center)`:

```roc
Text.from("Score", font).size(24).draw!(frame, {
	pos,
	color: Color.white,
	align: (Top, Right),
})
```

## Rationale

Before this change, `Draw.text!` required an `align` field and delegated to
`DrawHost.text_aligned!`. This makes anchor alignment—and the host-side
measurement needed to implement it—part of every custom-font text draw, even
when the caller already knows the exact origin.

That is particularly unsuitable for UI packages. A layout engine needs to own
word wrapping, per-line alignment, line height, constraints, and cache policy.
It should be able to derive those decisions purely from `Font`'s immutable
metric snapshot, then issue one draw per resolved line. Requiring alignment at
the drawing boundary duplicates work and imposes a different block-alignment
model on the caller.

The host previously carried separate raw and aligned drawing operations solely
to support this public policy. Once alignment is resolved in Roc, the aligned
transport has no distinct authority or ownership role and can be removed.
`Draw` supplies the frame-scoped drawing primitive; `Text` and application or
package code supply optional layout and alignment policy.

## Resulting contract

- `Draw.text!` performs no alignment pass. Its `pos` is the text's top-left
  drawing origin.
- Pure layout code can use `Font.measure`, wrapping rules, and its own alignment
  policy without depending on private `DrawHost` declarations.
- Simple applications can use `Text.Builder.draw!` when they want `Text` to
  measure the builder from the font's immutable metrics and resolve an anchor
  in Roc before drawing.
- `Text.Align` is `(VAlign, HAlign)`. Both immediate and prepared placement
  default to `(Top, Left)`, so the `align` field can be omitted for the common
  case.
- `Text.Prepared` retains its measured-bounds alignment convenience through the
  same `Text.Placement` contract; its resource lifecycle and preparation
  behavior are unchanged.
- The native host performs no immediate-text alignment or measurement; it
  draws immediate text only at an origin already resolved in Roc.
- `Draw.debug_text!` and `Draw.text_at!` remain top-left built-in-font
  conveniences and now delegate to `Draw.text!`.

This keeps rendering a `Draw.Frame` effect while leaving retained UI state and
layout policy in Roc. It introduces no new application/host protocol and no
new host authority.

## Compatibility

This is a public API change:

- `Draw.text!` callers remove `align` when they already provide a top-left
  origin. Other callers resolve the origin themselves or use
  `Text.Builder.draw!`.
- `Draw.HAlign`, `Draw.VAlign`, `Draw.TextAlign`, the `Draw.align_*` constants,
  `Draw.align_offset`, `Draw.origin_for`, and `Draw.align_factor` are removed.
- `Draw.text_centered!` is removed. Callers retain a `Font` and use
  `Text.from(...).draw!(..., { align: (Middle, Center), ... })` instead.
- `Text.Align` changes from a record to `(VAlign, HAlign)`, and the nine
  `Text.align_*` constants are removed. Existing placements use tuples such as
  `(Top, Center)`; top-left placements may omit `align`.

The aligned hosted declaration, native export, backend implementation, and
generated ABI entries are removed together. All platform examples and the
public `types/Drawing.roc` structural contract are migrated to the resulting
API.

## Verification

- [x] `zig build lint`
- [x] `zig build test`
- [x] `zig build graphical-smoke`
