### PR TITLE
Record input events from the window system and deliver an ordered event list

### DIFF
--- a/.types-version
+++ b/.types-version
@@ -7,4 +7,4 @@
 #
 # Produced by .github/workflows/release-types.yml. Empty until the first
 # roc-ray-types release is cut.
-https://github.com/lukewilliamboswell/roc-ray/releases/download/types-0.8.0/3akQjTNsQGrAM5WP6Q2t1wHfPYitrMH1EHZ4dK7F4mHX.tar.zst
+https://github.com/lukewilliamboswell/roc-ray/releases/download/types-0.9.0/BmSXwCo4tegQEkcPmYK7a5ABm6KPxsco7fZygzh1nG5v.tar.zst

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,10 +47,12 @@ The host reserves a few `--host-` switches for unattended runs. `--host-frames=N
 ends a real windowed run after N cycles, `--host-hidden` opens that window
 hidden, and `--host-keys=3:S,4:LEFT+X` / `--host-text=5:hi` script the keyboard
 and typed text on the cycles they name (a key is a character, one of a few names
-such as `LEFT` or `SPACE`, or a raw key code; a `^` suffix, as in `3:ESCAPE^`,
+such as `LEFT` or `SPACE`, or a raw key code; a `~` suffix, as in `3:ESCAPE~`,
 taps the key inside that cycle -- pressed and released in one input, never
 held -- which is what a hardware key that went down and up between two polls
-looks like). They are what the windowed sweep below drives the examples with;
+looks like. `~` because it is inert unquoted in cmd, PowerShell, bash and zsh
+alike; `^` is cmd's escape character and vanished on Windows). They are what
+the windowed sweep below drives the examples with;
 `--host-headless` and `--host-headless-frames=N` select the stub backend
 instead, which draws nothing.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -341,6 +341,18 @@ to both. `zig build lint` enforces this and points at the first line that
 drifted; without it a missing entry only surfaces when someone links against the
 Wayland bundle.
 
+A value that crosses the host boundary is flat: scalars, `List` of scalars, or
+`List` of a record of scalars. Unions and boxed lists do not cross. The input
+event record is the worked example -- the host fills
+`List({ kind : U8, code : U32, x : F32, y : F32 })` and
+`Devices.events_from_raw` in the types package decodes it into the typed
+`Devices.Event`; the `kind` numbering is stated on both sides
+(`InputEventKind` in `src/backend_raylib.zig`, `event_from_raw` in
+`types/Devices.roc`) so neither can drift alone. A new field on
+`Devices.Snapshot` touches `InputFromHost` and `input_from_raw` in both
+platform headers, `Devices.none` and `Devices.empty`, and the ABI regeneration
+below.
+
 Every hosted effect carries a phase set in `src/host_native.zig` --
 `enforcePhase(name, during_update)` and friends -- that says which app
 callbacks may reach it: `during_load` and `during_update` for anything that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,12 @@ The host reserves a few `--host-` switches for unattended runs. `--host-frames=N
 ends a real windowed run after N cycles, `--host-hidden` opens that window
 hidden, and `--host-keys=3:S,4:LEFT+X` / `--host-text=5:hi` script the keyboard
 and typed text on the cycles they name (a key is a character, one of a few names
-such as `LEFT` or `SPACE`, or a raw key code). They are what the windowed sweep
-below drives the examples with; `--host-headless` and `--host-headless-frames=N`
-select the stub backend instead, which draws nothing.
+such as `LEFT` or `SPACE`, or a raw key code; a `^` suffix, as in `3:ESCAPE^`,
+taps the key inside that cycle -- pressed and released in one input, never
+held -- which is what a hardware key that went down and up between two polls
+looks like). They are what the windowed sweep below drives the examples with;
+`--host-headless` and `--host-headless-frames=N` select the stub backend
+instead, which draws nothing.
 
 Debug hosts use a fast thread-safe allocator by default. To diagnose Roc-side
 leaks with Zig's stack-tracing allocator, pass this flag to a Debug-built app:

--- a/design.md
+++ b/design.md
@@ -346,28 +346,33 @@ below hold independently of frame timing.
 | Field | Kind | Source | Capacity and coalescing |
 | --- | --- | --- | --- |
 | `keys` held bit, `mouse` held bits, `mouse` position and delta | State sample | raylib's level at the cycle boundary | Latest value |
-| `keys` and `mouse.buttons` pressed and released bits | Interval event | Window-system key and mouse-button callbacks | Per key or button, at least one press and at least one release since the previous input; several of one key coalesce into one bit, count and order not retained; auto-repeat is not a press |
-| `mouse` wheel | Interval event | Window-system scroll callback | Every notch in the interval summed |
-| `text_input` | Interval event | Window-system character callback | 32 codepoints in the order typed; `text_input_overflow` set when more arrived and the rest were discarded |
+| `events` | Interval event | Window-system key, mouse-button, scroll and character callbacks | 256 per interval, in delivery order across all four sources, each click with the pointer position it landed at; `events_overflow` set when more arrived and the rest were discarded; auto-repeat is not an event |
+| `keys` and `mouse.buttons` pressed and released bits | Interval event, coalesced | The same callbacks | Per key or button, at least one press and at least one release since the previous input; several of one key coalesce into one bit. The bits coalesce; the list does not |
+| `mouse` wheel | Interval event, coalesced | Window-system scroll callback | Every notch in the interval summed; each notch is also an `events` entry |
+| `text_input` | Interval event | Window-system character callback | 32 codepoints in the order typed; `text_input_overflow` set when more arrived and the rest were discarded; each character is also an `events` entry, ordered relative to the key edges around it |
 | `gamepads` held bits and axes | State sample | raylib's per-cycle gamepad poll | Latest value |
-| `gamepads` pressed and released bits | Sampled edge | Comparison of two consecutive polls | Intentionally lossy: a press and release between two polls is not seen; there is no callback to record from |
+| `gamepads` pressed and released bits | Sampled edge | Comparison of two consecutive polls | Intentionally lossy: a press and release between two polls is not seen; there is no callback to record from, and gamepads never appear in `events` |
 
 The guarantee this gives an application is that every key, mouse-button,
-scroll and character event that reaches the process is either delivered in
-the next `Input` or reported as an overflow -- never silently lost -- with a
-latency of at most one cycle. A key tapped between two cycles is pressed and
-released in one input and held in neither; a button released and pressed
-again between two cycles is released and pressed in one input and held in
-both. Order across sources within one interval -- a character relative to a
-key edge, one key relative to another -- is not defined, and clicks in one
-interval all share the boundary pointer position. Gamepad buttons carry no
-such guarantee and say so.
+scroll and character event that reaches the process is delivered in the next
+`Input`, in order, with count and (for clicks) position preserved up to the
+stated capacity, or reported as overflow -- never silently lost -- with a
+latency of at most one cycle. `events` is the authoritative record; the
+packed bits, the wheel sum and `text_input` are coalesced conveniences
+derived alongside it, and they keep recording when the list is full, so the
+coalesced view is complete even on an interval whose list overflowed. A key
+tapped between two cycles is pressed and released in one input and held in
+neither; a button released and pressed again between two cycles is released
+and pressed in one input and held in both; two taps are two pairs of events
+and one pair of bits. Gamepad buttons carry no such guarantee and say so.
 
 A scripted keyboard (`Keys.set_source!`, `--host-keys`) is the same derivation
 over a scripted level, with a scripted tap recorded as an edge inside the
 cycle, so a headless or windowed test can state the between-polls case that a
-level per cycle could never express, and hardware edges are shut out entirely
-while a script is the source.
+level per cycle could never express. Scripted input feeds `events` too -- a
+tap as a press and a release, a held-set change as the edge it implies, typed
+text as characters in script order -- and hardware events are shut out
+entirely, device by device, while a script is that device's source.
 
 `App.Input(msg)` is also the type witness that ties a task's message to the
 application's own `Msg`. Only the platform's entry module can name the

--- a/design.md
+++ b/design.md
@@ -334,6 +334,41 @@ reports overflow explicitly or documents that it is intentionally lossy and
 what is coalesced. "Latest value" is sufficient for state; silently losing an
 edge or a message is not equivalent.
 
+The `devices` snapshot is where the two kinds meet, and its fields are
+classified as follows. On the desktop host the interval events are recorded by
+the host's own callbacks, chained behind raylib's on the window: raylib keeps
+levels, not queues -- its key and mouse-button callbacks store the latest
+action, its scroll callback overwrites the wheel, and its character queue holds
+sixteen per poll -- so anything that happened between two polls would collapse
+into whatever came last. Recording at the callback is what makes the guarantee
+below hold independently of frame timing.
+
+| Field | Kind | Source | Capacity and coalescing |
+| --- | --- | --- | --- |
+| `keys` held bit, `mouse` held bits, `mouse` position and delta | State sample | raylib's level at the cycle boundary | Latest value |
+| `keys` and `mouse.buttons` pressed and released bits | Interval event | Window-system key and mouse-button callbacks | Per key or button, at least one press and at least one release since the previous input; several of one key coalesce into one bit, count and order not retained; auto-repeat is not a press |
+| `mouse` wheel | Interval event | Window-system scroll callback | Every notch in the interval summed |
+| `text_input` | Interval event | Window-system character callback | 32 codepoints in the order typed; `text_input_overflow` set when more arrived and the rest were discarded |
+| `gamepads` held bits and axes | State sample | raylib's per-cycle gamepad poll | Latest value |
+| `gamepads` pressed and released bits | Sampled edge | Comparison of two consecutive polls | Intentionally lossy: a press and release between two polls is not seen; there is no callback to record from |
+
+The guarantee this gives an application is that every key, mouse-button,
+scroll and character event that reaches the process is either delivered in
+the next `Input` or reported as an overflow -- never silently lost -- with a
+latency of at most one cycle. A key tapped between two cycles is pressed and
+released in one input and held in neither; a button released and pressed
+again between two cycles is released and pressed in one input and held in
+both. Order across sources within one interval -- a character relative to a
+key edge, one key relative to another -- is not defined, and clicks in one
+interval all share the boundary pointer position. Gamepad buttons carry no
+such guarantee and say so.
+
+A scripted keyboard (`Keys.set_source!`, `--host-keys`) is the same derivation
+over a scripted level, with a scripted tap recorded as an edge inside the
+cycle, so a headless or windowed test can state the between-polls case that a
+level per cycle could never express, and hardware edges are shut out entirely
+while a script is the source.
+
 `App.Input(msg)` is also the type witness that ties a task's message to the
 application's own `Msg`. Only the platform's entry module can name the
 `requires` bound, so any public function whose signature mentions `msg` and

--- a/examples/input_inspector/main.roc
+++ b/examples/input_inspector/main.roc
@@ -2,8 +2,10 @@
 ##
 ## The window lists its controls; Q quits because Escape is displayed as an
 ## ordinary key. This example shows how each `Input` gives `update!` the latest
-## device state, and how `update!` can change the clipboard, cursor, and window
-## or read a pixel from the previous drawing.
+## device state and the ordered record of what the devices did, and how
+## `update!` can change the clipboard, cursor, and window or read a pixel from
+## the previous drawing. Every cycle with events prints them to stdout in
+## delivery order, which is what the windowed sweep asserts on.
 app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.Draw
@@ -16,6 +18,7 @@ import rr.Mouse
 import rr.Gamepad
 import rr.App
 import rr.Capture
+import rr.Stdout
 
 ## State kept between updates: accumulated typed text, clipboard feedback, the
 ## latest device snapshot, and the last colour read beneath the pointer. The
@@ -38,6 +41,9 @@ Model : {
 
 	## The colour the eyedropper last found under the pointer.
 	picked : Picked,
+
+	## The most recent cycle's event record, described.
+	events_line : Str,
 }
 
 ## What one screen readback under the pointer came back with.
@@ -66,7 +72,7 @@ init! = App.init(
 	# below could never light up. Q exits instead.
 		.with_exit_key(NoExitKey)
 		.with_frame_pacing(Capped(120)),
-	|_startup| Ok({ font: Draw.default_font!(), typed: "", clipboard_status: "clipboard idle", input: Devices.empty, picked: Err(Unavailable) }),
+	|_startup| Ok({ font: Draw.default_font!(), typed: "", clipboard_status: "clipboard idle", input: Devices.empty, picked: Err(Unavailable), events_line: "events: none yet" }),
 )
 
 title : Str
@@ -149,12 +155,63 @@ update! = |model, program_input| {
 	pointer = input.mouse.position()
 	picked = Capture.pixel_at!(Screen, { x: F32.to_i32_wrap(pointer.x), y: F32.to_i32_wrap(pointer.y) })
 
+	# The record, as opposed to the bits the chips show: every edge, click,
+	# notch and character in the order it happened. A cycle with nothing in
+	# it keeps the previous line on screen and prints nothing.
+	events_line =
+		if List.is_empty(input.events) {
+			model.events_line
+		} else {
+			line = describe_events(input.events, input.events_overflow)
+			_ = Stdout.line!(line)
+			line
+		}
+
 	if input.key_pressed(KeyQ) {
 		Err(Exit(0))
 	} else {
-		Ok({ font: model.font, typed: clipboard.typed, clipboard_status: clipboard.clipboard_status, input: input, picked: picked })
+		Ok({ font: model.font, typed: clipboard.typed, clipboard_status: clipboard.clipboard_status, input: input, picked: picked, events_line: events_line })
 	}
 }
+
+## One event as a short label, by code rather than name so the line stays
+## one token per event: `KeyPressed(65)`, `ButtonReleased(Left at 12,34)`.
+event_label : Devices.Event -> Str
+event_label = |event|
+	match event {
+		KeyPressed(key) => "KeyPressed(${U64.to_str(Keys.key_code(key))})"
+		KeyReleased(key) => "KeyReleased(${U64.to_str(Keys.key_code(key))})"
+		ButtonPressed(button, at) => "ButtonPressed(${button_label(button)} at ${F32.to_str(at.x)},${F32.to_str(at.y)})"
+		ButtonReleased(button, at) => "ButtonReleased(${button_label(button)} at ${F32.to_str(at.x)},${F32.to_str(at.y)})"
+		Wheel(delta) => "Wheel(${F32.to_str(delta.x)},${F32.to_str(delta.y)})"
+		Text(codepoint) => "Text(${U32.to_str(codepoint)})"
+	}
+
+button_label : Mouse.Button -> Str
+button_label = |button|
+	match button {
+		Left => "Left"
+		Right => "Right"
+		Middle => "Middle"
+		Side => "Side"
+		Extra => "Extra"
+		Forward => "Forward"
+		Back => "Back"
+	}
+
+## The whole record on one line, in delivery order, with the overflow flag.
+describe_events : List(Devices.Event), Bool -> Str
+describe_events = |events, overflowed| {
+	labels = Str.join_with(List.map(events, event_label), " ")
+	if overflowed "events: ${labels} (overflowed)" else "events: ${labels}"
+}
+
+expect event_label(KeyPressed(KeyA)) == "KeyPressed(65)"
+expect event_label(ButtonReleased(Left, { x: 12, y: 34 })) == "ButtonReleased(Left at 12,34)"
+expect event_label(Wheel({ x: 0, y: 1 })) == "Wheel(0,1)"
+expect event_label(Text(104)) == "Text(104)"
+expect describe_events([KeyPressed(KeyA), KeyReleased(KeyA), Text(104)], Bool.False) == "events: KeyPressed(65) KeyReleased(65) Text(104)"
+expect describe_events([Text(104)], Bool.True) == "events: Text(104) (overflowed)"
 
 ## Say what the eyedropper found, or why it found nothing.
 ##
@@ -303,7 +360,7 @@ render! = |model, frame| {
 
 	frame.clear!(theme.bg)
 	frame.text!({ pos: { x: 30, y: 26 }, text: title, size: 26, spacing: Draw.default_spacing, color: theme.ink, font: font })
-	frame.text!({ pos: { x: 30, y: 58 }, text: "Every field of one Devices.Snapshot, live", size: 15, spacing: Draw.default_spacing, color: theme.muted, font: font })
+	frame.text!({ pos: { x: 30, y: 58 }, text: "Every field of one Devices.Snapshot, live; the bits as chips, the event record as a line", size: 15, spacing: Draw.default_spacing, color: theme.muted, font: font })
 
 	panel!(frame, font, { x: 20, y: 84, width: 780, height: 258, label: "KEYS AND BUTTONS" })
 	chip!(frame, font, { x: 70, y: 126, width: 30, label: "W", on: w_down })
@@ -330,6 +387,7 @@ render! = |model, frame| {
 	light!(frame, font, { x: 220, y: 424, label: "Left stick", on: stick_moved })
 	light!(frame, font, { x: 410, y: 424, label: "Face down", on: gamepad_action_pressed })
 	line!(frame, font, { x: 600, y: 391, text: "Mouse ${F32.to_str(mouse_position.x)}, ${F32.to_str(mouse_position.y)}", color: theme.muted })
+	frame.text!({ pos: { x: 30, y: 446 }, text: model.events_line, size: 13, spacing: Draw.default_spacing, color: theme.ink, font: font })
 
 	panel!(frame, font, { x: 20, y: 478, width: 780, height: 184, label: "HOST EFFECTS" })
 	line!(frame, font, { x: 30, y: 510, text: cursor_help_visibility, color: theme.muted })

--- a/platform/Devices.roc
+++ b/platform/Devices.roc
@@ -7,11 +7,14 @@
 ## since the preceding input, from the window system's own event callbacks: an
 ## event that reaches the process is in the next input or reported as an
 ## overflow, never silently lost, and each is consumed by exactly one call to
-## `update!`. Presses of one key or button in one interval coalesce into a
-## single bit; typed text is capped at 32 codepoints with `text_input_overflow`
-## saying when more arrived; the wheel is the sum of every notch. Gamepad
-## buttons are sampled rather than recorded, so their edges can miss a press
-## and release that both happen between two cycles.
+## `update!`. The packed bits behind `key_pressed` and `mouse.button_pressed`
+## are the coalesced view -- at least one press, at least one release -- and
+## `events` is the record: every event in delivery order with count, order
+## across sources and click positions preserved, up to 256 per input with
+## `events_overflow` saying when more arrived. Typed text is capped at 32
+## codepoints with `text_input_overflow`; the wheel is the sum of every notch.
+## Gamepad buttons are sampled rather than recorded, so their edges can miss a
+## press and release that both happen between two cycles.
 ##
 ## The type and its pure query receivers live in the companion `roc-ray-types`
 ## package so reusable packages can depend on them without depending on this
@@ -24,14 +27,32 @@ Devices := [].{
 	## Everything the host observed from input devices for one cycle.
 	##
 	## `keys`, `text_input` and `text_input_overflow` are the keyboard, `mouse`
-	## is the pointer, and `gamepads` is up to four pads. Read them through the
-	## receivers -- `key_pressed`, `mouse.position()`, `gamepad(One)` -- rather
-	## than through the packed lists.
+	## is the pointer, `gamepads` is up to four pads, and `events` with
+	## `events_overflow` is the ordered record of everything the keyboard and
+	## pointer did. Read the state through the receivers -- `key_pressed`,
+	## `mouse.position()`, `gamepad(One)` -- rather than through the packed
+	## lists, and walk `events` when order or count matters.
 	##
 	## Declared in the `roc-ray-types` package's `Devices` and re-exported here,
 	## which is also where its receivers are documented. `App.Input` carries one
 	## as `input.devices`.
 	Snapshot : RrtDevices.Snapshot
+
+	## One key edge, click, wheel notch or typed character from
+	## `input.devices.events`, in the order it happened.
+	##
+	## ```roc
+	## List.walk(input.devices.events, model, |m, event|
+	##     match event {
+	##         ButtonPressed(Left, at) => start_drag(m, at)
+	##         ButtonReleased(Left, at) => end_drag(m, at)
+	##         Text(codepoint) => insert(m, codepoint)
+	##         _ => m
+	##     })
+	## ```
+	##
+	## Declared in the `roc-ray-types` package's `Devices` and re-exported here.
+	Event : RrtDevices.Event
 
 	## A snapshot with the host's packed list lengths and nothing pressed.
 	##

--- a/platform/Devices.roc
+++ b/platform/Devices.roc
@@ -1,10 +1,17 @@
 ## Latest device samples and interval events for one `App.Input`.
 ##
 ## `input.devices` carries the keyboard, pointer, text and gamepad state the
-## host sampled for this cycle. Held keys and pointer position are the latest
-## value at the cycle boundary; presses, releases and typed text are the events
-## retained since the preceding input, so each is consumed by exactly one call
-## to `update!`.
+## host observed for this cycle. Held keys, held buttons, pointer position and
+## gamepad axes are the latest value at the cycle boundary. Key and mouse
+## presses and releases, wheel movement and typed text are the events recorded
+## since the preceding input, from the window system's own event callbacks: an
+## event that reaches the process is in the next input or reported as an
+## overflow, never silently lost, and each is consumed by exactly one call to
+## `update!`. Presses of one key or button in one interval coalesce into a
+## single bit; typed text is capped at 32 codepoints with `text_input_overflow`
+## saying when more arrived; the wheel is the sum of every notch. Gamepad
+## buttons are sampled rather than recorded, so their edges can miss a press
+## and release that both happen between two cycles.
 ##
 ## The type and its pure query receivers live in the companion `roc-ray-types`
 ## package so reusable packages can depend on them without depending on this
@@ -14,12 +21,12 @@ import rrt.Devices as RrtDevices
 
 Devices := [].{
 
-	## Everything the host sampled from input devices for one cycle.
+	## Everything the host observed from input devices for one cycle.
 	##
-	## `keys` and `text_input` are the keyboard, `mouse` is the pointer, and
-	## `gamepads` is up to four pads. Read them through the receivers --
-	## `key_pressed`, `mouse.position()`, `gamepad(One)` -- rather than through
-	## the packed lists.
+	## `keys`, `text_input` and `text_input_overflow` are the keyboard, `mouse`
+	## is the pointer, and `gamepads` is up to four pads. Read them through the
+	## receivers -- `key_pressed`, `mouse.position()`, `gamepad(One)` -- rather
+	## than through the packed lists.
 	##
 	## Declared in the `roc-ray-types` package's `Devices` and re-exported here,
 	## which is also where its receivers are documented. `App.Input` carries one

--- a/platform/Gamepad.roc
+++ b/platform/Gamepad.roc
@@ -11,6 +11,12 @@ Gamepad := [].{
 
 	## Gamepad input sampled once per host-cycle input for every slot.
 	##
+	## Sampled, unlike the keyboard and mouse: raylib polls gamepads once per
+	## cycle with no event callback to record from, so the pressed and released
+	## bits come from comparing two samples and a button pressed and released
+	## between two cycles is lost. Hold a button for at least one cycle to be
+	## sure it registers.
+	##
 	## Declared in the `roc-ray-types` package's `Gamepad` and re-exported here,
 	## which is also where its receivers are documented.
 	Snapshot : RrtGamepad.Snapshot
@@ -47,11 +53,14 @@ Gamepad := [].{
 	button_up : { buttons : List(U8), ..state }, Id, Button -> Bool
 	button_up = RrtGamepad.button_up
 
-	## Check if a gamepad button was pressed during this input interval.
+	## Check if a gamepad button went from up to down between the previous
+	## sample and this one. Sampled, so a press and release inside one cycle
+	## is not seen; see `Snapshot`.
 	button_pressed : { buttons : List(U8), ..state }, Id, Button -> Bool
 	button_pressed = RrtGamepad.button_pressed
 
-	## Check if a gamepad button was released during this input interval.
+	## Check if a gamepad button went from down to up between the previous
+	## sample and this one, with the same caveat as `button_pressed`.
 	button_released : { buttons : List(U8), ..state }, Id, Button -> Bool
 	button_released = RrtGamepad.button_released
 

--- a/platform/Keys.roc
+++ b/platform/Keys.roc
@@ -51,8 +51,12 @@ Keys := [].{
 	##
 	## An interval event recorded from the window system, so a key that went
 	## down and up between two cycles is still pressed (and released) in the
-	## next input, never lost to frame timing. Presses of one key inside one
-	## interval coalesce into one answer. Pass `input.devices` directly.
+	## next input, never lost to frame timing. This is the coalesced view:
+	## presses of one key inside one interval answer once. When the count or
+	## the order matters -- a double tap, a chord, a keystroke between two
+	## typed characters -- walk `input.devices.events`, which holds every
+	## `KeyPressed` and `KeyReleased` in delivery order. Pass `input.devices`
+	## directly.
 	key_pressed : { keys : List(U8), ..state }, Key -> Bool
 	key_pressed = RrtKeys.key_pressed
 

--- a/platform/Keys.roc
+++ b/platform/Keys.roc
@@ -37,19 +37,27 @@ Keys := [].{
 	key_code : Key -> U64
 	key_code = RrtKeys.key_code
 
-	## Check if a specific key is currently held down. Pass `input.devices` directly.
+	## Check if a specific key is held down at this cycle's boundary. A state
+	## sample. Pass `input.devices` directly.
 	key_down : { keys : List(U8), ..state }, Key -> Bool
 	key_down = RrtKeys.key_down
 
-	## Check if a specific key is currently not pressed (up). Pass `input.devices` directly.
+	## Check if a specific key is up at this cycle's boundary. Pass
+	## `input.devices` directly.
 	key_up : { keys : List(U8), ..state }, Key -> Bool
 	key_up = RrtKeys.key_up
 
-	## Check if a key was pressed during this input interval. Pass `input.devices` directly.
+	## Check if a key was pressed at least once since the previous input.
+	##
+	## An interval event recorded from the window system, so a key that went
+	## down and up between two cycles is still pressed (and released) in the
+	## next input, never lost to frame timing. Presses of one key inside one
+	## interval coalesce into one answer. Pass `input.devices` directly.
 	key_pressed : { keys : List(U8), ..state }, Key -> Bool
 	key_pressed = RrtKeys.key_pressed
 
-	## Check if a key was released during this input interval. Pass `input.devices` directly.
+	## Check if a key was released at least once since the previous input, with
+	## the same guarantee as `key_pressed`. Pass `input.devices` directly.
 	key_released : { keys : List(U8), ..state }, Key -> Bool
 	key_released = RrtKeys.key_released
 
@@ -67,9 +75,10 @@ Keys := [].{
 	## Where keyboard state comes from: the hardware, or a script.
 	##
 	## `Virtual` names the keys held down on the next frame, and only those.
-	## The host runs the same edge detector over a scripted source that it runs
+	## The host runs the same derivation over a scripted source that it runs
 	## over hardware, so a key that appears in one frame's list and not the
-	## previous one is pressed, and one that disappears is released.
+	## previous one is pressed, and one that disappears is released. Hardware
+	## edges are shut out entirely while a script is the source.
 	Source : [Hardware, Virtual(List(Key))]
 
 	## A scripted source holding exactly these keys down.
@@ -131,7 +140,8 @@ Keys := [].{
 	## The codepoints arrive on the next cycle's `input.devices.text_input` and
 	## are gone the cycle after, the way a real keyboard's characters arrive on
 	## one frame and not the next. At most 32 codepoints are delivered per
-	## frame and the excess is discarded, exactly as for hardware input.
+	## input; a longer script has the excess discarded and
+	## `text_input_overflow` set, exactly as for hardware input.
 	##
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
 	##

--- a/platform/Mouse.roc
+++ b/platform/Mouse.roc
@@ -119,7 +119,9 @@ Mouse := [].{
 
 	## Horizontal and vertical wheel movement since the previous input: every
 	## scroll event in the interval summed, so notches turned between two
-	## cycles are all counted rather than only the last.
+	## cycles are all counted rather than only the last. Each notch is also a
+	## `Wheel` entry in `input.devices.events`, in order with the clicks and
+	## keys around it.
 	wheel_delta : { wheel_x : F32, wheel_y : F32, ..state } -> { x : F32, y : F32 }
 	wheel_delta = RrtMouse.wheel_delta
 
@@ -137,9 +139,12 @@ Mouse := [].{
 	##
 	## An interval event recorded from the window system, so a click that
 	## began and ended between two cycles is still pressed (and released) in
-	## the next input. Presses of one button inside one interval coalesce into
-	## one answer, and every click in the interval shares the boundary
-	## position `position` reports.
+	## the next input. This is the coalesced view: presses of one button
+	## inside one interval answer once, and `position` is where the pointer
+	## was at the cycle boundary. For a drag that ended and began again inside
+	## one frame, a double click, or the exact spot each click landed at,
+	## walk `input.devices.events`: every `ButtonPressed` and `ButtonReleased`
+	## is there in order, each with its own position.
 	button_pressed : { buttons : List(U8), ..state }, Button -> Bool
 	button_pressed = RrtMouse.button_pressed
 

--- a/platform/Mouse.roc
+++ b/platform/Mouse.roc
@@ -117,23 +117,34 @@ Mouse := [].{
 	delta : { delta_x : F32, delta_y : F32, ..state } -> { x : F32, y : F32 }
 	delta = RrtMouse.delta
 
-	## Horizontal and vertical wheel movement retained for this input interval.
+	## Horizontal and vertical wheel movement since the previous input: every
+	## scroll event in the interval summed, so notches turned between two
+	## cycles are all counted rather than only the last.
 	wheel_delta : { wheel_x : F32, wheel_y : F32, ..state } -> { x : F32, y : F32 }
 	wheel_delta = RrtMouse.wheel_delta
 
-	## Check if a mouse button is currently held down.
+	## Check if a mouse button is held down at this cycle's boundary. A state
+	## sample.
 	button_down : { buttons : List(U8), ..state }, Button -> Bool
 	button_down = RrtMouse.button_down
 
-	## Check if a mouse button is currently up.
+	## Check if a mouse button is up at this cycle's boundary.
 	button_up : { buttons : List(U8), ..state }, Button -> Bool
 	button_up = RrtMouse.button_up
 
-	## Check if a mouse button was pressed during this input interval.
+	## Check if a mouse button was pressed at least once since the previous
+	## input.
+	##
+	## An interval event recorded from the window system, so a click that
+	## began and ended between two cycles is still pressed (and released) in
+	## the next input. Presses of one button inside one interval coalesce into
+	## one answer, and every click in the interval shares the boundary
+	## position `position` reports.
 	button_pressed : { buttons : List(U8), ..state }, Button -> Bool
 	button_pressed = RrtMouse.button_pressed
 
-	## Check if a mouse button was released during this input interval.
+	## Check if a mouse button was released at least once since the previous
+	## input, with the same guarantee as `button_pressed`.
 	button_released : { buttons : List(U8), ..state }, Button -> Bool
 	button_released = RrtMouse.button_released
 }

--- a/platform/main-wayland.roc
+++ b/platform/main-wayland.roc
@@ -266,7 +266,8 @@ import CmdHost
 ## compiler may optimize the reshaping below into a direct pass-through.
 InputFromHost : {
 	keys : List(U8), ## 349 packed state bytes, one per raylib key code 0-348
-	text_input : List(U32), ## Unicode codepoints entered this frame
+	text_input : List(U32), ## Unicode codepoints typed this interval, at most 32
+	text_input_overflow : Bool, ## whether more than 32 were typed and the rest discarded
 	gamepads : {
 		available : List(U8), ## 4 availability bytes
 		buttons : List(U8), ## 4 * 18 packed button-state bytes
@@ -322,6 +323,7 @@ input_from_raw : InputFromHost -> Devices.Snapshot
 input_from_raw = |raw| {
 	keys: raw.keys,
 	text_input: raw.text_input,
+	text_input_overflow: raw.text_input_overflow,
 	gamepads: {
 		connected: raw.gamepads.available,
 		buttons: raw.gamepads.buttons,

--- a/platform/main-wayland.roc
+++ b/platform/main-wayland.roc
@@ -219,6 +219,7 @@ import DrawHost
 import Text
 import Color
 import Devices
+import rrt.Devices as RrtDevices
 import Files
 import FilesHost
 import Window
@@ -268,6 +269,8 @@ InputFromHost : {
 	keys : List(U8), ## 349 packed state bytes, one per raylib key code 0-348
 	text_input : List(U32), ## Unicode codepoints typed this interval, at most 32
 	text_input_overflow : Bool, ## whether more than 32 were typed and the rest discarded
+	events : List(RrtDevices.RawEvent), ## every event this interval in delivery order, at most 256
+	events_overflow : Bool, ## whether more than 256 arrived and the rest were discarded
 	gamepads : {
 		available : List(U8), ## 4 availability bytes
 		buttons : List(U8), ## 4 * 18 packed button-state bytes
@@ -316,14 +319,16 @@ app_config_for_host! = || AppConfig.to_host({}, (program.init!.config)(HostHost.
 
 ## Reshape the flat sampled input into the public `Devices.Snapshot` record.
 ##
-## Only `gamepads.available` is renamed; the compiler may optimize the rest of
-## this into a direct pass-through, which is why the two layouts are kept
-## deliberately compatible.
+## `gamepads.available` is renamed and the flat event records are decoded into
+## the typed `Devices.Event` union -- a union cannot cross the host boundary --
+## and the rest passes through unchanged.
 input_from_raw : InputFromHost -> Devices.Snapshot
 input_from_raw = |raw| {
 	keys: raw.keys,
 	text_input: raw.text_input,
 	text_input_overflow: raw.text_input_overflow,
+	events: RrtDevices.events_from_raw(raw.events),
+	events_overflow: raw.events_overflow,
 	gamepads: {
 		connected: raw.gamepads.available,
 		buttons: raw.gamepads.buttons,

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -269,7 +269,8 @@ import CmdHost
 ## compiler may optimize the reshaping below into a direct pass-through.
 InputFromHost : {
 	keys : List(U8), ## 349 packed state bytes, one per raylib key code 0-348
-	text_input : List(U32), ## Unicode codepoints entered this frame
+	text_input : List(U32), ## Unicode codepoints typed this interval, at most 32
+	text_input_overflow : Bool, ## whether more than 32 were typed and the rest discarded
 	gamepads : {
 		available : List(U8), ## 4 availability bytes
 		buttons : List(U8), ## 4 * 18 packed button-state bytes
@@ -325,6 +326,7 @@ input_from_raw : InputFromHost -> Devices.Snapshot
 input_from_raw = |raw| {
 	keys: raw.keys,
 	text_input: raw.text_input,
+	text_input_overflow: raw.text_input_overflow,
 	gamepads: {
 		connected: raw.gamepads.available,
 		buttons: raw.gamepads.buttons,

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -222,6 +222,7 @@ import DrawHost
 import Text
 import Color
 import Devices
+import rrt.Devices as RrtDevices
 import Files
 import FilesHost
 import Window
@@ -271,6 +272,8 @@ InputFromHost : {
 	keys : List(U8), ## 349 packed state bytes, one per raylib key code 0-348
 	text_input : List(U32), ## Unicode codepoints typed this interval, at most 32
 	text_input_overflow : Bool, ## whether more than 32 were typed and the rest discarded
+	events : List(RrtDevices.RawEvent), ## every event this interval in delivery order, at most 256
+	events_overflow : Bool, ## whether more than 256 arrived and the rest were discarded
 	gamepads : {
 		available : List(U8), ## 4 availability bytes
 		buttons : List(U8), ## 4 * 18 packed button-state bytes
@@ -319,14 +322,16 @@ app_config_for_host! = || AppConfig.to_host({}, (program.init!.config)(HostHost.
 
 ## Reshape the flat sampled input into the public `Devices.Snapshot` record.
 ##
-## Only `gamepads.available` is renamed; the compiler may optimize the rest of
-## this into a direct pass-through, which is why the two layouts are kept
-## deliberately compatible.
+## `gamepads.available` is renamed and the flat event records are decoded into
+## the typed `Devices.Event` union -- a union cannot cross the host boundary --
+## and the rest passes through unchanged.
 input_from_raw : InputFromHost -> Devices.Snapshot
 input_from_raw = |raw| {
 	keys: raw.keys,
 	text_input: raw.text_input,
 	text_input_overflow: raw.text_input_overflow,
+	events: RrtDevices.events_from_raw(raw.events),
+	events_overflow: raw.events_overflow,
 	gamepads: {
 		connected: raw.gamepads.available,
 		buttons: raw.gamepads.buttons,

--- a/scripts/test_spec.json
+++ b/scripts/test_spec.json
@@ -7,7 +7,7 @@
     "Every examples/<name> directory must appear exactly once, and each app has",
     "one or more named cases. Case fields, all optional except name:",
     "  frames           cycles to run before the host exits by itself",
-    "  keys             --host-keys script, e.g. \"3:S,4:LEFT+X\" (cycle:keys; a ^ suffix taps the key inside the cycle)",
+    "  keys             --host-keys script, e.g. \"3:S,4:LEFT+X\" (cycle:keys; a ~ suffix taps the key inside the cycle)",
     "  text             --host-text script, e.g. \"5:hi\" (cycle:typed text)",
     "  args             extra application arguments",
     "  contains         substrings the combined output must contain",
@@ -155,7 +155,7 @@
         {
           "name": "events-in-order",
           "frames": 1000000,
-          "keys": "3:A^+B^,4:Q",
+          "keys": "3:A~+B~,4:Q",
           "text": "3:hi",
           "timeout_seconds": 30,
           "contains": [
@@ -200,7 +200,7 @@
         {
           "name": "tapped-quit",
           "frames": 1000000,
-          "keys": "3:W,6:ESCAPE^",
+          "keys": "3:W,6:ESCAPE~",
           "timeout_seconds": 30,
           "_note": "Escape is tapped inside cycle 6 and never held, so the run only ends if a press that began and ended between two polls reaches key_pressed"
         }

--- a/scripts/test_spec.json
+++ b/scripts/test_spec.json
@@ -7,7 +7,7 @@
     "Every examples/<name> directory must appear exactly once, and each app has",
     "one or more named cases. Case fields, all optional except name:",
     "  frames           cycles to run before the host exits by itself",
-    "  keys             --host-keys script, e.g. \"3:S,4:LEFT+X\" (cycle:keys)",
+    "  keys             --host-keys script, e.g. \"3:S,4:LEFT+X\" (cycle:keys; a ^ suffix taps the key inside the cycle)",
     "  text             --host-text script, e.g. \"5:hi\" (cycle:typed text)",
     "  args             extra application arguments",
     "  contains         substrings the combined output must contain",
@@ -184,6 +184,13 @@
           "frames": 1000000,
           "keys": "3:W,4:W,5:S,8:SPACE,12:ESCAPE",
           "timeout_seconds": 30
+        },
+        {
+          "name": "tapped-quit",
+          "frames": 1000000,
+          "keys": "3:W,6:ESCAPE^",
+          "timeout_seconds": 30,
+          "_note": "Escape is tapped inside cycle 6 and never held, so the run only ends if a press that began and ended between two polls reaches key_pressed"
         }
       ]
     },

--- a/scripts/test_spec.json
+++ b/scripts/test_spec.json
@@ -151,6 +151,18 @@
           "keys": "3:A,4:A,8:Q",
           "text": "5:hi",
           "timeout_seconds": 30
+        },
+        {
+          "name": "events-in-order",
+          "frames": 1000000,
+          "keys": "3:A^+B^,4:Q",
+          "text": "3:hi",
+          "timeout_seconds": 30,
+          "contains": [
+            "events: KeyPressed(65) KeyReleased(65) KeyPressed(66) KeyReleased(66) Text(104) Text(105)",
+            "events: KeyPressed(81)"
+          ],
+          "_note": "Two taps and two characters inside cycle 3 must reach the app as six ordered events -- the bits alone would show one press per key -- and the held Q on cycle 4 as a press event that also quits"
         }
       ]
     },

--- a/src/backend_raylib.zig
+++ b/src/backend_raylib.zig
@@ -64,11 +64,12 @@ pub const RenderTexture = rl.RenderTexture2D;
 /// Native shader program retained in the host resource heap.
 pub const Shader = rl.Shader;
 
-/// Persistent packed keyboard state - updated each frame.
-/// Bit 0 is held, bit 1 is pressed this frame, and bit 2 is released this frame.
+/// Persistent packed keyboard state, derived once per input interval.
+/// Bit 0 is held, bit 1 is pressed this interval, and bit 2 is released this
+/// interval.
 var key_state: [ffi.KEY_COUNT]u8 = [_]u8{0} ** ffi.KEY_COUNT;
 
-/// Persistent packed mouse button state - updated each frame, with the same bits.
+/// Persistent packed mouse button state, with the same bits.
 var mouse_button_state: [ffi.MOUSE_BUTTON_COUNT]u8 = [_]u8{0} ** ffi.MOUSE_BUTTON_COUNT;
 
 /// Persistent gamepad snapshot, flattened by gamepad then control index.
@@ -76,10 +77,91 @@ var gamepad_available: [ffi.GAMEPAD_COUNT]u8 = [_]u8{0} ** ffi.GAMEPAD_COUNT;
 var gamepad_button_state: [ffi.GAMEPAD_COUNT * ffi.GAMEPAD_BUTTON_COUNT]u8 = [_]u8{0} ** (ffi.GAMEPAD_COUNT * ffi.GAMEPAD_BUTTON_COUNT);
 var gamepad_axes: [ffi.GAMEPAD_COUNT * ffi.GAMEPAD_AXIS_COUNT]f32 = [_]f32{0} ** (ffi.GAMEPAD_COUNT * ffi.GAMEPAD_AXIS_COUNT);
 
-/// raylib's internal codepoint queue is bounded; this also leaves room if its
-/// default grows. Any excess is drained so it cannot leak into a later frame.
+/// How many typed codepoints one input interval delivers.
+///
+/// The host records characters itself, from the window system's character
+/// callback, so this is the real bound: raylib's own queue holds sixteen per
+/// poll and drops the rest without saying so, and it is not consulted while
+/// the callbacks are installed. Past this many the extra codepoints are
+/// discarded and the interval is reported as overflowed, never silently cut.
 pub const TEXT_INPUT_CAPACITY: usize = 32;
+
+/// How many codepoints raylib's own character queue holds per poll
+/// (`MAX_CHAR_PRESSED_QUEUE` in rcore.c). Only the fallback path, with no GLFW
+/// window to hook, reads that queue.
+const RAYLIB_CHAR_QUEUE_CAPACITY: usize = 16;
+
+/// Typed characters recorded since the interval began, in the order typed.
 var text_input: [TEXT_INPUT_CAPACITY]u32 = [_]u32{0} ** TEXT_INPUT_CAPACITY;
+var text_input_len: usize = 0;
+var text_input_overflowed: bool = false;
+
+/// Wheel movement summed since the interval began.
+var hardware_wheel: Vec2 = .{ .x = 0, .y = 0 };
+
+/// A press or a release of one key or button.
+pub const InputEdge = enum { press, release };
+
+/// Which of the two edge sources a derived state consumes.
+///
+/// `hardware` is the window system, recorded by the chained GLFW callbacks;
+/// `virtual` is a script. The two are kept apart so a scripted keyboard shuts
+/// the real one out completely, edges included, and so a tap scripted while
+/// hardware was the source does not surface cycles later.
+pub const InputSource = enum { hardware, virtual };
+
+/// The edges of every key (or button) recorded since the state was last
+/// derived: one byte per code holding the `INPUT_PRESSED` and `INPUT_RELEASED`
+/// bits.
+///
+/// Recording the same edge twice is idempotent. The accumulator says whether at
+/// least one press and at least one release happened, not how many or in what
+/// order; that coalescing is the whole of what it loses, and it has no
+/// capacity to exhaust, so there is no overflow to report.
+fn EdgeAccumulator(comptime count: usize) type {
+    return struct {
+        bits: [count]u8 = [_]u8{0} ** count,
+
+        fn record(self: *@This(), index: usize, edge: InputEdge) void {
+            self.bits[index] |= switch (edge) {
+                .press => ffi.INPUT_PRESSED,
+                .release => ffi.INPUT_RELEASED,
+            };
+        }
+
+        fn take(self: *@This(), index: usize) u8 {
+            const edges = self.bits[index];
+            self.bits[index] = 0;
+            return edges;
+        }
+
+        fn clear(self: *@This()) void {
+            self.bits = [_]u8{0} ** count;
+        }
+    };
+}
+
+/// Edges the window system delivered, recorded by the chained GLFW callbacks.
+var hardware_key_edges: EdgeAccumulator(ffi.KEY_COUNT) = .{};
+var hardware_mouse_button_edges: EdgeAccumulator(ffi.MOUSE_BUTTON_COUNT) = .{};
+/// Edges a script placed inside one cycle, for the virtual keyboard.
+var virtual_key_edges: EdgeAccumulator(ffi.KEY_COUNT) = .{};
+
+test "an edge accumulator coalesces repeats and empties when taken" {
+    var edges: EdgeAccumulator(4) = .{};
+    try std.testing.expectEqual(@as(u8, 0), edges.take(1));
+
+    edges.record(1, .press);
+    edges.record(1, .release);
+    edges.record(1, .press);
+    edges.record(3, .release);
+    try std.testing.expectEqual(ffi.INPUT_PRESSED | ffi.INPUT_RELEASED, edges.take(1));
+    try std.testing.expectEqual(@as(u8, 0), edges.take(1));
+    try std.testing.expectEqual(@as(u8, 0), edges.take(2));
+
+    edges.clear();
+    try std.testing.expectEqual(@as(u8, 0), edges.take(3));
+}
 
 fn gamepadButtonIndex(gamepad: usize, button: usize) usize {
     return gamepad * ffi.GAMEPAD_BUTTON_COUNT + button;
@@ -106,12 +188,21 @@ fn disconnectedInputState(previous: u8) u8 {
     return if (previous & ffi.INPUT_HELD != 0) ffi.INPUT_RELEASED else 0;
 }
 
-/// Derive this frame's packed state from the previous state and one held query.
-/// Raylib's pressed/released queries are equivalent to these transitions for
-/// keys and mouse buttons, so the host only needs one boundary call per input.
-fn nextInputState(previous: u8, down: bool) u8 {
+/// Derive one interval's packed state from the previous state, the level at
+/// the interval's end, and the edges recorded during it.
+///
+/// `edges` is what the window system (or a script) said happened; the level
+/// comparison is a second witness to the same transitions. Taking the union
+/// means a tap that began and ended inside the interval -- level unchanged,
+/// so invisible to the comparison -- still reads as pressed and released, and
+/// a transition whose edge was somehow not recorded still reads from the
+/// level. Gamepads, which raylib polls with no callback, pass no edges and
+/// get level detection alone.
+fn nextInputState(previous: u8, down: bool, edges: u8) u8 {
     const was_down = previous & ffi.INPUT_HELD != 0;
-    return inputStateBits(down, down and !was_down, !down and was_down);
+    const pressed = edges & ffi.INPUT_PRESSED != 0 or (down and !was_down);
+    const released = edges & ffi.INPUT_RELEASED != 0 or (!down and was_down);
+    return inputStateBits(down, pressed, released);
 }
 
 fn raylibGamepadButtonDown(_: void, gamepad: c_int, button: c_int) bool {
@@ -133,6 +224,7 @@ fn updateGamepadButtonStates(
             states[flat_index] = nextInputState(
                 states[flat_index],
                 is_button_down(context, gamepad_id, @intCast(button)),
+                0,
             );
         } else {
             states[flat_index] = disconnectedInputState(states[flat_index]);
@@ -152,18 +244,34 @@ test "disconnecting a held input synthesizes one release edge" {
 }
 
 test "input state derives press and release edges from held transitions" {
-    const up = nextInputState(0, false);
+    const up = nextInputState(0, false, 0);
     try std.testing.expectEqual(@as(u8, 0), up);
 
-    const pressed = nextInputState(up, true);
+    const pressed = nextInputState(up, true, 0);
     try std.testing.expectEqual(ffi.INPUT_HELD | ffi.INPUT_PRESSED, pressed);
 
-    const held = nextInputState(pressed, true);
+    const held = nextInputState(pressed, true, 0);
     try std.testing.expectEqual(ffi.INPUT_HELD, held);
 
-    const released = nextInputState(held, false);
+    const released = nextInputState(held, false, 0);
     try std.testing.expectEqual(ffi.INPUT_RELEASED, released);
-    try std.testing.expectEqual(@as(u8, 0), nextInputState(released, false));
+    try std.testing.expectEqual(@as(u8, 0), nextInputState(released, false, 0));
+}
+
+test "recorded edges surface even when the level did not change" {
+    // A tap inside the interval: the level is up at both ends.
+    const tap = nextInputState(0, false, ffi.INPUT_PRESSED | ffi.INPUT_RELEASED);
+    try std.testing.expectEqual(ffi.INPUT_PRESSED | ffi.INPUT_RELEASED, tap);
+
+    // Released and pressed again inside the interval: the level is down at
+    // both ends, and the app is told about both edges rather than a hold.
+    const held = ffi.INPUT_HELD;
+    const regrip = nextInputState(held, true, ffi.INPUT_RELEASED | ffi.INPUT_PRESSED);
+    try std.testing.expectEqual(ffi.INPUT_HELD | ffi.INPUT_RELEASED | ffi.INPUT_PRESSED, regrip);
+
+    // An edge and a level transition that agree are one edge, not two.
+    try std.testing.expectEqual(ffi.INPUT_HELD | ffi.INPUT_PRESSED, nextInputState(0, true, ffi.INPUT_PRESSED));
+    try std.testing.expectEqual(ffi.INPUT_RELEASED, nextInputState(held, false, ffi.INPUT_RELEASED));
 }
 
 test "gamepad buttons use one held query per connected button" {
@@ -218,33 +326,298 @@ test "gamepad button edges survive disconnect and reconnect" {
     try std.testing.expectEqual(ffi.INPUT_HELD | ffi.INPUT_PRESSED, states[index]);
 }
 
-/// Update keyboard state from raylib (call once per frame)
-pub fn updateKeyboardState() void {
-    for (0..ffi.KEY_COUNT) |i| {
-        const key: c_int = @intCast(i);
-        key_state[i] = nextInputState(key_state[i], rl.IsKeyDown(key));
+// ---- Window-system event callbacks ----
+//
+// raylib's GLFW platform keeps levels, not queues: its key and mouse-button
+// callbacks store the latest action, its scroll callback overwrites the
+// wheel, and its character queue is a fixed sixteen per poll. Everything that
+// happens between two polls collapses into whatever came last, and the poll
+// period is the frame time. So the host chains its own callbacks behind
+// raylib's on the same window and records every event itself: edges into the
+// accumulators above, wheel offsets into a sum, characters into a bounded
+// buffer with an overflow flag. raylib's callback is still forwarded every
+// event, so its own state -- and its exit key, which its key callback
+// handles -- keep working unchanged. All of it runs on the frame thread,
+// inside `glfwPollEvents`.
+
+/// GLFW's window type. Opaque here: the host never dereferences it.
+const GlfwWindow = opaque {};
+const GlfwKeyFn = ?*const fn (?*GlfwWindow, c_int, c_int, c_int, c_int) callconv(.c) void;
+const GlfwMouseButtonFn = ?*const fn (?*GlfwWindow, c_int, c_int, c_int) callconv(.c) void;
+const GlfwScrollFn = ?*const fn (?*GlfwWindow, f64, f64) callconv(.c) void;
+const GlfwCharFn = ?*const fn (?*GlfwWindow, c_uint) callconv(.c) void;
+
+// Declared by hand rather than through a header: the vendored raylib ships
+// only its own headers, but every target's archive carries GLFW. The window
+// comes from the current context rather than `GetWindowHandle`, which returns
+// the native (HWND / NSWindow) handle on two of the four targets.
+extern fn glfwGetCurrentContext() ?*GlfwWindow;
+extern fn glfwSetKeyCallback(window: ?*GlfwWindow, callback: GlfwKeyFn) GlfwKeyFn;
+extern fn glfwSetMouseButtonCallback(window: ?*GlfwWindow, callback: GlfwMouseButtonFn) GlfwMouseButtonFn;
+extern fn glfwSetScrollCallback(window: ?*GlfwWindow, callback: GlfwScrollFn) GlfwScrollFn;
+extern fn glfwSetCharCallback(window: ?*GlfwWindow, callback: GlfwCharFn) GlfwCharFn;
+
+const GLFW_RELEASE: c_int = 0;
+const GLFW_PRESS: c_int = 1;
+const GLFW_REPEAT: c_int = 2;
+
+/// raylib's own callbacks, forwarded every event from the host's.
+var raylib_key_callback: GlfwKeyFn = null;
+var raylib_mouse_button_callback: GlfwMouseButtonFn = null;
+var raylib_scroll_callback: GlfwScrollFn = null;
+var raylib_char_callback: GlfwCharFn = null;
+var input_callbacks_installed: bool = false;
+
+fn hostKeyCallback(window: ?*GlfwWindow, key: c_int, scancode: c_int, action: c_int, mods: c_int) callconv(.c) void {
+    if (raylib_key_callback) |forward| forward(window, key, scancode, action, mods);
+    recordKeyAction(key, action);
+}
+
+fn hostMouseButtonCallback(window: ?*GlfwWindow, button: c_int, action: c_int, mods: c_int) callconv(.c) void {
+    if (raylib_mouse_button_callback) |forward| forward(window, button, action, mods);
+    recordMouseButtonAction(button, action);
+}
+
+fn hostScrollCallback(window: ?*GlfwWindow, x_offset: f64, y_offset: f64) callconv(.c) void {
+    if (raylib_scroll_callback) |forward| forward(window, x_offset, y_offset);
+    recordScroll(x_offset, y_offset);
+}
+
+fn hostCharCallback(window: ?*GlfwWindow, codepoint: c_uint) callconv(.c) void {
+    if (raylib_char_callback) |forward| forward(window, codepoint);
+    recordCodepoint(codepoint);
+}
+
+/// Decode one GLFW key action into an edge, if it is one.
+///
+/// `GLFW_KEY_UNKNOWN` is -1 and is dropped along with any code past the packed
+/// list. Auto-repeat is not an edge: the key is still held, the user did
+/// nothing, and treating it as a press would fabricate one per repeat during
+/// a stall. raylib still sees the repeat through the forwarded callback.
+fn recordKeyAction(key: c_int, action: c_int) void {
+    if (key < 0 or key >= ffi.KEY_COUNT) return;
+    const edge: InputEdge = switch (action) {
+        GLFW_PRESS => .press,
+        GLFW_RELEASE => .release,
+        else => return,
+    };
+    recordHardwareKeyEdge(@intCast(key), edge);
+}
+
+fn recordMouseButtonAction(button: c_int, action: c_int) void {
+    if (button < 0 or button >= ffi.MOUSE_BUTTON_COUNT) return;
+    const edge: InputEdge = switch (action) {
+        GLFW_PRESS => .press,
+        GLFW_RELEASE => .release,
+        else => return,
+    };
+    recordHardwareMouseButtonEdge(@intCast(button), edge);
+}
+
+/// Record a key edge the window system delivered.
+///
+/// The callback above is the caller in a windowed run; a test is the other,
+/// standing in for the window system between two polls.
+pub fn recordHardwareKeyEdge(code: usize, edge: InputEdge) void {
+    hardware_key_edges.record(code, edge);
+}
+
+/// Record a mouse button edge the window system delivered.
+pub fn recordHardwareMouseButtonEdge(button: usize, edge: InputEdge) void {
+    hardware_mouse_button_edges.record(button, edge);
+}
+
+/// Record a key edge a script placed inside the current cycle.
+///
+/// A code the host has no slot for is dropped, as `applyVirtualKeys` drops it.
+/// Consumed by the next derivation from the virtual source; discarded by a
+/// derivation from hardware, where it has no cycle to land in.
+pub fn recordVirtualKeyEdge(code: u64, edge: InputEdge) void {
+    if (code >= ffi.KEY_COUNT) return;
+    virtual_key_edges.record(@intCast(code), edge);
+}
+
+/// Add one scroll event to the interval's wheel movement.
+pub fn recordScroll(x_offset: f64, y_offset: f64) void {
+    hardware_wheel.x += @floatCast(x_offset);
+    hardware_wheel.y += @floatCast(y_offset);
+}
+
+/// Append one typed codepoint, or note that the interval's buffer is full.
+pub fn recordCodepoint(codepoint: u32) void {
+    if (text_input_len < text_input.len) {
+        text_input[text_input_len] = codepoint;
+        text_input_len += 1;
+    } else {
+        text_input_overflowed = true;
     }
+}
+
+/// Chain the host's input callbacks behind raylib's on the live window.
+///
+/// Called once the window exists: raylib installs its own callbacks in
+/// `InitWindow`, and each `glfwSet*Callback` hands back the one it replaces,
+/// which is what the host forwards to. Returns false when there is no current
+/// GLFW context to hook, in which case edges come from level comparison alone
+/// and text from raylib's own queue -- the sampled behaviour the callbacks
+/// exist to improve on. Idempotent, so it can never chain to itself.
+pub fn installInputEventCallbacks() bool {
+    if (input_callbacks_installed) return true;
+    const window = glfwGetCurrentContext() orelse return false;
+    raylib_key_callback = glfwSetKeyCallback(window, hostKeyCallback);
+    raylib_mouse_button_callback = glfwSetMouseButtonCallback(window, hostMouseButtonCallback);
+    raylib_scroll_callback = glfwSetScrollCallback(window, hostScrollCallback);
+    raylib_char_callback = glfwSetCharCallback(window, hostCharCallback);
+    input_callbacks_installed = true;
+    clearRecordedHardwareInput();
+    return true;
+}
+
+/// Forget the callbacks along with the window they were installed on.
+fn forgetInputEventCallbacks() void {
+    input_callbacks_installed = false;
+    raylib_key_callback = null;
+    raylib_mouse_button_callback = null;
+    raylib_scroll_callback = null;
+    raylib_char_callback = null;
+    clearRecordedHardwareInput();
+}
+
+/// Drop everything the window system recorded but nothing has consumed.
+fn clearRecordedHardwareInput() void {
+    hardware_key_edges.clear();
+    hardware_mouse_button_edges.clear();
+    hardware_wheel = .{ .x = 0, .y = 0 };
+    text_input_len = 0;
+    text_input_overflowed = false;
+}
+
+test "GLFW key actions become edges, except repeats and unknown keys" {
+    defer clearRecordedHardwareInput();
+    const key_a = 65;
+
+    hostKeyCallback(null, key_a, 0, GLFW_PRESS, 0);
+    hostKeyCallback(null, key_a, 0, GLFW_REPEAT, 0);
+    hostKeyCallback(null, key_a, 0, GLFW_REPEAT, 0);
+    try std.testing.expectEqual(ffi.INPUT_PRESSED, hardware_key_edges.take(key_a));
+
+    hostKeyCallback(null, key_a, 0, GLFW_RELEASE, 0);
+    try std.testing.expectEqual(ffi.INPUT_RELEASED, hardware_key_edges.take(key_a));
+
+    // GLFW_KEY_UNKNOWN and a code past the packed list have nowhere to land.
+    hostKeyCallback(null, -1, 0, GLFW_PRESS, 0);
+    hostKeyCallback(null, ffi.KEY_COUNT, 0, GLFW_PRESS, 0);
+    for (hardware_key_edges.bits) |bits| try std.testing.expectEqual(@as(u8, 0), bits);
+
+    hostMouseButtonCallback(null, 1, GLFW_PRESS, 0);
+    hostMouseButtonCallback(null, ffi.MOUSE_BUTTON_COUNT, GLFW_PRESS, 0);
+    try std.testing.expectEqual(ffi.INPUT_PRESSED, hardware_mouse_button_edges.take(1));
+    for (hardware_mouse_button_edges.bits) |bits| try std.testing.expectEqual(@as(u8, 0), bits);
+}
+
+test "every event is forwarded to raylib's callback unchanged" {
+    const Forwarded = struct {
+        var key: [5]c_int = undefined;
+        var key_calls: usize = 0;
+        var button: [3]c_int = undefined;
+        var scroll: [2]f64 = undefined;
+        var char: c_uint = 0;
+
+        fn onKey(_: ?*GlfwWindow, k: c_int, scancode: c_int, action: c_int, mods: c_int) callconv(.c) void {
+            key = .{ k, scancode, action, mods, 0 };
+            key_calls += 1;
+        }
+        fn onMouseButton(_: ?*GlfwWindow, b: c_int, action: c_int, mods: c_int) callconv(.c) void {
+            button = .{ b, action, mods };
+        }
+        fn onScroll(_: ?*GlfwWindow, x: f64, y: f64) callconv(.c) void {
+            scroll = .{ x, y };
+        }
+        fn onChar(_: ?*GlfwWindow, c: c_uint) callconv(.c) void {
+            char = c;
+        }
+    };
+    raylib_key_callback = Forwarded.onKey;
+    raylib_mouse_button_callback = Forwarded.onMouseButton;
+    raylib_scroll_callback = Forwarded.onScroll;
+    raylib_char_callback = Forwarded.onChar;
+    defer forgetInputEventCallbacks();
+
+    // The exit key is raylib's to handle, inside its key callback, so the
+    // repeat and the press both have to reach it even though only the press
+    // is an edge to the host.
+    hostKeyCallback(null, 256, 9, GLFW_PRESS, 1);
+    hostKeyCallback(null, 256, 9, GLFW_REPEAT, 1);
+    try std.testing.expectEqual(@as(usize, 2), Forwarded.key_calls);
+    try std.testing.expectEqualSlices(c_int, &.{ 256, 9, GLFW_REPEAT, 1 }, Forwarded.key[0..4]);
+
+    hostMouseButtonCallback(null, 2, GLFW_RELEASE, 4);
+    try std.testing.expectEqualSlices(c_int, &.{ 2, GLFW_RELEASE, 4 }, &Forwarded.button);
+
+    hostScrollCallback(null, -1.5, 2.0);
+    try std.testing.expectEqualSlices(f64, &.{ -1.5, 2.0 }, &Forwarded.scroll);
+
+    hostCharCallback(null, 0x20ac);
+    try std.testing.expectEqual(@as(c_uint, 0x20ac), Forwarded.char);
+}
+
+/// Derive the packed keyboard state for one interval.
+///
+/// `down` is the level at the interval's end and `source` names the edge
+/// accumulator to consume; the other accumulator is discarded, so a scripted
+/// keyboard never leaks a hardware edge and a script's tap cannot surface after
+/// the app hands the keyboard back.
+pub fn deriveKeyboardState(source: InputSource, down: *const [ffi.KEY_COUNT]bool) void {
+    const consumed, const discarded = switch (source) {
+        .hardware => .{ &hardware_key_edges, &virtual_key_edges },
+        .virtual => .{ &virtual_key_edges, &hardware_key_edges },
+    };
+    discarded.clear();
+    for (0..ffi.KEY_COUNT) |i| {
+        key_state[i] = nextInputState(key_state[i], down[i], consumed.take(i));
+    }
+}
+
+/// Derive the packed mouse button state for one interval, as
+/// `deriveKeyboardState` does. Only hardware records button edges; a virtual
+/// pointer states levels, so `virtual` consumes nothing and discards the
+/// hardware edges.
+pub fn deriveMouseButtonState(source: InputSource, down: *const [ffi.MOUSE_BUTTON_COUNT]bool) void {
+    for (0..ffi.MOUSE_BUTTON_COUNT) |i| {
+        const edges = hardware_mouse_button_edges.take(i);
+        mouse_button_state[i] = nextInputState(mouse_button_state[i], down[i], if (source == .hardware) edges else 0);
+    }
+}
+
+/// Update keyboard state from the window system, once per interval.
+///
+/// The level is raylib's, kept current by the forwarded callbacks; the edges
+/// are the host's own record of the interval.
+pub fn updateKeyboardState() void {
+    var down: [ffi.KEY_COUNT]bool = undefined;
+    for (0..ffi.KEY_COUNT) |i| down[i] = rl.IsKeyDown(@intCast(i));
+    deriveKeyboardState(.hardware, &down);
 }
 
 /// Advance the packed keyboard state from caller-supplied held flags.
 ///
 /// Used by the virtual keyboard in place of `updateKeyboardState`, and by a
 /// headless run, which has no hardware to ask at all. It runs the same
-/// `nextInputState` edge detection, so a scripted key produces real
-/// pressed-this-frame and released-this-frame bits and an app's ordinary
-/// key handling reacts to it exactly as it would to hardware.
+/// derivation, so a scripted key produces real pressed-this-interval and
+/// released-this-interval bits, and a scripted tap (`recordVirtualKeyEdge`)
+/// lands inside one cycle exactly as a hardware tap between two polls does.
 pub fn updateKeyboardStateFrom(down: *const [ffi.KEY_COUNT]bool) void {
-    for (0..ffi.KEY_COUNT) |i| {
-        key_state[i] = nextInputState(key_state[i], down[i]);
-    }
+    deriveKeyboardState(.virtual, down);
 }
 
-/// Forget every key's held and edge bits.
+/// Forget every key's held and edge bits, recorded edges included.
 ///
 /// Called when an app lifetime starts, so a key held when one app exited is
 /// not still held when the next one begins.
 pub fn clearKeyState() void {
     key_state = [_]u8{0} ** ffi.KEY_COUNT;
+    hardware_key_edges.clear();
+    virtual_key_edges.clear();
 }
 
 /// Get the current packed keyboard state array.
@@ -252,12 +625,11 @@ pub fn getKeyState() *const [ffi.KEY_COUNT]u8 {
     return &key_state;
 }
 
-/// Update mouse button state from raylib (call once per frame)
+/// Update mouse button state from the window system, once per interval.
 pub fn updateMouseButtonState() void {
-    for (0..ffi.MOUSE_BUTTON_COUNT) |i| {
-        const button: c_int = @intCast(i);
-        mouse_button_state[i] = nextInputState(mouse_button_state[i], rl.IsMouseButtonDown(button));
-    }
+    var down: [ffi.MOUSE_BUTTON_COUNT]bool = undefined;
+    for (0..ffi.MOUSE_BUTTON_COUNT) |i| down[i] = rl.IsMouseButtonDown(@intCast(i));
+    deriveMouseButtonState(.hardware, &down);
 }
 
 /// Get the current packed mouse button state array.
@@ -268,21 +640,104 @@ pub fn getMouseButtonState() *const [ffi.MOUSE_BUTTON_COUNT]u8 {
 /// Forget every mouse button's held and edge bits, as `clearKeyState` does.
 pub fn clearMouseButtonState() void {
     mouse_button_state = [_]u8{0} ** ffi.MOUSE_BUTTON_COUNT;
+    hardware_mouse_button_edges.clear();
 }
 
 /// Advance the packed mouse button state from caller-supplied down flags.
 ///
 /// Used by the virtual mouse in place of `updateMouseButtonState`. It runs the
-/// same `nextInputState` edge detection, so a scripted pointer produces real
-/// pressed-this-frame and released-this-frame bits and an app's ordinary click
-/// handling reacts to it exactly as it would to hardware.
+/// same derivation, so a scripted pointer produces real pressed-this-interval
+/// and released-this-interval bits and an app's ordinary click handling
+/// reacts to it exactly as it would to hardware.
 pub fn updateMouseButtonStateFrom(down: *const [ffi.MOUSE_BUTTON_COUNT]bool) void {
-    for (0..ffi.MOUSE_BUTTON_COUNT) |i| {
-        mouse_button_state[i] = nextInputState(mouse_button_state[i], down[i]);
-    }
+    deriveMouseButtonState(.virtual, down);
+}
+
+test "a tap between two polls is pressed and released, never held" {
+    defer clearKeyState();
+    const key_e = 69;
+    const up: [ffi.KEY_COUNT]bool = @splat(false);
+
+    deriveKeyboardState(.hardware, &up);
+    try std.testing.expectEqual(@as(u8, 0), getKeyState()[key_e]);
+
+    // The window system delivers PRESS then RELEASE inside one interval, so
+    // the level is up at both polls.
+    recordHardwareKeyEdge(key_e, .press);
+    recordHardwareKeyEdge(key_e, .release);
+    deriveKeyboardState(.hardware, &up);
+    try std.testing.expectEqual(ffi.INPUT_PRESSED | ffi.INPUT_RELEASED, getKeyState()[key_e]);
+
+    // Consumed: the next interval is quiet again.
+    deriveKeyboardState(.hardware, &up);
+    try std.testing.expectEqual(@as(u8, 0), getKeyState()[key_e]);
+}
+
+test "a release and re-press between two polls is not one long hold" {
+    defer clearMouseButtonState();
+    const left = 0;
+    var down: [ffi.MOUSE_BUTTON_COUNT]bool = @splat(false);
+
+    down[left] = true;
+    recordHardwareMouseButtonEdge(left, .press);
+    deriveMouseButtonState(.hardware, &down);
+    try std.testing.expectEqual(ffi.INPUT_HELD | ffi.INPUT_PRESSED, getMouseButtonState()[left]);
+
+    // RELEASE then PRESS inside the interval; the level is down at both polls.
+    recordHardwareMouseButtonEdge(left, .release);
+    recordHardwareMouseButtonEdge(left, .press);
+    deriveMouseButtonState(.hardware, &down);
+    try std.testing.expectEqual(ffi.INPUT_HELD | ffi.INPUT_RELEASED | ffi.INPUT_PRESSED, getMouseButtonState()[left]);
+
+    deriveMouseButtonState(.hardware, &down);
+    try std.testing.expectEqual(ffi.INPUT_HELD, getMouseButtonState()[left]);
+}
+
+test "each source consumes its own edges and discards the other's" {
+    defer clearKeyState();
+    defer clearMouseButtonState();
+    const key_a = 65;
+    const up: [ffi.KEY_COUNT]bool = @splat(false);
+
+    // A hardware tap while a script owns the keyboard is not the script's.
+    recordHardwareKeyEdge(key_a, .press);
+    recordHardwareKeyEdge(key_a, .release);
+    deriveKeyboardState(.virtual, &up);
+    try std.testing.expectEqual(@as(u8, 0), getKeyState()[key_a]);
+    // And it does not resurface when the app hands the keyboard back.
+    deriveKeyboardState(.hardware, &up);
+    try std.testing.expectEqual(@as(u8, 0), getKeyState()[key_a]);
+
+    // A scripted tap consumed by hardware derivation is likewise gone.
+    recordVirtualKeyEdge(key_a, .press);
+    recordVirtualKeyEdge(key_a, .release);
+    deriveKeyboardState(.hardware, &up);
+    try std.testing.expectEqual(@as(u8, 0), getKeyState()[key_a]);
+    deriveKeyboardState(.virtual, &up);
+    try std.testing.expectEqual(@as(u8, 0), getKeyState()[key_a]);
+
+    // A scripted tap consumed by the virtual source lands.
+    recordVirtualKeyEdge(key_a, .press);
+    recordVirtualKeyEdge(key_a, .release);
+    recordVirtualKeyEdge(ffi.KEY_COUNT + 5, .press);
+    deriveKeyboardState(.virtual, &up);
+    try std.testing.expectEqual(ffi.INPUT_PRESSED | ffi.INPUT_RELEASED, getKeyState()[key_a]);
+
+    // A virtual pointer states levels only; hardware button edges are dropped.
+    const buttons_up: [ffi.MOUSE_BUTTON_COUNT]bool = @splat(false);
+    recordHardwareMouseButtonEdge(0, .press);
+    deriveMouseButtonState(.virtual, &buttons_up);
+    try std.testing.expectEqual(@as(u8, 0), getMouseButtonState()[0]);
+    deriveMouseButtonState(.hardware, &buttons_up);
+    try std.testing.expectEqual(@as(u8, 0), getMouseButtonState()[0]);
 }
 
 /// Sample all supported gamepads once for this frame.
+///
+/// Sampled, not recorded: raylib polls gamepads inside `PollInputEvents` with
+/// no callback to chain, so a button pressed and released between two polls
+/// is invisible here. That is documented as lossy on the Roc side rather than
+/// papered over.
 pub fn updateGamepadState() void {
     for (0..ffi.GAMEPAD_COUNT) |gamepad| {
         const gamepad_id: c_int = @intCast(gamepad);
@@ -361,8 +816,72 @@ pub fn releaseDroppedFiles() void {
     rl.UnloadDroppedFiles(list);
 }
 
-/// Drain this frame's queued Unicode input and return a stable scratch slice.
-pub fn getTextInput() []const u32 {
+/// Take the interval's wheel movement: every scroll event summed.
+///
+/// Taken, not read, so each notch is delivered to exactly one input. The
+/// caller takes it every cycle whether or not a scripted pointer is standing
+/// in for the hardware one, so notches turned while the pointer was scripted
+/// do not land on the cycle the app hands it back. Without callbacks this is
+/// raylib's own value, which is the last event of the poll rather than the
+/// sum.
+pub fn takeMouseWheelMove() Vec2 {
+    if (!input_callbacks_installed) return getMouseWheelMoveV();
+    return takeRecordedWheel();
+}
+
+fn takeRecordedWheel() Vec2 {
+    const moved = hardware_wheel;
+    hardware_wheel = .{ .x = 0, .y = 0 };
+    return moved;
+}
+
+test "wheel notches inside one interval are summed, then consumed" {
+    defer clearRecordedHardwareInput();
+    try std.testing.expectEqual(@as(f32, 0), takeRecordedWheel().y);
+
+    hostScrollCallback(null, 0, 1);
+    hostScrollCallback(null, 0, 1);
+    hostScrollCallback(null, -0.5, -0.25);
+    const moved = takeRecordedWheel();
+    try std.testing.expectEqual(@as(f32, -0.5), moved.x);
+    try std.testing.expectEqual(@as(f32, 1.75), moved.y);
+
+    const next = takeRecordedWheel();
+    try std.testing.expectEqual(@as(f32, 0), next.x);
+    try std.testing.expectEqual(@as(f32, 0), next.y);
+}
+
+/// One interval's typed text, and whether any of it was discarded.
+pub const TextInput = struct {
+    codepoints: []const u32,
+    overflowed: bool,
+};
+
+/// Take the interval's typed text: at most `TEXT_INPUT_CAPACITY` codepoints in
+/// the order typed, and whether more arrived than that.
+///
+/// The slice is a stable scratch buffer that the next recorded character
+/// overwrites, so the caller copies it before the next poll. Without callbacks
+/// this drains raylib's own queue instead.
+pub fn takeTextInput() TextInput {
+    if (!input_callbacks_installed) return drainRaylibTextQueue();
+    return takeRecordedText();
+}
+
+fn takeRecordedText() TextInput {
+    const delivered = text_input[0..text_input_len];
+    const overflowed = text_input_overflowed;
+    text_input_len = 0;
+    text_input_overflowed = false;
+    return .{ .codepoints = delivered, .overflowed = overflowed };
+}
+
+/// raylib's queue holds `RAYLIB_CHAR_QUEUE_CAPACITY` codepoints per poll and
+/// drops the rest without saying so. A full queue cannot be told apart from an
+/// overflowed one, so it is reported as an overflow: the honest answer is
+/// "possibly", and the flag's contract is that a clear flag means nothing was
+/// lost.
+fn drainRaylibTextQueue() TextInput {
     var count: usize = 0;
     while (true) {
         const codepoint = rl.GetCharPressed();
@@ -372,7 +891,38 @@ pub fn getTextInput() []const u32 {
             count += 1;
         }
     }
-    return text_input[0..count];
+    return .{
+        .codepoints = text_input[0..count],
+        .overflowed = count >= RAYLIB_CHAR_QUEUE_CAPACITY,
+    };
+}
+
+test "typed text past the interval's capacity is reported, not silently cut" {
+    defer clearRecordedHardwareInput();
+
+    hostCharCallback(null, 'h');
+    hostCharCallback(null, 'i');
+    const short = takeRecordedText();
+    try std.testing.expectEqualSlices(u32, &.{ 'h', 'i' }, short.codepoints);
+    try std.testing.expect(!short.overflowed);
+
+    // Gone once taken: characters arrive on one input and not the next.
+    const empty = takeRecordedText();
+    try std.testing.expectEqual(@as(usize, 0), empty.codepoints.len);
+    try std.testing.expect(!empty.overflowed);
+
+    for (0..TEXT_INPUT_CAPACITY) |i| hostCharCallback(null, @intCast('a' + (i % 26)));
+    const exact = takeRecordedText();
+    try std.testing.expectEqual(TEXT_INPUT_CAPACITY, exact.codepoints.len);
+    try std.testing.expect(!exact.overflowed);
+
+    for (0..TEXT_INPUT_CAPACITY + 1) |_| hostCharCallback(null, 'x');
+    const over = takeRecordedText();
+    try std.testing.expectEqual(TEXT_INPUT_CAPACITY, over.codepoints.len);
+    try std.testing.expect(over.overflowed);
+
+    // The flag travels with the interval that overflowed, not the next one.
+    try std.testing.expect(!takeRecordedText().overflowed);
 }
 
 /// Return raylib's built-in font, which is not owned by a resource heap.
@@ -1158,8 +1708,9 @@ pub fn windowConfigFlags(resizable: bool, fullscreen: bool, vsync: bool, visible
     return flags;
 }
 
-/// Close the window.
+/// Close the window. The input callbacks chained on it go with it.
 pub fn closeWindow() void {
+    forgetInputEventCallbacks();
     rl.CloseWindow();
 }
 

--- a/src/backend_raylib.zig
+++ b/src/backend_raylib.zig
@@ -116,8 +116,9 @@ pub const InputSource = enum { hardware, virtual };
 ///
 /// Recording the same edge twice is idempotent. The accumulator says whether at
 /// least one press and at least one release happened, not how many or in what
-/// order; that coalescing is the whole of what it loses, and it has no
-/// capacity to exhaust, so there is no overflow to report.
+/// order; that is the coalesced view, and it has no capacity to exhaust. The
+/// event log below is the authoritative one: it keeps count, order and, for
+/// clicks, position.
 fn EdgeAccumulator(comptime count: usize) type {
     return struct {
         bits: [count]u8 = [_]u8{0} ** count,
@@ -161,6 +162,303 @@ test "an edge accumulator coalesces repeats and empties when taken" {
 
     edges.clear();
     try std.testing.expectEqual(@as(u8, 0), edges.take(3));
+}
+
+// ---- The event log ----
+//
+// The packed bits above are the coalesced view: at least one press, at least
+// one release. The log is the record: every key edge, click, wheel notch and
+// typed character in the order the window system delivered them, with the
+// pointer position a click landed at. It is bounded and says when it overflowed;
+// the bits, the wheel sum and the text buffer keep recording regardless, so the
+// coalesced view stays complete even when the list did not.
+
+/// How many events one input interval records, across every source.
+///
+/// A human cannot produce this many between two polls even through a
+/// multi-second stall -- auto-repeat is not recorded -- so overflow marks a
+/// synthetic source or a hung frame, and the flag says so rather than the
+/// tail going missing.
+pub const INPUT_EVENT_CAPACITY: usize = 256;
+
+/// What one recorded event was. The numbering is the wire contract with
+/// `Devices.events_from_raw` in the types package.
+pub const InputEventKind = enum(u8) {
+    key_pressed = 0,
+    key_released = 1,
+    button_pressed = 2,
+    button_released = 3,
+    wheel = 4,
+    text = 5,
+};
+
+/// One recorded event in the flat shape that crosses to Roc.
+///
+/// `code` is the key code, mouse button code or codepoint the kind implies;
+/// `x` and `y` are the pointer position for a click and the offsets for a
+/// wheel notch, and zero otherwise.
+pub const InputEventRecord = extern struct {
+    kind: u8,
+    code: u32,
+    x: f32,
+    y: f32,
+};
+
+/// Which device an event came from, so a scripted source can shut out the
+/// hardware one device at a time.
+const InputClass = enum { keyboard, mouse, text };
+
+const LoggedEvent = struct {
+    seq: u64,
+    class: InputClass,
+    record: InputEventRecord,
+};
+
+/// Global delivery order across both logs, so the hardware mouse and a
+/// scripted keyboard still interleave the way they happened.
+var input_event_seq: u64 = 0;
+
+/// One source's events for the interval, in delivery order.
+const EventLog = struct {
+    entries: [INPUT_EVENT_CAPACITY]LoggedEvent = undefined,
+    len: usize = 0,
+    overflowed: bool = false,
+
+    fn append(self: *@This(), class: InputClass, record: InputEventRecord) void {
+        if (self.len == self.entries.len) {
+            self.overflowed = true;
+            return;
+        }
+        self.entries[self.len] = .{ .seq = input_event_seq, .class = class, .record = record };
+        input_event_seq += 1;
+        self.len += 1;
+    }
+
+    fn clear(self: *@This()) void {
+        self.len = 0;
+        self.overflowed = false;
+    }
+};
+
+/// Events the window system delivered, recorded by the chained callbacks.
+var hardware_events: EventLog = .{};
+/// Events a script produced: taps, held-set transitions, typed text.
+var virtual_events: EventLog = .{};
+
+/// Which source each device class takes its events from this cycle.
+pub const EventSources = struct {
+    keyboard: InputSource,
+    mouse: InputSource,
+    text: InputSource,
+};
+
+/// One interval's events, and whether any were dropped past the capacity.
+pub const InputEvents = struct {
+    events: []const InputEventRecord,
+    overflowed: bool,
+};
+
+/// Stable scratch the taken events are returned in.
+var taken_events: [INPUT_EVENT_CAPACITY]InputEventRecord = undefined;
+
+fn keyRecord(code: usize, edge: InputEdge) InputEventRecord {
+    return .{
+        .kind = @intFromEnum(@as(InputEventKind, if (edge == .press) .key_pressed else .key_released)),
+        .code = @intCast(code),
+        .x = 0,
+        .y = 0,
+    };
+}
+
+fn buttonRecord(button: usize, edge: InputEdge, position: Vec2) InputEventRecord {
+    return .{
+        .kind = @intFromEnum(@as(InputEventKind, if (edge == .press) .button_pressed else .button_released)),
+        .code = @intCast(button),
+        .x = position.x,
+        .y = position.y,
+    };
+}
+
+fn wheelRecord(x_offset: f32, y_offset: f32) InputEventRecord {
+    return .{ .kind = @intFromEnum(InputEventKind.wheel), .code = 0, .x = x_offset, .y = y_offset };
+}
+
+fn textRecord(codepoint: u32) InputEventRecord {
+    return .{ .kind = @intFromEnum(InputEventKind.text), .code = codepoint, .x = 0, .y = 0 };
+}
+
+fn sourceFeeds(sources: EventSources, source: InputSource) bool {
+    return sources.keyboard == source or sources.mouse == source or sources.text == source;
+}
+
+/// Take the interval's events: both logs merged in delivery order, keeping
+/// each event only if its device's source is the log it came from.
+///
+/// Taken once per cycle, in the same cycle as the packed bits and after they
+/// are derived, so an event and the bit it set are never split across two
+/// inputs. Both logs are cleared, so an event recorded for a source that was
+/// not chosen this cycle is gone rather than surfacing later. A log that
+/// overflowed lost events of some class it cannot name, so the overflow is
+/// reported if any class was taking from it.
+pub fn takeInputEvents(sources: EventSources) InputEvents {
+    var count: usize = 0;
+    var overflowed = false;
+    var h: usize = 0;
+    var v: usize = 0;
+    while (h < hardware_events.len or v < virtual_events.len) {
+        const from_hardware = v == virtual_events.len or
+            (h < hardware_events.len and hardware_events.entries[h].seq < virtual_events.entries[v].seq);
+        const entry = if (from_hardware) hardware_events.entries[h] else virtual_events.entries[v];
+        const source: InputSource = if (from_hardware) .hardware else .virtual;
+        if (from_hardware) h += 1 else v += 1;
+
+        const wanted = switch (entry.class) {
+            .keyboard => sources.keyboard,
+            .mouse => sources.mouse,
+            .text => sources.text,
+        };
+        if (wanted != source) continue;
+        if (count == taken_events.len) {
+            overflowed = true;
+            break;
+        }
+        taken_events[count] = entry.record;
+        count += 1;
+    }
+    if (hardware_events.overflowed and sourceFeeds(sources, .hardware)) overflowed = true;
+    if (virtual_events.overflowed and sourceFeeds(sources, .virtual)) overflowed = true;
+    hardware_events.clear();
+    virtual_events.clear();
+    return .{ .events = taken_events[0..count], .overflowed = overflowed };
+}
+
+/// Forget both logs, so one app lifetime cannot inherit another's events.
+pub fn clearInputEvents() void {
+    hardware_events.clear();
+    virtual_events.clear();
+}
+
+const all_hardware = EventSources{ .keyboard = .hardware, .mouse = .hardware, .text = .hardware };
+const all_virtual = EventSources{ .keyboard = .virtual, .mouse = .virtual, .text = .virtual };
+
+fn expectEvent(record: InputEventRecord, kind: InputEventKind, code: u32, x: f32, y: f32) !void {
+    try std.testing.expectEqual(@intFromEnum(kind), record.kind);
+    try std.testing.expectEqual(code, record.code);
+    try std.testing.expectEqual(x, record.x);
+    try std.testing.expectEqual(y, record.y);
+}
+
+test "events keep window-system delivery order across every source" {
+    defer clearInputEvents();
+    defer clearRecordedHardwareInput();
+
+    recordHardwareKeyEdge(65, .press);
+    recordHardwareMouseButtonEdge(0, .press, .{ .x = 12, .y = 34 });
+    recordCodepoint('a');
+    recordScroll(0, 1);
+    recordHardwareMouseButtonEdge(0, .release, .{ .x = 15, .y = 30 });
+    recordHardwareKeyEdge(65, .release);
+
+    const taken = takeInputEvents(all_hardware);
+    try std.testing.expect(!taken.overflowed);
+    try std.testing.expectEqual(@as(usize, 6), taken.events.len);
+    try expectEvent(taken.events[0], .key_pressed, 65, 0, 0);
+    try expectEvent(taken.events[1], .button_pressed, 0, 12, 34);
+    try expectEvent(taken.events[2], .text, 'a', 0, 0);
+    try expectEvent(taken.events[3], .wheel, 0, 0, 1);
+    try expectEvent(taken.events[4], .button_released, 0, 15, 30);
+    try expectEvent(taken.events[5], .key_released, 65, 0, 0);
+
+    // Taken with the interval: the next one starts empty.
+    try std.testing.expectEqual(@as(usize, 0), takeInputEvents(all_hardware).events.len);
+}
+
+test "the log keeps every tap where the bits keep one" {
+    defer clearKeyState();
+    defer clearInputEvents();
+    const key_e = 69;
+    const up: [ffi.KEY_COUNT]bool = @splat(false);
+
+    recordHardwareKeyEdge(key_e, .press);
+    recordHardwareKeyEdge(key_e, .release);
+    recordHardwareKeyEdge(key_e, .press);
+    recordHardwareKeyEdge(key_e, .release);
+    deriveKeyboardState(.hardware, &up);
+    try std.testing.expectEqual(ffi.INPUT_PRESSED | ffi.INPUT_RELEASED, getKeyState()[key_e]);
+
+    const taken = takeInputEvents(all_hardware);
+    try std.testing.expectEqual(@as(usize, 4), taken.events.len);
+    try expectEvent(taken.events[0], .key_pressed, key_e, 0, 0);
+    try expectEvent(taken.events[1], .key_released, key_e, 0, 0);
+    try expectEvent(taken.events[2], .key_pressed, key_e, 0, 0);
+    try expectEvent(taken.events[3], .key_released, key_e, 0, 0);
+}
+
+test "past the capacity the list reports overflow while the coalesced view keeps recording" {
+    defer clearKeyState();
+    defer clearInputEvents();
+    defer clearRecordedHardwareInput();
+    const up: [ffi.KEY_COUNT]bool = @splat(false);
+
+    for (0..INPUT_EVENT_CAPACITY) |_| recordHardwareKeyEdge(65, .press);
+    // These are past the cap: dropped from the list, but the bit, the wheel
+    // sum and the text buffer still see them.
+    recordHardwareKeyEdge(66, .press);
+    recordScroll(0, 2);
+    recordScroll(0, 3);
+    recordCodepoint('z');
+
+    deriveKeyboardState(.hardware, &up);
+    try std.testing.expectEqual(ffi.INPUT_PRESSED, getKeyState()[65]);
+    try std.testing.expectEqual(ffi.INPUT_PRESSED, getKeyState()[66]);
+    try std.testing.expectEqual(@as(f32, 5), takeRecordedWheel().y);
+    try std.testing.expectEqualSlices(u32, &.{'z'}, takeRecordedText().codepoints);
+
+    const taken = takeInputEvents(all_hardware);
+    try std.testing.expect(taken.overflowed);
+    try std.testing.expectEqual(INPUT_EVENT_CAPACITY, taken.events.len);
+    try expectEvent(taken.events[INPUT_EVENT_CAPACITY - 1], .key_pressed, 65, 0, 0);
+
+    // The flag travels with the interval that overflowed.
+    try std.testing.expect(!takeInputEvents(all_hardware).overflowed);
+
+    // Exactly the capacity is not an overflow.
+    for (0..INPUT_EVENT_CAPACITY) |_| recordHardwareKeyEdge(65, .press);
+    const exact = takeInputEvents(all_hardware);
+    try std.testing.expect(!exact.overflowed);
+    try std.testing.expectEqual(INPUT_EVENT_CAPACITY, exact.events.len);
+}
+
+test "each device takes events from its own source and the rest are discarded" {
+    defer clearKeyState();
+    defer clearInputEvents();
+    defer clearRecordedHardwareInput();
+
+    recordHardwareKeyEdge(65, .press);
+    recordVirtualKeyEdge(66, .press);
+    recordHardwareMouseButtonEdge(1, .press, .{ .x = 1, .y = 2 });
+    recordCodepoint('h');
+    recordVirtualText('v');
+    recordVirtualKeyEdge(66, .release);
+
+    // Scripted keyboard and text, hardware mouse: the hardware key and char
+    // are not delivered, and what is delivered stays in delivery order.
+    const taken = takeInputEvents(.{ .keyboard = .virtual, .mouse = .hardware, .text = .virtual });
+    try std.testing.expect(!taken.overflowed);
+    try std.testing.expectEqual(@as(usize, 4), taken.events.len);
+    try expectEvent(taken.events[0], .key_pressed, 66, 0, 0);
+    try expectEvent(taken.events[1], .button_pressed, 1, 1, 2);
+    try expectEvent(taken.events[2], .text, 'v', 0, 0);
+    try expectEvent(taken.events[3], .key_released, 66, 0, 0);
+
+    // The discarded events do not resurface when the source changes back.
+    try std.testing.expectEqual(@as(usize, 0), takeInputEvents(all_hardware).events.len);
+
+    // An overflowed log is reported only to the devices reading from it.
+    for (0..INPUT_EVENT_CAPACITY + 1) |_| recordHardwareKeyEdge(65, .press);
+    try std.testing.expect(!takeInputEvents(all_virtual).overflowed);
+    for (0..INPUT_EVENT_CAPACITY + 1) |_| recordHardwareKeyEdge(65, .press);
+    try std.testing.expect(takeInputEvents(.{ .keyboard = .virtual, .mouse = .hardware, .text = .virtual }).overflowed);
 }
 
 fn gamepadButtonIndex(gamepad: usize, button: usize) usize {
@@ -334,9 +632,9 @@ test "gamepad button edges survive disconnect and reconnect" {
 // happens between two polls collapses into whatever came last, and the poll
 // period is the frame time. So the host chains its own callbacks behind
 // raylib's on the same window and records every event itself: edges into the
-// accumulators above, wheel offsets into a sum, characters into a bounded
-// buffer with an overflow flag. raylib's callback is still forwarded every
-// event, so its own state -- and its exit key, which its key callback
+// accumulators and the log above, wheel offsets into a sum, characters into a
+// bounded buffer with an overflow flag. raylib's callback is still forwarded
+// every event, so its own state -- and its exit key, which its key callback
 // handles -- keep working unchanged. All of it runs on the frame thread,
 // inside `glfwPollEvents`.
 
@@ -367,6 +665,30 @@ var raylib_mouse_button_callback: GlfwMouseButtonFn = null;
 var raylib_scroll_callback: GlfwScrollFn = null;
 var raylib_char_callback: GlfwCharFn = null;
 var input_callbacks_installed: bool = false;
+
+/// Where a click's position is read from inside the button callback.
+///
+/// raylib's while the callbacks are installed; the origin before that, so a
+/// test can drive the callback without a window (and without linking raylib
+/// into the test binary).
+var callback_mouse_position: *const fn () Vec2 = &originPosition;
+
+fn originPosition() Vec2 {
+    return .{ .x = 0, .y = 0 };
+}
+
+/// The pointer as raylib reports it, in the same logical coordinates as
+/// `mouse.position()`.
+///
+/// Read inside the button callback on purpose: GLFW dispatches the motion
+/// events that precede a click before the click itself, and raylib's
+/// cursor-position callback has already applied its offset and scale by the
+/// time ours runs, so this is the position the click landed at without
+/// re-deriving raylib's scaling here.
+fn raylibMousePosition() Vec2 {
+    const position = rl.GetMousePosition();
+    return .{ .x = position.x, .y = position.y };
+}
 
 fn hostKeyCallback(window: ?*GlfwWindow, key: c_int, scancode: c_int, action: c_int, mods: c_int) callconv(.c) void {
     if (raylib_key_callback) |forward| forward(window, key, scancode, action, mods);
@@ -411,20 +733,24 @@ fn recordMouseButtonAction(button: c_int, action: c_int) void {
         GLFW_RELEASE => .release,
         else => return,
     };
-    recordHardwareMouseButtonEdge(@intCast(button), edge);
+    recordHardwareMouseButtonEdge(@intCast(button), edge, callback_mouse_position());
 }
 
-/// Record a key edge the window system delivered.
+/// Record a key edge the window system delivered: into the coalesced bits
+/// and the ordered log alike.
 ///
 /// The callback above is the caller in a windowed run; a test is the other,
 /// standing in for the window system between two polls.
 pub fn recordHardwareKeyEdge(code: usize, edge: InputEdge) void {
     hardware_key_edges.record(code, edge);
+    hardware_events.append(.keyboard, keyRecord(code, edge));
 }
 
-/// Record a mouse button edge the window system delivered.
-pub fn recordHardwareMouseButtonEdge(button: usize, edge: InputEdge) void {
+/// Record a mouse button edge the window system delivered, with the pointer
+/// position the click landed at.
+pub fn recordHardwareMouseButtonEdge(button: usize, edge: InputEdge, position: Vec2) void {
     hardware_mouse_button_edges.record(button, edge);
+    hardware_events.append(.mouse, buttonRecord(button, edge, position));
 }
 
 /// Record a key edge a script placed inside the current cycle.
@@ -435,15 +761,32 @@ pub fn recordHardwareMouseButtonEdge(button: usize, edge: InputEdge) void {
 pub fn recordVirtualKeyEdge(code: u64, edge: InputEdge) void {
     if (code >= ffi.KEY_COUNT) return;
     virtual_key_edges.record(@intCast(code), edge);
+    virtual_events.append(.keyboard, keyRecord(@intCast(code), edge));
 }
 
-/// Add one scroll event to the interval's wheel movement.
+/// Record a wheel movement a script placed inside the current cycle. The
+/// scripted pointer's own sum is the host's; only the event is logged here.
+pub fn recordVirtualWheel(x_offset: f32, y_offset: f32) void {
+    virtual_events.append(.mouse, wheelRecord(x_offset, y_offset));
+}
+
+/// Record one scripted codepoint in the ordered log. The scripted text buffer
+/// itself is the host's.
+pub fn recordVirtualText(codepoint: u32) void {
+    virtual_events.append(.text, textRecord(codepoint));
+}
+
+/// Add one scroll event to the interval's wheel movement and the log.
 pub fn recordScroll(x_offset: f64, y_offset: f64) void {
-    hardware_wheel.x += @floatCast(x_offset);
-    hardware_wheel.y += @floatCast(y_offset);
+    const x: f32 = @floatCast(x_offset);
+    const y: f32 = @floatCast(y_offset);
+    hardware_wheel.x += x;
+    hardware_wheel.y += y;
+    hardware_events.append(.mouse, wheelRecord(x, y));
 }
 
-/// Append one typed codepoint, or note that the interval's buffer is full.
+/// Append one typed codepoint, or note that the interval's buffer is full;
+/// the log records it either way, up to its own capacity.
 pub fn recordCodepoint(codepoint: u32) void {
     if (text_input_len < text_input.len) {
         text_input[text_input_len] = codepoint;
@@ -451,6 +794,7 @@ pub fn recordCodepoint(codepoint: u32) void {
     } else {
         text_input_overflowed = true;
     }
+    hardware_events.append(.text, textRecord(codepoint));
 }
 
 /// Chain the host's input callbacks behind raylib's on the live window.
@@ -468,6 +812,7 @@ pub fn installInputEventCallbacks() bool {
     raylib_mouse_button_callback = glfwSetMouseButtonCallback(window, hostMouseButtonCallback);
     raylib_scroll_callback = glfwSetScrollCallback(window, hostScrollCallback);
     raylib_char_callback = glfwSetCharCallback(window, hostCharCallback);
+    callback_mouse_position = &raylibMousePosition;
     input_callbacks_installed = true;
     clearRecordedHardwareInput();
     return true;
@@ -480,6 +825,7 @@ fn forgetInputEventCallbacks() void {
     raylib_mouse_button_callback = null;
     raylib_scroll_callback = null;
     raylib_char_callback = null;
+    callback_mouse_position = &originPosition;
     clearRecordedHardwareInput();
 }
 
@@ -487,6 +833,7 @@ fn forgetInputEventCallbacks() void {
 fn clearRecordedHardwareInput() void {
     hardware_key_edges.clear();
     hardware_mouse_button_edges.clear();
+    hardware_events.clear();
     hardware_wheel = .{ .x = 0, .y = 0 };
     text_input_len = 0;
     text_input_overflowed = false;
@@ -513,6 +860,35 @@ test "GLFW key actions become edges, except repeats and unknown keys" {
     hostMouseButtonCallback(null, ffi.MOUSE_BUTTON_COUNT, GLFW_PRESS, 0);
     try std.testing.expectEqual(ffi.INPUT_PRESSED, hardware_mouse_button_edges.take(1));
     for (hardware_mouse_button_edges.bits) |bits| try std.testing.expectEqual(@as(u8, 0), bits);
+
+    // The log saw exactly the edges: two for A, one for the button; no
+    // repeats, no unknown keys.
+    const taken = takeInputEvents(all_hardware);
+    try std.testing.expectEqual(@as(usize, 3), taken.events.len);
+    try expectEvent(taken.events[0], .key_pressed, key_a, 0, 0);
+    try expectEvent(taken.events[1], .key_released, key_a, 0, 0);
+    try expectEvent(taken.events[2], .button_pressed, 1, 0, 0);
+}
+
+test "a click carries the pointer position read at the moment it fired" {
+    const Pointer = struct {
+        var at: Vec2 = .{ .x = 0, .y = 0 };
+        fn position() Vec2 {
+            return at;
+        }
+    };
+    callback_mouse_position = &Pointer.position;
+    defer forgetInputEventCallbacks();
+
+    Pointer.at = .{ .x = 100, .y = 40 };
+    hostMouseButtonCallback(null, 0, GLFW_PRESS, 0);
+    Pointer.at = .{ .x = 180, .y = 90 };
+    hostMouseButtonCallback(null, 0, GLFW_RELEASE, 0);
+
+    const taken = takeInputEvents(all_hardware);
+    try std.testing.expectEqual(@as(usize, 2), taken.events.len);
+    try expectEvent(taken.events[0], .button_pressed, 0, 100, 40);
+    try expectEvent(taken.events[1], .button_released, 0, 180, 90);
 }
 
 test "every event is forwarded to raylib's callback unchanged" {
@@ -566,26 +942,42 @@ test "every event is forwarded to raylib's callback unchanged" {
 /// `down` is the level at the interval's end and `source` names the edge
 /// accumulator to consume; the other accumulator is discarded, so a scripted
 /// keyboard never leaks a hardware edge and a script's tap cannot surface after
-/// the app hands the keyboard back.
+/// the app hands the keyboard back. A transition the level shows but no edge
+/// recorded -- a scripted held set changing between cycles, or a hardware
+/// callback that was somehow missed -- is logged here, so the list stays the
+/// authoritative record of everything the bits say.
 pub fn deriveKeyboardState(source: InputSource, down: *const [ffi.KEY_COUNT]bool) void {
-    const consumed, const discarded = switch (source) {
-        .hardware => .{ &hardware_key_edges, &virtual_key_edges },
-        .virtual => .{ &virtual_key_edges, &hardware_key_edges },
+    const consumed, const discarded, const log = switch (source) {
+        .hardware => .{ &hardware_key_edges, &virtual_key_edges, &hardware_events },
+        .virtual => .{ &virtual_key_edges, &hardware_key_edges, &virtual_events },
     };
     discarded.clear();
     for (0..ffi.KEY_COUNT) |i| {
-        key_state[i] = nextInputState(key_state[i], down[i], consumed.take(i));
+        const edges = consumed.take(i);
+        const next = nextInputState(key_state[i], down[i], edges);
+        if (next & ffi.INPUT_PRESSED != 0 and edges & ffi.INPUT_PRESSED == 0) log.append(.keyboard, keyRecord(i, .press));
+        if (next & ffi.INPUT_RELEASED != 0 and edges & ffi.INPUT_RELEASED == 0) log.append(.keyboard, keyRecord(i, .release));
+        key_state[i] = next;
     }
 }
 
 /// Derive the packed mouse button state for one interval, as
 /// `deriveKeyboardState` does. Only hardware records button edges; a virtual
 /// pointer states levels, so `virtual` consumes nothing and discards the
-/// hardware edges.
-pub fn deriveMouseButtonState(source: InputSource, down: *const [ffi.MOUSE_BUTTON_COUNT]bool) void {
+/// hardware edges, and its transitions are logged with the pointer's scripted
+/// position.
+pub fn deriveMouseButtonState(source: InputSource, down: *const [ffi.MOUSE_BUTTON_COUNT]bool, position: Vec2) void {
+    const log = switch (source) {
+        .hardware => &hardware_events,
+        .virtual => &virtual_events,
+    };
     for (0..ffi.MOUSE_BUTTON_COUNT) |i| {
-        const edges = hardware_mouse_button_edges.take(i);
-        mouse_button_state[i] = nextInputState(mouse_button_state[i], down[i], if (source == .hardware) edges else 0);
+        const recorded = hardware_mouse_button_edges.take(i);
+        const edges = if (source == .hardware) recorded else 0;
+        const next = nextInputState(mouse_button_state[i], down[i], edges);
+        if (next & ffi.INPUT_PRESSED != 0 and edges & ffi.INPUT_PRESSED == 0) log.append(.mouse, buttonRecord(i, .press, position));
+        if (next & ffi.INPUT_RELEASED != 0 and edges & ffi.INPUT_RELEASED == 0) log.append(.mouse, buttonRecord(i, .release, position));
+        mouse_button_state[i] = next;
     }
 }
 
@@ -629,7 +1021,7 @@ pub fn getKeyState() *const [ffi.KEY_COUNT]u8 {
 pub fn updateMouseButtonState() void {
     var down: [ffi.MOUSE_BUTTON_COUNT]bool = undefined;
     for (0..ffi.MOUSE_BUTTON_COUNT) |i| down[i] = rl.IsMouseButtonDown(@intCast(i));
-    deriveMouseButtonState(.hardware, &down);
+    deriveMouseButtonState(.hardware, &down, raylibMousePosition());
 }
 
 /// Get the current packed mouse button state array.
@@ -643,18 +1035,20 @@ pub fn clearMouseButtonState() void {
     hardware_mouse_button_edges.clear();
 }
 
-/// Advance the packed mouse button state from caller-supplied down flags.
+/// Advance the packed mouse button state from caller-supplied down flags and
+/// the scripted pointer's position.
 ///
 /// Used by the virtual mouse in place of `updateMouseButtonState`. It runs the
 /// same derivation, so a scripted pointer produces real pressed-this-interval
 /// and released-this-interval bits and an app's ordinary click handling
 /// reacts to it exactly as it would to hardware.
-pub fn updateMouseButtonStateFrom(down: *const [ffi.MOUSE_BUTTON_COUNT]bool) void {
-    deriveMouseButtonState(.virtual, down);
+pub fn updateMouseButtonStateFrom(down: *const [ffi.MOUSE_BUTTON_COUNT]bool, position: Vec2) void {
+    deriveMouseButtonState(.virtual, down, position);
 }
 
 test "a tap between two polls is pressed and released, never held" {
     defer clearKeyState();
+    defer clearInputEvents();
     const key_e = 69;
     const up: [ffi.KEY_COUNT]bool = @splat(false);
 
@@ -675,29 +1069,33 @@ test "a tap between two polls is pressed and released, never held" {
 
 test "a release and re-press between two polls is not one long hold" {
     defer clearMouseButtonState();
+    defer clearInputEvents();
     const left = 0;
+    const at = Vec2{ .x = 5, .y = 6 };
     var down: [ffi.MOUSE_BUTTON_COUNT]bool = @splat(false);
 
     down[left] = true;
-    recordHardwareMouseButtonEdge(left, .press);
-    deriveMouseButtonState(.hardware, &down);
+    recordHardwareMouseButtonEdge(left, .press, at);
+    deriveMouseButtonState(.hardware, &down, at);
     try std.testing.expectEqual(ffi.INPUT_HELD | ffi.INPUT_PRESSED, getMouseButtonState()[left]);
 
     // RELEASE then PRESS inside the interval; the level is down at both polls.
-    recordHardwareMouseButtonEdge(left, .release);
-    recordHardwareMouseButtonEdge(left, .press);
-    deriveMouseButtonState(.hardware, &down);
+    recordHardwareMouseButtonEdge(left, .release, at);
+    recordHardwareMouseButtonEdge(left, .press, at);
+    deriveMouseButtonState(.hardware, &down, at);
     try std.testing.expectEqual(ffi.INPUT_HELD | ffi.INPUT_RELEASED | ffi.INPUT_PRESSED, getMouseButtonState()[left]);
 
-    deriveMouseButtonState(.hardware, &down);
+    deriveMouseButtonState(.hardware, &down, at);
     try std.testing.expectEqual(ffi.INPUT_HELD, getMouseButtonState()[left]);
 }
 
 test "each source consumes its own edges and discards the other's" {
     defer clearKeyState();
     defer clearMouseButtonState();
+    defer clearInputEvents();
     const key_a = 65;
     const up: [ffi.KEY_COUNT]bool = @splat(false);
+    const origin = Vec2{ .x = 0, .y = 0 };
 
     // A hardware tap while a script owns the keyboard is not the script's.
     recordHardwareKeyEdge(key_a, .press);
@@ -725,11 +1123,45 @@ test "each source consumes its own edges and discards the other's" {
 
     // A virtual pointer states levels only; hardware button edges are dropped.
     const buttons_up: [ffi.MOUSE_BUTTON_COUNT]bool = @splat(false);
-    recordHardwareMouseButtonEdge(0, .press);
-    deriveMouseButtonState(.virtual, &buttons_up);
+    recordHardwareMouseButtonEdge(0, .press, origin);
+    deriveMouseButtonState(.virtual, &buttons_up, origin);
     try std.testing.expectEqual(@as(u8, 0), getMouseButtonState()[0]);
-    deriveMouseButtonState(.hardware, &buttons_up);
+    deriveMouseButtonState(.hardware, &buttons_up, origin);
     try std.testing.expectEqual(@as(u8, 0), getMouseButtonState()[0]);
+}
+
+test "a level transition with no recorded edge is logged so the list stays complete" {
+    defer clearKeyState();
+    defer clearMouseButtonState();
+    defer clearInputEvents();
+    var down: [ffi.KEY_COUNT]bool = @splat(false);
+    var buttons: [ffi.MOUSE_BUTTON_COUNT]bool = @splat(false);
+
+    // A scripted held set: S goes down on one cycle and up on the next, and
+    // the pointer's button with it, at the scripted position.
+    down['S'] = true;
+    buttons[0] = true;
+    deriveKeyboardState(.virtual, &down);
+    deriveMouseButtonState(.virtual, &buttons, .{ .x = 7, .y = 8 });
+    down['S'] = false;
+    buttons[0] = false;
+    deriveKeyboardState(.virtual, &down);
+    deriveMouseButtonState(.virtual, &buttons, .{ .x = 9, .y = 10 });
+
+    const taken = takeInputEvents(all_virtual);
+    try std.testing.expectEqual(@as(usize, 4), taken.events.len);
+    try expectEvent(taken.events[0], .key_pressed, 'S', 0, 0);
+    try expectEvent(taken.events[1], .button_pressed, 0, 7, 8);
+    try expectEvent(taken.events[2], .key_released, 'S', 0, 0);
+    try expectEvent(taken.events[3], .button_released, 0, 9, 10);
+
+    // A recorded edge and the level agreeing is one event, not two.
+    recordHardwareKeyEdge('S', .press);
+    down['S'] = true;
+    deriveKeyboardState(.hardware, &down);
+    const once = takeInputEvents(all_hardware);
+    try std.testing.expectEqual(@as(usize, 1), once.events.len);
+    try expectEvent(once.events[0], .key_pressed, 'S', 0, 0);
 }
 
 /// Sample all supported gamepads once for this frame.
@@ -849,6 +1281,11 @@ test "wheel notches inside one interval are summed, then consumed" {
     const next = takeRecordedWheel();
     try std.testing.expectEqual(@as(f32, 0), next.x);
     try std.testing.expectEqual(@as(f32, 0), next.y);
+
+    // Each notch is its own event in the log.
+    const taken = takeInputEvents(all_hardware);
+    try std.testing.expectEqual(@as(usize, 3), taken.events.len);
+    try expectEvent(taken.events[2], .wheel, 0, -0.5, -0.25);
 }
 
 /// One interval's typed text, and whether any of it was discarded.
@@ -880,12 +1317,14 @@ fn takeRecordedText() TextInput {
 /// drops the rest without saying so. A full queue cannot be told apart from an
 /// overflowed one, so it is reported as an overflow: the honest answer is
 /// "possibly", and the flag's contract is that a clear flag means nothing was
-/// lost.
+/// lost. The codepoints are logged as they are drained so the event list sees
+/// them on this path too.
 fn drainRaylibTextQueue() TextInput {
     var count: usize = 0;
     while (true) {
         const codepoint = rl.GetCharPressed();
         if (codepoint <= 0) break;
+        hardware_events.append(.text, textRecord(@intCast(codepoint)));
         if (count < text_input.len) {
             text_input[count] = @intCast(codepoint);
             count += 1;
@@ -923,6 +1362,12 @@ test "typed text past the interval's capacity is reported, not silently cut" {
 
     // The flag travels with the interval that overflowed, not the next one.
     try std.testing.expect(!takeRecordedText().overflowed);
+
+    // The log kept every character, including the one past the text cap.
+    const taken = takeInputEvents(all_hardware);
+    try std.testing.expectEqual(2 + TEXT_INPUT_CAPACITY + TEXT_INPUT_CAPACITY + 1, taken.events.len);
+    try expectEvent(taken.events[0], .text, 'h', 0, 0);
+    try expectEvent(taken.events[taken.events.len - 1], .text, 'x', 0, 0);
 }
 
 /// Return raylib's built-in font, which is not owned by a resource heap.

--- a/src/host_native.zig
+++ b/src/host_native.zig
@@ -70,6 +70,8 @@ const CaptureFromHost = abi.Update_for_hostArg1Capture;
 /// One file dropped onto the window, crossing as the public `App.Dropped`.
 const DroppedFile = abi.Update_for_hostArg1Dropped;
 const DroppedPosition = abi.Update_for_hostArg1DroppedPosition;
+/// One input event in the flat shape the types package decodes.
+const InputEventRecord = abi.Update_for_hostArg1DevicesEvents;
 const TilemapRawMap = abi.TilemapHostLoad_tmxMap;
 const TilemapRawLayer = abi.TilemapHostLoad_tmxMapLayers;
 const TilemapRawObject = abi.TilemapHostLoad_tmxMapObjects;
@@ -6370,6 +6372,8 @@ fn hostedCaptureSetVirtualMouse(args: abi.CaptureHostSet_virtual_mouseArgs) call
     virtual_mouse_x = args.x;
     virtual_mouse_y = args.y;
     virtual_mouse_wheel = args.wheel;
+    // The sum is the field above; the event list gets the notch as well.
+    if (args.wheel != 0) raylib.recordVirtualWheel(0, args.wheel);
     // Indices follow raylib's mouse button codes, which `Mouse` also uses.
     virtual_mouse_buttons[0] = args.left;
     virtual_mouse_buttons[1] = args.right;
@@ -6415,6 +6419,9 @@ fn applyVirtualText(codepoints: []const u32) void {
     @memcpy(virtual_text[0..kept], codepoints[0..kept]);
     virtual_text_len = kept;
     virtual_text_overflowed = codepoints.len > kept;
+    // Every codepoint goes to the event list in script order, the one past
+    // the text cap included: the list has its own, larger bound.
+    for (codepoints) |codepoint| raylib.recordVirtualText(codepoint);
 }
 
 /// Take the queued scripted text, or null when the frame's text is hardware's.
@@ -6445,6 +6452,7 @@ fn resetVirtualInput() void {
     virtual_text_overflowed = false;
     raylib.clearKeyState();
     raylib.clearMouseButtonState();
+    raylib.clearInputEvents();
 }
 
 fn hostedCaptureSetVirtualKeys(host: *RocHost, args: abi.CaptureHostSet_virtual_keysArgs) callconv(.c) void {
@@ -7365,15 +7373,20 @@ const RuntimeOptions = struct {
 };
 
 const InputState = struct {
+    roc_host: *RocHost,
     keys: ffi.Keys,
     mouse_buttons: ffi.MouseButtons,
     gamepad_available: ffi.GamepadAvailability,
     gamepad_buttons: ffi.GamepadButtons,
     gamepad_axes: ffi.GamepadAxes,
     text_input: ffi.TextInput,
+    /// This cycle's ordered events, taken once alongside the packed bits and
+    /// borrowed from the backend's scratch until `hostState` copies them out.
+    events: raylib.InputEvents = .{ .events = &.{}, .overflowed = false },
 
     fn init(roc_host: *RocHost) InputState {
         return .{
+            .roc_host = roc_host,
             .keys = ffi.Keys.init(roc_host),
             .mouse_buttons = ffi.MouseButtons.init(roc_host),
             .gamepad_available = ffi.GamepadAvailability.init(roc_host),
@@ -7411,10 +7424,16 @@ const InputState = struct {
     ) InputSnapshot {
         self.text_input.update(text_input.codepoints);
         self.retainForRoc();
+        // Fresh each cycle and transferred whole, like the dropped files:
+        // Roc releases it with the input.
+        const events = inputEventsSnapshot(self.roc_host, self.events);
+        self.events = .{ .events = &.{}, .overflowed = false };
         return .{
             .keys = self.keys.list,
             .text_input = self.text_input.list,
             .text_input_overflow = text_input.overflowed,
+            .events = events.list,
+            .events_overflow = events.overflowed,
             .gamepads = .{
                 .available = self.gamepad_available.list,
                 .buttons = self.gamepad_buttons.list,
@@ -7436,7 +7455,9 @@ const InputState = struct {
         };
     }
 
-    fn updateFromRaylib(self: *InputState) void {
+    /// Sample input for a windowed cycle. `text_source` says whether this
+    /// cycle's text is scripted, which decides whose text events are taken.
+    fn updateFromRaylib(self: *InputState, text_source: raylib.InputSource) void {
         // A scripted keyboard goes through the same derivation as hardware,
         // so pressed/released this interval behave identically for the app.
         if (virtual_keys_active) {
@@ -7449,7 +7470,7 @@ const InputState = struct {
         // A scripted pointer goes through the same derivation as hardware,
         // so pressed/released this interval behave identically for the app.
         if (virtual_mouse_active) {
-            raylib.updateMouseButtonStateFrom(&virtual_mouse_buttons);
+            raylib.updateMouseButtonStateFrom(&virtual_mouse_buttons, .{ .x = virtual_mouse_x, .y = virtual_mouse_y });
         } else {
             raylib.updateMouseButtonState();
         }
@@ -7459,6 +7480,14 @@ const InputState = struct {
         self.gamepad_available.update(raylib.getGamepadAvailability());
         self.gamepad_buttons.update(raylib.getGamepadButtonState());
         self.gamepad_axes.update(raylib.getGamepadAxes());
+
+        // After both derivations, so a transition they logged is in this
+        // cycle's list next to the bit it set.
+        self.events = raylib.takeInputEvents(.{
+            .keyboard = if (virtual_keys_active) .virtual else .hardware,
+            .mouse = if (virtual_mouse_active) .virtual else .hardware,
+            .text = text_source,
+        });
     }
 
     /// Sample input for a headless cycle, where there is no hardware to ask.
@@ -7468,13 +7497,113 @@ const InputState = struct {
     /// released bits real devices would have produced. With nothing scripted
     /// both arrays are all false, which is what no keyboard and no mouse look
     /// like -- so an app that scripts neither sees what it always saw.
-    fn updateHeadless(self: *InputState) void {
+    fn updateHeadless(self: *InputState, text_source: raylib.InputSource) void {
         raylib.updateKeyboardStateFrom(&virtual_key_down);
         self.keys.update(raylib.getKeyState());
-        raylib.updateMouseButtonStateFrom(&virtual_mouse_buttons);
+        raylib.updateMouseButtonStateFrom(&virtual_mouse_buttons, .{ .x = virtual_mouse_x, .y = virtual_mouse_y });
         self.mouse_buttons.update(raylib.getMouseButtonState());
+        self.events = raylib.takeInputEvents(.{ .keyboard = .virtual, .mouse = .virtual, .text = text_source });
     }
 };
+
+/// One cycle's ordered input events on their way to `update!`.
+///
+/// `list` is owned; handing it to Roc transfers it, exactly as a cycle's
+/// dropped files are transferred.
+const InputEventsList = struct {
+    list: abi.RocListWith(InputEventRecord, false),
+    overflowed: bool,
+};
+
+/// Copy this cycle's events into a Roc list, in delivery order.
+///
+/// The backend's scratch is overwritten by the next recorded event, so the
+/// records are copied out here rather than borrowed. The count is already
+/// bounded by `raylib.INPUT_EVENT_CAPACITY`; `overflowed` is the backend's
+/// word that something past it was discarded, carried through unchanged so
+/// an app that got a full list can tell whether it was the whole interval.
+fn inputEventsSnapshot(roc_host: *RocHost, events: raylib.InputEvents) InputEventsList {
+    if (events.events.len == 0) return .{ .list = abi.RocListWith(InputEventRecord, false).empty(), .overflowed = events.overflowed };
+
+    var buffer: [raylib.INPUT_EVENT_CAPACITY]InputEventRecord = undefined;
+    for (events.events, buffer[0..events.events.len]) |record, *slot| {
+        slot.* = .{ .kind = record.kind, .code = record.code, .x = record.x, .y = record.y };
+    }
+    return .{
+        .list = abi.RocListWith(InputEventRecord, false).fromSlice(buffer[0..events.events.len], roc_host),
+        .overflowed = events.overflowed,
+    };
+}
+
+test "a quiet cycle delivers no events and reports no overflow" {
+    var roc_env = abi.RocEnv{ .allocator = std.testing.allocator, .roc_io = abi.RocIo.freestanding() };
+    var roc_host = abi.makeRocHost(&roc_env);
+
+    const sampled = inputEventsSnapshot(&roc_host, .{ .events = &.{}, .overflowed = false });
+    defer sampled.list.deinit(&roc_host);
+    try std.testing.expectEqual(@as(usize, 0), sampled.list.len());
+    try std.testing.expect(!sampled.overflowed);
+}
+
+test "events are copied out in order and the list is released with the input" {
+    var roc_env = abi.RocEnv{ .allocator = std.testing.allocator, .roc_io = abi.RocIo.freestanding() };
+    var roc_host = abi.makeRocHost(&roc_env);
+
+    const records = [_]raylib.InputEventRecord{
+        .{ .kind = 0, .code = 65, .x = 0, .y = 0 },
+        .{ .kind = 2, .code = 0, .x = 12.5, .y = 34 },
+        .{ .kind = 5, .code = 0x20ac, .x = 0, .y = 0 },
+    };
+    const sampled = inputEventsSnapshot(&roc_host, .{ .events = &records, .overflowed = false });
+    try std.testing.expectEqual(@as(usize, 3), sampled.list.len());
+    const items = sampled.list.items();
+    try std.testing.expectEqual(@as(u8, 0), items[0].kind);
+    try std.testing.expectEqual(@as(u32, 65), items[0].code);
+    try std.testing.expectEqual(@as(f32, 12.5), items[1].x);
+    try std.testing.expectEqual(@as(f32, 34), items[1].y);
+    try std.testing.expectEqual(@as(u32, 0x20ac), items[2].code);
+    // The testing allocator is what checks the release: an unbalanced
+    // refcount is a leak or a double free here, not a no-op.
+    sampled.list.deinit(&roc_host);
+
+    // Overflow travels with the interval that overflowed.
+    const full = inputEventsSnapshot(&roc_host, .{ .events = &records, .overflowed = true });
+    defer full.list.deinit(&roc_host);
+    try std.testing.expect(full.overflowed);
+    try std.testing.expectEqual(@as(usize, 3), full.list.len());
+}
+
+test "a scripted cycle's events reach the snapshot list in delivery order" {
+    var roc_env = abi.RocEnv{ .allocator = std.testing.allocator, .roc_io = abi.RocIo.freestanding() };
+    var roc_host = abi.makeRocHost(&roc_env);
+    var input = InputState.init(&roc_host);
+    defer input.deinit();
+    defer resetVirtualInput();
+
+    // Tap Escape, then type "hi", then hold S from this cycle: the script
+    // order is the delivery order.
+    const options = RuntimeOptions{ .key_script = "3:ESCAPE^+S", .text_script = "3:hi" };
+    applyInputScripts(options, 3);
+    const scripted_text = takeVirtualText().?;
+    input.updateHeadless(.virtual);
+    const snapshot = input.hostState(0, 0, .{ .x = 0, .y = 0 }, .{ .x = 0, .y = 0 }, scripted_text);
+    defer snapshot.decref(&roc_host);
+
+    try std.testing.expect(!snapshot.events_overflow);
+    try std.testing.expectEqual(@as(usize, 5), snapshot.events.len());
+    const items = snapshot.events.items();
+    try std.testing.expectEqual(@as(u8, 0), items[0].kind); // KeyPressed(Escape)
+    try std.testing.expectEqual(@as(u32, 256), items[0].code);
+    try std.testing.expectEqual(@as(u8, 1), items[1].kind); // KeyReleased(Escape)
+    try std.testing.expectEqual(@as(u8, 5), items[2].kind); // Text('h')
+    try std.testing.expectEqual(@as(u32, 'h'), items[2].code);
+    try std.testing.expectEqual(@as(u32, 'i'), items[3].code);
+    try std.testing.expectEqual(@as(u8, 0), items[4].kind); // KeyPressed(S): the held set changed
+    try std.testing.expectEqual(@as(u32, 'S'), items[4].code);
+    // And the bits agree with the list.
+    try std.testing.expectEqual(ffi.INPUT_PRESSED | ffi.INPUT_RELEASED, input.keys.list.items()[256]);
+    try std.testing.expectEqual(ffi.INPUT_HELD | ffi.INPUT_PRESSED, input.keys.list.items()['S']);
+}
 
 /// One cycle's file drops on their way to `update!`.
 ///
@@ -10165,7 +10294,14 @@ fn runNormalApp(roc_host: *RocHost, allocator: std.mem.Allocator, app_config: Ap
         updateMusicStreams();
 
         applyInputScripts(options, cycle_count);
-        input.updateFromRaylib();
+        // Text is taken first, and either way: a scripted frame that left the
+        // hardware characters behind would deliver them on the next one, and
+        // which source the text came from decides whose text events the cycle
+        // takes below.
+        const typed_text = raylib.takeTextInput();
+        const scripted_text = takeVirtualText();
+        const text_input = scripted_text orelse typed_text;
+        input.updateFromRaylib(if (scripted_text != null) .virtual else .hardware);
         const mouse_pos = if (virtual_mouse_active)
             raylib.Vec2{ .x = virtual_mouse_x, .y = virtual_mouse_y }
         else
@@ -10185,11 +10321,6 @@ fn runNormalApp(roc_host: *RocHost, allocator: std.mem.Allocator, app_config: Ap
             // again on every subsequent frame.
             virtual_mouse_wheel = 0;
         }
-        // Taken either way, for the same reason as the wheel: a scripted frame
-        // that left the hardware characters behind would deliver them on the
-        // next one.
-        const typed_text = raylib.takeTextInput();
-        const text_input = takeVirtualText() orelse typed_text;
         const input_snapshot = input.hostState(
             mouse_pos.x,
             mouse_pos.y,
@@ -10321,8 +10452,9 @@ fn runHeadlessApp(roc_host: *RocHost, app_config: AppConfig, frames: u64) c_int 
         std.debug.assert(callbacks.updates == 1);
         const frame_time: f32 = if (cycle_count == 0) 0 else HEADLESS_FRAME_TIME;
         const timestamp_nanos = cycle_count * HEADLESS_FRAME_NANOS;
-        input.updateHeadless();
-        const text_input = takeVirtualText() orelse raylib.TextInput{ .codepoints = &.{}, .overflowed = false };
+        const scripted_text = takeVirtualText();
+        const text_input = scripted_text orelse raylib.TextInput{ .codepoints = &.{}, .overflowed = false };
+        input.updateHeadless(if (scripted_text != null) .virtual else .hardware);
         // A headless run has no pointer, so a scripted one is the only pointer
         // there is. Everything a windowed run derives from it -- position,
         // delta, the wheel's single frame of movement -- is derived here the

--- a/src/host_native.zig
+++ b/src/host_native.zig
@@ -1904,18 +1904,23 @@ var virtual_mouse_last_y: f32 = 0;
 var virtual_mouse_has_last: bool = false;
 /// Scripted keyboard state, replacing the hardware keyboard while active.
 ///
-/// Held flags only: the same edge detector that runs over hardware runs over
-/// this array, so pressed and released fall out of consecutive frames rather
-/// than being described here. Nothing about the real keyboard changes -- a key
-/// the user is holding is simply not what Roc is told about.
+/// Held flags: the same derivation that runs over hardware runs over this
+/// array, so pressed and released fall out of consecutive frames rather than
+/// being described here. A tap that starts and ends inside one cycle is the
+/// one thing a level cannot say, so a script records that as an edge instead
+/// (`raylib.recordVirtualKeyEdge`), exactly as the window system's callbacks
+/// do for hardware. Nothing about the real keyboard changes -- a key the user
+/// is holding is simply not what Roc is told about.
 var virtual_keys_active: bool = false;
 var virtual_key_down: [ffi.KEY_COUNT]bool = @splat(false);
 /// Scripted text queued for the next input, in the order it was entered.
 ///
-/// The same bound as the hardware channel, and lossy the same way: a longer
-/// script loses its tail rather than spilling into the following frame.
+/// The same bound as the hardware channel, and it overflows the same way: a
+/// longer script loses its tail rather than spilling into the following
+/// frame, and the input says so.
 var virtual_text: [raylib.TEXT_INPUT_CAPACITY]u32 = @splat(0);
 var virtual_text_len: usize = 0;
+var virtual_text_overflowed: bool = false;
 /// Nanoseconds of divergence introduced by fixed-step recordings.
 ///
 /// Fixed-step recording reports exact `1/fps` deltas instead of raylib's
@@ -6401,11 +6406,15 @@ fn applyVirtualKeys(active: bool, codes: []const u64) void {
     }
 }
 
-/// Queue scripted codepoints as the next input's text, discarding the excess.
+/// Queue scripted codepoints as the next input's text.
+///
+/// The excess past the interval's capacity is discarded and reported as an
+/// overflow, exactly as the hardware channel reports its own.
 fn applyVirtualText(codepoints: []const u32) void {
     const kept = @min(codepoints.len, virtual_text.len);
     @memcpy(virtual_text[0..kept], codepoints[0..kept]);
     virtual_text_len = kept;
+    virtual_text_overflowed = codepoints.len > kept;
 }
 
 /// Take the queued scripted text, or null when the frame's text is hardware's.
@@ -6413,11 +6422,13 @@ fn applyVirtualText(codepoints: []const u32) void {
 /// Taking rather than reading: text arrives on one frame and not the next, so
 /// a script that queued nothing this frame hands the channel back rather than
 /// repeating what it said last time.
-fn takeVirtualText() ?[]const u32 {
+fn takeVirtualText() ?raylib.TextInput {
     if (virtual_text_len == 0) return null;
     const queued = virtual_text[0..virtual_text_len];
+    const overflowed = virtual_text_overflowed;
     virtual_text_len = 0;
-    return queued;
+    virtual_text_overflowed = false;
+    return .{ .codepoints = queued, .overflowed = overflowed };
 }
 
 /// Forget every scripted input, so one app lifetime cannot inherit another's.
@@ -6431,6 +6442,7 @@ fn resetVirtualInput() void {
     virtual_keys_active = false;
     virtual_key_down = @splat(false);
     virtual_text_len = 0;
+    virtual_text_overflowed = false;
     raylib.clearKeyState();
     raylib.clearMouseButtonState();
 }
@@ -7395,13 +7407,14 @@ const InputState = struct {
         mouse_y: f32,
         mouse_delta: raylib.Vec2,
         mouse_wheel: raylib.Vec2,
-        text_input: []const u32,
+        text_input: raylib.TextInput,
     ) InputSnapshot {
-        self.text_input.update(text_input);
+        self.text_input.update(text_input.codepoints);
         self.retainForRoc();
         return .{
             .keys = self.keys.list,
             .text_input = self.text_input.list,
+            .text_input_overflow = text_input.overflowed,
             .gamepads = .{
                 .available = self.gamepad_available.list,
                 .buttons = self.gamepad_buttons.list,
@@ -7424,9 +7437,8 @@ const InputState = struct {
     }
 
     fn updateFromRaylib(self: *InputState) void {
-        // A scripted keyboard goes through the same edge detection as
-        // hardware, so pressed/released this frame behave identically for the
-        // app.
+        // A scripted keyboard goes through the same derivation as hardware,
+        // so pressed/released this interval behave identically for the app.
         if (virtual_keys_active) {
             raylib.updateKeyboardStateFrom(&virtual_key_down);
         } else {
@@ -7434,8 +7446,8 @@ const InputState = struct {
         }
         self.keys.update(raylib.getKeyState());
 
-        // A scripted pointer goes through the same edge detection as hardware,
-        // so pressed/released this frame behave identically for the app.
+        // A scripted pointer goes through the same derivation as hardware,
+        // so pressed/released this interval behave identically for the app.
         if (virtual_mouse_active) {
             raylib.updateMouseButtonStateFrom(&virtual_mouse_buttons);
         } else {
@@ -7593,7 +7605,9 @@ fn printUsage() void {
         \\
         \\  --host-frames=N   exit after N cycles of a real windowed run
         \\  --host-hidden     open the real window hidden (needs a display server)
-        \\  --host-keys=SCRIPT  hold keys on given cycles, e.g. "3:S,4:LEFT+X,10:32"
+        \\  --host-keys=SCRIPT  hold keys on given cycles, e.g. "3:S,4:LEFT+X,10:32";
+        \\                      a ^ suffix taps the key inside that cycle instead
+        \\                      of holding it, e.g. "3:ESCAPE^"
         \\  --host-text=SCRIPT  deliver typed text on given cycles, e.g. "2:ab,3:c"
         \\
     , .{});
@@ -7653,18 +7667,46 @@ fn scriptSegment(spec: []const u8, cycle: u64) ScriptError!?[]const u8 {
     return found;
 }
 
-/// The key codes a `--host-keys` script holds on `cycle`, or null when it
+/// What a `--host-keys` script does on one cycle.
+///
+/// `held` keys are down for the whole cycle: pressed on the first cycle that
+/// names them, released on the first that does not. `taps` are pressed and
+/// released inside the cycle, so the input sees both edges and no hold -- the
+/// hardware case of a key that went down and up between two polls, which is
+/// what a level-per-cycle script could never express.
+const ScriptedKeys = struct {
+    held: []const u64,
+    taps: []const u64,
+};
+
+/// Scratch for one cycle of a key script.
+const ScriptedKeyBuffers = struct {
+    held: [KEY_SCRIPT_CAPACITY]u64 = undefined,
+    taps: [KEY_SCRIPT_CAPACITY]u64 = undefined,
+};
+
+/// The suffix that turns a held key into a tap: `S^`.
+const TAP_SUFFIX = '^';
+
+/// The keys a `--host-keys` script holds and taps on `cycle`, or null when it
 /// scripts nothing there.
-fn scriptedKeysAtCycle(spec: []const u8, cycle: u64, out: *[KEY_SCRIPT_CAPACITY]u64) ScriptError!?[]const u64 {
+fn scriptedKeysAtCycle(spec: []const u8, cycle: u64, out: *ScriptedKeyBuffers) ScriptError!?ScriptedKeys {
     const payload = (try scriptSegment(spec, cycle)) orelse return null;
     var tokens = std.mem.splitScalar(u8, payload, '+');
-    var count: usize = 0;
+    var held: usize = 0;
+    var taps: usize = 0;
     while (tokens.next()) |token| {
-        if (count == out.len) return error.InvalidScript;
-        out[count] = try parseScriptedKey(token);
-        count += 1;
+        if (token.len > 1 and token[token.len - 1] == TAP_SUFFIX) {
+            if (taps == out.taps.len) return error.InvalidScript;
+            out.taps[taps] = try parseScriptedKey(token[0 .. token.len - 1]);
+            taps += 1;
+        } else {
+            if (held == out.held.len) return error.InvalidScript;
+            out.held[held] = try parseScriptedKey(token);
+            held += 1;
+        }
     }
-    return out[0..count];
+    return .{ .held = out.held[0..held], .taps = out.taps[0..taps] };
 }
 
 /// Validate a whole script without running it, so a typo fails at startup
@@ -7677,7 +7719,7 @@ fn validateScript(spec: []const u8, keys: bool) ScriptError!void {
         const at = std.fmt.parseUnsigned(u64, segment[0..colon], 10) catch return error.InvalidScript;
         if (segment[colon + 1 ..].len == 0) return error.InvalidScript;
         if (keys) {
-            var scratch: [KEY_SCRIPT_CAPACITY]u64 = undefined;
+            var scratch = ScriptedKeyBuffers{};
             _ = try scriptedKeysAtCycle(spec, at, &scratch);
         }
     }
@@ -7686,12 +7728,21 @@ fn validateScript(spec: []const u8, keys: bool) ScriptError!void {
 /// Apply this cycle's scripted keyboard and typed text, if any are scripted.
 ///
 /// Called immediately before the cycle samples input, so a scripted key goes
-/// through exactly the same edge detection as a hardware one.
+/// through exactly the same derivation as a hardware one: held keys as the
+/// level, taps as edges recorded inside the interval.
 fn applyInputScripts(options: RuntimeOptions, cycle: u64) void {
     if (options.key_script) |spec| {
-        var codes: [KEY_SCRIPT_CAPACITY]u64 = undefined;
-        const held = scriptedKeysAtCycle(spec, cycle, &codes) catch null;
-        if (held) |keys| applyVirtualKeys(true, keys) else applyVirtualKeys(false, &.{});
+        var buffers = ScriptedKeyBuffers{};
+        const scripted = scriptedKeysAtCycle(spec, cycle, &buffers) catch null;
+        if (scripted) |keys| {
+            applyVirtualKeys(true, keys.held);
+            for (keys.taps) |code| {
+                raylib.recordVirtualKeyEdge(code, .press);
+                raylib.recordVirtualKeyEdge(code, .release);
+            }
+        } else {
+            applyVirtualKeys(false, &.{});
+        }
     }
     if (options.text_script) |spec| {
         const typed = scriptSegment(spec, cycle) catch null;
@@ -7705,24 +7756,80 @@ fn applyInputScripts(options: RuntimeOptions, cycle: u64) void {
 }
 
 test "a key script holds only the cycles it names" {
-    var codes: [KEY_SCRIPT_CAPACITY]u64 = undefined;
+    var buffers = ScriptedKeyBuffers{};
     const spec = "3:S,4:LEFT+x,10:32";
 
-    try std.testing.expectEqual(@as(?[]const u64, null), try scriptedKeysAtCycle(spec, 0, &codes));
-    try std.testing.expectEqualSlices(u64, &.{'S'}, (try scriptedKeysAtCycle(spec, 3, &codes)).?);
-    try std.testing.expectEqualSlices(u64, &.{ 263, 'X' }, (try scriptedKeysAtCycle(spec, 4, &codes)).?);
-    try std.testing.expectEqualSlices(u64, &.{32}, (try scriptedKeysAtCycle(spec, 10, &codes)).?);
-    try std.testing.expectEqual(@as(?[]const u64, null), try scriptedKeysAtCycle(spec, 5, &codes));
+    try std.testing.expect((try scriptedKeysAtCycle(spec, 0, &buffers)) == null);
+    try std.testing.expectEqualSlices(u64, &.{'S'}, (try scriptedKeysAtCycle(spec, 3, &buffers)).?.held);
+    try std.testing.expectEqualSlices(u64, &.{ 263, 'X' }, (try scriptedKeysAtCycle(spec, 4, &buffers)).?.held);
+    try std.testing.expectEqualSlices(u64, &.{32}, (try scriptedKeysAtCycle(spec, 10, &buffers)).?.held);
+    try std.testing.expect((try scriptedKeysAtCycle(spec, 5, &buffers)) == null);
+    for (0..11) |cycle| {
+        if (try scriptedKeysAtCycle(spec, cycle, &buffers)) |keys| {
+            try std.testing.expectEqual(@as(usize, 0), keys.taps.len);
+        }
+    }
+}
+
+test "a ^ suffix scripts a tap rather than a hold" {
+    var buffers = ScriptedKeyBuffers{};
+    const spec = "3:ESCAPE^,4:S^+a+SPACE^";
+
+    const escape = (try scriptedKeysAtCycle(spec, 3, &buffers)).?;
+    try std.testing.expectEqual(@as(usize, 0), escape.held.len);
+    try std.testing.expectEqualSlices(u64, &.{256}, escape.taps);
+
+    const mixed = (try scriptedKeysAtCycle(spec, 4, &buffers)).?;
+    try std.testing.expectEqualSlices(u64, &.{'A'}, mixed.held);
+    try std.testing.expectEqualSlices(u64, &.{ 'S', 32 }, mixed.taps);
+
+    // A bare ^ is the key that types it, not a tap of nothing.
+    const caret = (try scriptedKeysAtCycle("1:^", 1, &buffers)).?;
+    try std.testing.expectEqualSlices(u64, &.{'^'}, caret.held);
+    try std.testing.expectEqual(@as(usize, 0), caret.taps.len);
+    try validateScript(spec, true);
 }
 
 test "a malformed script is rejected rather than scripting nothing" {
-    var codes: [KEY_SCRIPT_CAPACITY]u64 = undefined;
-    try std.testing.expectError(error.InvalidScript, scriptedKeysAtCycle("3", 3, &codes));
-    try std.testing.expectError(error.InvalidScript, scriptedKeysAtCycle("3:", 3, &codes));
-    try std.testing.expectError(error.InvalidScript, scriptedKeysAtCycle("x:S", 3, &codes));
-    try std.testing.expectError(error.InvalidScript, scriptedKeysAtCycle("3:NOPE", 3, &codes));
+    var buffers = ScriptedKeyBuffers{};
+    try std.testing.expectError(error.InvalidScript, scriptedKeysAtCycle("3", 3, &buffers));
+    try std.testing.expectError(error.InvalidScript, scriptedKeysAtCycle("3:", 3, &buffers));
+    try std.testing.expectError(error.InvalidScript, scriptedKeysAtCycle("x:S", 3, &buffers));
+    try std.testing.expectError(error.InvalidScript, scriptedKeysAtCycle("3:NOPE", 3, &buffers));
+    try std.testing.expectError(error.InvalidScript, scriptedKeysAtCycle("3:NOPE^", 3, &buffers));
     try std.testing.expectError(error.InvalidScript, validateScript("3:S,", true));
     try validateScript("1:ab,2:c", false);
+}
+
+test "a scripted tap lands inside one cycle as a press and a release" {
+    defer resetVirtualInput();
+    const escape = 256;
+    const options = RuntimeOptions{ .key_script = "2:S,3:ESCAPE^,4:S" };
+
+    // Cycle 1 is not scripted: hardware, with nothing recorded.
+    applyInputScripts(options, 1);
+    try std.testing.expect(!virtual_keys_active);
+
+    // Cycle 2 holds S, which is a press on the level.
+    applyInputScripts(options, 2);
+    raylib.updateKeyboardStateFrom(&virtual_key_down);
+    try std.testing.expectEqual(ffi.INPUT_HELD | ffi.INPUT_PRESSED, raylib.getKeyState()['S']);
+
+    // Cycle 3 taps Escape: both edges, never held, and S is released by the
+    // level in the same cycle. That is what an app quitting on
+    // `key_pressed(KeyEscape)` sees when the key went down and up between two
+    // polls.
+    applyInputScripts(options, 3);
+    try std.testing.expect(virtual_keys_active);
+    raylib.updateKeyboardStateFrom(&virtual_key_down);
+    try std.testing.expectEqual(ffi.INPUT_PRESSED | ffi.INPUT_RELEASED, raylib.getKeyState()[escape]);
+    try std.testing.expectEqual(ffi.INPUT_RELEASED, raylib.getKeyState()['S']);
+
+    // The tap was consumed with its cycle.
+    applyInputScripts(options, 4);
+    raylib.updateKeyboardStateFrom(&virtual_key_down);
+    try std.testing.expectEqual(@as(u8, 0), raylib.getKeyState()[escape]);
+    try std.testing.expectEqual(ffi.INPUT_HELD | ffi.INPUT_PRESSED, raylib.getKeyState()['S']);
 }
 
 fn parseRuntimeOptions(allocator: std.mem.Allocator, argc: usize, argv: [*][*:0]u8) !RuntimeOptions {
@@ -8473,21 +8580,28 @@ test "a key code past the packed state list is dropped rather than written" {
     for (virtual_key_down) |down| try std.testing.expect(!down);
 }
 
-test "scripted text is delivered once and truncated at the frame's bound" {
+test "scripted text is delivered once and its overflow is reported" {
     defer resetVirtualInput();
 
     applyVirtualText(&.{ 'h', 'i' });
-    try std.testing.expectEqualSlices(u32, &.{ 'h', 'i' }, takeVirtualText().?);
+    const short = takeVirtualText().?;
+    try std.testing.expectEqualSlices(u32, &.{ 'h', 'i' }, short.codepoints);
+    try std.testing.expect(!short.overflowed);
     // Gone on the next frame: real characters arrive once, not every frame
     // until something else is typed.
-    try std.testing.expectEqual(@as(?[]const u32, null), takeVirtualText());
+    try std.testing.expect(takeVirtualText() == null);
 
     var long: [raylib.TEXT_INPUT_CAPACITY + 4]u32 = @splat('x');
     long[0] = 'a';
     applyVirtualText(&long);
     const delivered = takeVirtualText().?;
-    try std.testing.expectEqual(raylib.TEXT_INPUT_CAPACITY, delivered.len);
-    try std.testing.expectEqual(@as(u32, 'a'), delivered[0]);
+    try std.testing.expectEqual(raylib.TEXT_INPUT_CAPACITY, delivered.codepoints.len);
+    try std.testing.expectEqual(@as(u32, 'a'), delivered.codepoints[0]);
+    try std.testing.expect(delivered.overflowed);
+
+    // Exactly the capacity is not an overflow: everything typed arrived.
+    applyVirtualText(long[0..raylib.TEXT_INPUT_CAPACITY]);
+    try std.testing.expect(!takeVirtualText().?.overflowed);
 }
 
 test "taking a model for render clears the host-owned reference" {
@@ -9957,6 +10071,13 @@ fn runNormalApp(roc_host: *RocHost, allocator: std.mem.Allocator, app_config: Ap
         window_title.ptr,
     );
     defer raylib.closeWindow();
+    // Chained behind raylib's own callbacks, so it needs the window too. Every
+    // key, button, wheel and character event between two polls is recorded
+    // from here on; without the hook the host would be back to comparing two
+    // levels, which loses whatever happened in between.
+    if (!raylib.installInputEventCallbacks()) {
+        std.log.warn("no GLFW window to record input events on; edges fall back to level sampling", .{});
+    }
     // Both of these need a live window: InitWindow zeroes raylib's CORE state
     // and writes exitKey = KEY_ESCAPE, so an earlier SetExitKey is discarded,
     // and SetWindowMinSize needs the window handle.
@@ -10050,21 +10171,25 @@ fn runNormalApp(roc_host: *RocHost, allocator: std.mem.Allocator, app_config: Ap
         else
             raylib.getMousePosition();
         const mouse_delta = if (virtual_mouse_active) virtualMouseDelta() else raylib.getMouseDelta();
+        // Taken either way: notches turned while the pointer was scripted
+        // would otherwise land on the cycle the app hands it back.
+        const hardware_wheel = raylib.takeMouseWheelMove();
         const mouse_wheel = if (virtual_mouse_active)
             raylib.Vec2{ .x = 0, .y = virtual_mouse_wheel }
         else
-            raylib.getMouseWheelMoveV();
+            hardware_wheel;
         if (virtual_mouse_active) {
             recordVirtualMousePosition();
-            // A real wheel reports movement for one frame and then returns to
-            // zero, so consume the scripted value rather than reporting it
+            // A real wheel reports movement for one interval and then returns
+            // to zero, so consume the scripted value rather than reporting it
             // again on every subsequent frame.
             virtual_mouse_wheel = 0;
         }
-        // Drain raylib's queue either way: a scripted frame that left the
-        // hardware characters behind would deliver them on the next one.
-        const typed_text = raylib.getTextInput();
-        const text_input: []const u32 = takeVirtualText() orelse typed_text;
+        // Taken either way, for the same reason as the wheel: a scripted frame
+        // that left the hardware characters behind would deliver them on the
+        // next one.
+        const typed_text = raylib.takeTextInput();
+        const text_input = takeVirtualText() orelse typed_text;
         const input_snapshot = input.hostState(
             mouse_pos.x,
             mouse_pos.y,
@@ -10197,7 +10322,7 @@ fn runHeadlessApp(roc_host: *RocHost, app_config: AppConfig, frames: u64) c_int 
         const frame_time: f32 = if (cycle_count == 0) 0 else HEADLESS_FRAME_TIME;
         const timestamp_nanos = cycle_count * HEADLESS_FRAME_NANOS;
         input.updateHeadless();
-        const text_input: []const u32 = takeVirtualText() orelse &.{};
+        const text_input = takeVirtualText() orelse raylib.TextInput{ .codepoints = &.{}, .overflowed = false };
         // A headless run has no pointer, so a scripted one is the only pointer
         // there is. Everything a windowed run derives from it -- position,
         // delta, the wheel's single frame of movement -- is derived here the

--- a/src/host_native.zig
+++ b/src/host_native.zig
@@ -7582,7 +7582,7 @@ test "a scripted cycle's events reach the snapshot list in delivery order" {
 
     // Tap Escape, then type "hi", then hold S from this cycle: the script
     // order is the delivery order.
-    const options = RuntimeOptions{ .key_script = "3:ESCAPE^+S", .text_script = "3:hi" };
+    const options = RuntimeOptions{ .key_script = "3:ESCAPE~+S", .text_script = "3:hi" };
     applyInputScripts(options, 3);
     const scripted_text = takeVirtualText().?;
     input.updateHeadless(.virtual);
@@ -7735,8 +7735,8 @@ fn printUsage() void {
         \\  --host-frames=N   exit after N cycles of a real windowed run
         \\  --host-hidden     open the real window hidden (needs a display server)
         \\  --host-keys=SCRIPT  hold keys on given cycles, e.g. "3:S,4:LEFT+X,10:32";
-        \\                      a ^ suffix taps the key inside that cycle instead
-        \\                      of holding it, e.g. "3:ESCAPE^"
+        \\                      a ~ suffix taps the key inside that cycle instead
+        \\                      of holding it, e.g. "3:ESCAPE~"
         \\  --host-text=SCRIPT  deliver typed text on given cycles, e.g. "2:ab,3:c"
         \\
     , .{});
@@ -7814,8 +7814,14 @@ const ScriptedKeyBuffers = struct {
     taps: [KEY_SCRIPT_CAPACITY]u64 = undefined,
 };
 
-/// The suffix that turns a held key into a tap: `S^`.
-const TAP_SUFFIX = '^';
+/// The suffix that turns a held key into a tap: `S~`.
+///
+/// Chosen for being inert unquoted in every shell the sweep runs under: cmd
+/// does nothing with a `~`, PowerShell expands one only as a whole token, and
+/// bash and zsh tilde-expand only a word that starts with it. `^` was the
+/// first choice and is cmd's escape character, so `3:A^+B^` reached the host
+/// as `3:A+B` on Windows -- a held pair instead of two taps -- silently.
+const TAP_SUFFIX = '~';
 
 /// The keys a `--host-keys` script holds and taps on `cycle`, or null when it
 /// scripts nothing there.
@@ -7825,6 +7831,8 @@ fn scriptedKeysAtCycle(spec: []const u8, cycle: u64, out: *ScriptedKeyBuffers) S
     var held: usize = 0;
     var taps: usize = 0;
     while (tokens.next()) |token| {
+        // A bare suffix taps nothing; it is a typo, not a key.
+        if (token.len == 1 and token[0] == TAP_SUFFIX) return error.InvalidScript;
         if (token.len > 1 and token[token.len - 1] == TAP_SUFFIX) {
             if (taps == out.taps.len) return error.InvalidScript;
             out.taps[taps] = try parseScriptedKey(token[0 .. token.len - 1]);
@@ -7900,9 +7908,9 @@ test "a key script holds only the cycles it names" {
     }
 }
 
-test "a ^ suffix scripts a tap rather than a hold" {
+test "a ~ suffix scripts a tap rather than a hold" {
     var buffers = ScriptedKeyBuffers{};
-    const spec = "3:ESCAPE^,4:S^+a+SPACE^";
+    const spec = "3:ESCAPE~,4:S~+a+SPACE~";
 
     const escape = (try scriptedKeysAtCycle(spec, 3, &buffers)).?;
     try std.testing.expectEqual(@as(usize, 0), escape.held.len);
@@ -7912,10 +7920,9 @@ test "a ^ suffix scripts a tap rather than a hold" {
     try std.testing.expectEqualSlices(u64, &.{'A'}, mixed.held);
     try std.testing.expectEqualSlices(u64, &.{ 'S', 32 }, mixed.taps);
 
-    // A bare ^ is the key that types it, not a tap of nothing.
-    const caret = (try scriptedKeysAtCycle("1:^", 1, &buffers)).?;
-    try std.testing.expectEqualSlices(u64, &.{'^'}, caret.held);
-    try std.testing.expectEqual(@as(usize, 0), caret.taps.len);
+    // A bare ~ is a tap of nothing, which is a typo rather than a key.
+    try std.testing.expectError(error.InvalidScript, scriptedKeysAtCycle("1:~", 1, &buffers));
+    try std.testing.expectError(error.InvalidScript, validateScript("1:S+~", true));
     try validateScript(spec, true);
 }
 
@@ -7925,7 +7932,7 @@ test "a malformed script is rejected rather than scripting nothing" {
     try std.testing.expectError(error.InvalidScript, scriptedKeysAtCycle("3:", 3, &buffers));
     try std.testing.expectError(error.InvalidScript, scriptedKeysAtCycle("x:S", 3, &buffers));
     try std.testing.expectError(error.InvalidScript, scriptedKeysAtCycle("3:NOPE", 3, &buffers));
-    try std.testing.expectError(error.InvalidScript, scriptedKeysAtCycle("3:NOPE^", 3, &buffers));
+    try std.testing.expectError(error.InvalidScript, scriptedKeysAtCycle("3:NOPE~", 3, &buffers));
     try std.testing.expectError(error.InvalidScript, validateScript("3:S,", true));
     try validateScript("1:ab,2:c", false);
 }
@@ -7933,7 +7940,7 @@ test "a malformed script is rejected rather than scripting nothing" {
 test "a scripted tap lands inside one cycle as a press and a release" {
     defer resetVirtualInput();
     const escape = 256;
-    const options = RuntimeOptions{ .key_script = "2:S,3:ESCAPE^,4:S" };
+    const options = RuntimeOptions{ .key_script = "2:S,3:ESCAPE~,4:S" };
 
     // Cycle 1 is not scripted: hardware, with nothing recorded.
     applyInputScripts(options, 1);

--- a/src/roc_platform_abi.zig
+++ b/src/roc_platform_abi.zig
@@ -6385,11 +6385,11 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct_9c901b89b0293b6b
-pub const __AnonStruct_9c901b89b0293b6b = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct_b6ea9d11bc6dc5c3
+pub const __AnonStruct_b6ea9d11bc6dc5c3 = if (@sizeOf(usize) == 4) extern struct {
     capture: __AnonStruct_681b090756070ab0,
     time: __AnonStruct_db5a281b648e1efe,
-    devices: __AnonStruct_74da537dd9780edf,
+    devices: __AnonStruct_f4abe635a8244379,
     dropped: RocList(__AnonStruct_66bf628355bb7f8e),
     task_results: RocList(__AnonStruct_3e6f83279dfc8d12),
     window: __AnonStruct_225d69ea1bc0e508,
@@ -6418,7 +6418,7 @@ pub const __AnonStruct_9c901b89b0293b6b = if (@sizeOf(usize) == 4) extern struct
 } else extern struct {
     capture: __AnonStruct_681b090756070ab0,
     time: __AnonStruct_db5a281b648e1efe,
-    devices: __AnonStruct_74da537dd9780edf,
+    devices: __AnonStruct_f4abe635a8244379,
     dropped: RocList(__AnonStruct_66bf628355bb7f8e),
     task_results: RocList(__AnonStruct_3e6f83279dfc8d12),
     window: __AnonStruct_225d69ea1bc0e508,
@@ -6448,12 +6448,12 @@ pub const __AnonStruct_9c901b89b0293b6b = if (@sizeOf(usize) == 4) extern struct
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_9c901b89b0293b6b) != 304) @compileError("__AnonStruct_9c901b89b0293b6b size mismatch");
-        if (@alignOf(__AnonStruct_9c901b89b0293b6b) != 8) @compileError("__AnonStruct_9c901b89b0293b6b alignment mismatch");
+        if (@sizeOf(__AnonStruct_b6ea9d11bc6dc5c3) != 312) @compileError("__AnonStruct_b6ea9d11bc6dc5c3 size mismatch");
+        if (@alignOf(__AnonStruct_b6ea9d11bc6dc5c3) != 8) @compileError("__AnonStruct_b6ea9d11bc6dc5c3 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_9c901b89b0293b6b) != 208) @compileError("__AnonStruct_9c901b89b0293b6b size mismatch");
-        if (@alignOf(__AnonStruct_9c901b89b0293b6b) != 8) @compileError("__AnonStruct_9c901b89b0293b6b alignment mismatch");
+        if (@sizeOf(__AnonStruct_b6ea9d11bc6dc5c3) != 216) @compileError("__AnonStruct_b6ea9d11bc6dc5c3 size mismatch");
+        if (@alignOf(__AnonStruct_b6ea9d11bc6dc5c3) != 8) @compileError("__AnonStruct_b6ea9d11bc6dc5c3 alignment mismatch");
     }
 }
 
@@ -6509,12 +6509,13 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct_74da537dd9780edf
-pub const __AnonStruct_74da537dd9780edf = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct_f4abe635a8244379
+pub const __AnonStruct_f4abe635a8244379 = if (@sizeOf(usize) == 4) extern struct {
     gamepads: __AnonStruct_1c8617e96852f779,
     keys: RocListWith(u8, false),
     mouse: MouseSnapshot,
     text_input: RocListWith(u32, false),
+    text_input_overflow: bool,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
@@ -6537,6 +6538,7 @@ pub const __AnonStruct_74da537dd9780edf = if (@sizeOf(usize) == 4) extern struct
     keys: RocListWith(u8, false),
     mouse: MouseSnapshot,
     text_input: RocListWith(u32, false),
+    text_input_overflow: bool,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
@@ -6558,12 +6560,12 @@ pub const __AnonStruct_74da537dd9780edf = if (@sizeOf(usize) == 4) extern struct
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_74da537dd9780edf) != 176) @compileError("__AnonStruct_74da537dd9780edf size mismatch");
-        if (@alignOf(__AnonStruct_74da537dd9780edf) != 8) @compileError("__AnonStruct_74da537dd9780edf alignment mismatch");
+        if (@sizeOf(__AnonStruct_f4abe635a8244379) != 184) @compileError("__AnonStruct_f4abe635a8244379 size mismatch");
+        if (@alignOf(__AnonStruct_f4abe635a8244379) != 8) @compileError("__AnonStruct_f4abe635a8244379 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_74da537dd9780edf) != 104) @compileError("__AnonStruct_74da537dd9780edf size mismatch");
-        if (@alignOf(__AnonStruct_74da537dd9780edf) != 4) @compileError("__AnonStruct_74da537dd9780edf alignment mismatch");
+        if (@sizeOf(__AnonStruct_f4abe635a8244379) != 108) @compileError("__AnonStruct_f4abe635a8244379 size mismatch");
+        if (@alignOf(__AnonStruct_f4abe635a8244379) != 4) @compileError("__AnonStruct_f4abe635a8244379 alignment mismatch");
     }
 }
 
@@ -11910,10 +11912,10 @@ pub const CmdHostRunArg0 = __AnonStruct_3fe396bc5ba0c31c;
 pub const CmdHostRunArg0Envs = __AnonStruct_82a96c5d55d63488;
 pub const CmdHostRun = __AnonStruct_fa110e8829dc221b;
 pub const App_config_for_host = __AnonStruct_a868748fcc059834;
-pub const Update_for_hostArg1 = __AnonStruct_9c901b89b0293b6b;
+pub const Update_for_hostArg1 = __AnonStruct_b6ea9d11bc6dc5c3;
 pub const Update_for_hostArg1Capture = __AnonStruct_681b090756070ab0;
 pub const Update_for_hostArg1Time = __AnonStruct_db5a281b648e1efe;
-pub const Update_for_hostArg1Devices = __AnonStruct_74da537dd9780edf;
+pub const Update_for_hostArg1Devices = __AnonStruct_f4abe635a8244379;
 pub const Update_for_hostArg1DevicesGamepads = __AnonStruct_1c8617e96852f779;
 pub const Update_for_hostArg1Dropped = __AnonStruct_66bf628355bb7f8e;
 pub const Update_for_hostArg1DroppedPosition = __AnonStruct_2818a50bdccefb1e;
@@ -12689,8 +12691,8 @@ pub const Init_for_hostResultRelease = struct {
     }
 };
 
-pub const __AnonStruct_9c901b89b0293b6bRelease = struct {
-    pub fn release(value: __AnonStruct_9c901b89b0293b6b, roc_host: *RocHost) void {
+pub const __AnonStruct_b6ea9d11bc6dc5c3Release = struct {
+    pub fn release(value: __AnonStruct_b6ea9d11bc6dc5c3, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -12701,8 +12703,8 @@ pub const __AnonStruct_681b090756070ab0Release = struct {
     }
 };
 
-pub const __AnonStruct_74da537dd9780edfRelease = struct {
-    pub fn release(value: __AnonStruct_74da537dd9780edf, roc_host: *RocHost) void {
+pub const __AnonStruct_f4abe635a8244379Release = struct {
+    pub fn release(value: __AnonStruct_f4abe635a8244379, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -12979,8 +12981,8 @@ fn rocReleasePolicy(comptime T: type) type {
     if (T == __AnonStruct_def8e181e644dca4) return __AnonStruct_def8e181e644dca4Release;
     if (T == __AnonStruct_8fd71e3705bdb8b5) return __AnonStruct_8fd71e3705bdb8b5Release;
     if (T == __AnonStruct_a868748fcc059834) return __AnonStruct_a868748fcc059834Release;
-    if (T == __AnonStruct_9c901b89b0293b6b) return __AnonStruct_9c901b89b0293b6bRelease;
-    if (T == __AnonStruct_74da537dd9780edf) return __AnonStruct_74da537dd9780edfRelease;
+    if (T == __AnonStruct_b6ea9d11bc6dc5c3) return __AnonStruct_b6ea9d11bc6dc5c3Release;
+    if (T == __AnonStruct_f4abe635a8244379) return __AnonStruct_f4abe635a8244379Release;
     if (T == __AnonStruct_1c8617e96852f779) return __AnonStruct_1c8617e96852f779Release;
     if (T == RocListWith(f32, false)) return RocListSpineRelease(RocListWith(f32, false));
     if (T == MouseSnapshot) return MouseSnapshotRelease;
@@ -13997,7 +13999,7 @@ pub extern fn app_config_for_host() callconv(.c) __AnonStruct_a868748fcc059834;
 pub extern fn init_for_host() callconv(.c) Init_for_hostResult;
 
 /// Entrypoint: update_for_host!
-pub extern fn update_for_host(arg0: RocBox, arg1: __AnonStruct_9c901b89b0293b6b) callconv(.c) Update_for_hostResult;
+pub extern fn update_for_host(arg0: RocBox, arg1: __AnonStruct_b6ea9d11bc6dc5c3) callconv(.c) Update_for_hostResult;
 
 /// Entrypoint: render_for_host!
 pub extern fn render_for_host(arg0: RocBox) callconv(.c) Render_for_hostResult;

--- a/src/roc_platform_abi.zig
+++ b/src/roc_platform_abi.zig
@@ -6385,11 +6385,11 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct_b6ea9d11bc6dc5c3
-pub const __AnonStruct_b6ea9d11bc6dc5c3 = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct_cf3def8e4b7f351
+pub const __AnonStruct_cf3def8e4b7f351 = if (@sizeOf(usize) == 4) extern struct {
     capture: __AnonStruct_681b090756070ab0,
     time: __AnonStruct_db5a281b648e1efe,
-    devices: __AnonStruct_f4abe635a8244379,
+    devices: __AnonStruct_1339741edbb01404,
     dropped: RocList(__AnonStruct_66bf628355bb7f8e),
     task_results: RocList(__AnonStruct_3e6f83279dfc8d12),
     window: __AnonStruct_225d69ea1bc0e508,
@@ -6418,7 +6418,7 @@ pub const __AnonStruct_b6ea9d11bc6dc5c3 = if (@sizeOf(usize) == 4) extern struct
 } else extern struct {
     capture: __AnonStruct_681b090756070ab0,
     time: __AnonStruct_db5a281b648e1efe,
-    devices: __AnonStruct_f4abe635a8244379,
+    devices: __AnonStruct_1339741edbb01404,
     dropped: RocList(__AnonStruct_66bf628355bb7f8e),
     task_results: RocList(__AnonStruct_3e6f83279dfc8d12),
     window: __AnonStruct_225d69ea1bc0e508,
@@ -6448,12 +6448,12 @@ pub const __AnonStruct_b6ea9d11bc6dc5c3 = if (@sizeOf(usize) == 4) extern struct
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_b6ea9d11bc6dc5c3) != 312) @compileError("__AnonStruct_b6ea9d11bc6dc5c3 size mismatch");
-        if (@alignOf(__AnonStruct_b6ea9d11bc6dc5c3) != 8) @compileError("__AnonStruct_b6ea9d11bc6dc5c3 alignment mismatch");
+        if (@sizeOf(__AnonStruct_cf3def8e4b7f351) != 336) @compileError("__AnonStruct_cf3def8e4b7f351 size mismatch");
+        if (@alignOf(__AnonStruct_cf3def8e4b7f351) != 8) @compileError("__AnonStruct_cf3def8e4b7f351 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_b6ea9d11bc6dc5c3) != 216) @compileError("__AnonStruct_b6ea9d11bc6dc5c3 size mismatch");
-        if (@alignOf(__AnonStruct_b6ea9d11bc6dc5c3) != 8) @compileError("__AnonStruct_b6ea9d11bc6dc5c3 alignment mismatch");
+        if (@sizeOf(__AnonStruct_cf3def8e4b7f351) != 224) @compileError("__AnonStruct_cf3def8e4b7f351 size mismatch");
+        if (@alignOf(__AnonStruct_cf3def8e4b7f351) != 8) @compileError("__AnonStruct_cf3def8e4b7f351 alignment mismatch");
     }
 }
 
@@ -6509,16 +6509,19 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct_f4abe635a8244379
-pub const __AnonStruct_f4abe635a8244379 = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct_1339741edbb01404
+pub const __AnonStruct_1339741edbb01404 = if (@sizeOf(usize) == 4) extern struct {
+    events: RocListWith(__AnonStruct_59fc16acdd7d0c98, false),
     gamepads: __AnonStruct_1c8617e96852f779,
     keys: RocListWith(u8, false),
     mouse: MouseSnapshot,
     text_input: RocListWith(u32, false),
+    events_overflow: bool,
     text_input_overflow: bool,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
+        value.events.decref(roc_host);
         value.gamepads.decref(roc_host);
         value.keys.decref(roc_host);
         value.mouse.decref(roc_host);
@@ -6528,20 +6531,24 @@ pub const __AnonStruct_f4abe635a8244379 = if (@sizeOf(usize) == 4) extern struct
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
+        value.events.incref(amount);
         value.gamepads.incref(amount);
         value.keys.incref(amount);
         value.mouse.incref(amount);
         value.text_input.incref(amount);
     }
 } else extern struct {
+    events: RocListWith(__AnonStruct_59fc16acdd7d0c98, false),
     gamepads: __AnonStruct_1c8617e96852f779,
     keys: RocListWith(u8, false),
     mouse: MouseSnapshot,
     text_input: RocListWith(u32, false),
+    events_overflow: bool,
     text_input_overflow: bool,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
+        value.events.decref(roc_host);
         value.gamepads.decref(roc_host);
         value.keys.decref(roc_host);
         value.mouse.decref(roc_host);
@@ -6551,6 +6558,7 @@ pub const __AnonStruct_f4abe635a8244379 = if (@sizeOf(usize) == 4) extern struct
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
+        value.events.incref(amount);
         value.gamepads.incref(amount);
         value.keys.incref(amount);
         value.mouse.incref(amount);
@@ -6560,12 +6568,62 @@ pub const __AnonStruct_f4abe635a8244379 = if (@sizeOf(usize) == 4) extern struct
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_f4abe635a8244379) != 184) @compileError("__AnonStruct_f4abe635a8244379 size mismatch");
-        if (@alignOf(__AnonStruct_f4abe635a8244379) != 8) @compileError("__AnonStruct_f4abe635a8244379 alignment mismatch");
+        if (@sizeOf(__AnonStruct_1339741edbb01404) != 208) @compileError("__AnonStruct_1339741edbb01404 size mismatch");
+        if (@alignOf(__AnonStruct_1339741edbb01404) != 8) @compileError("__AnonStruct_1339741edbb01404 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_f4abe635a8244379) != 108) @compileError("__AnonStruct_f4abe635a8244379 size mismatch");
-        if (@alignOf(__AnonStruct_f4abe635a8244379) != 4) @compileError("__AnonStruct_f4abe635a8244379 alignment mismatch");
+        if (@sizeOf(__AnonStruct_1339741edbb01404) != 120) @compileError("__AnonStruct_1339741edbb01404 size mismatch");
+        if (@alignOf(__AnonStruct_1339741edbb01404) != 4) @compileError("__AnonStruct_1339741edbb01404 alignment mismatch");
+    }
+}
+
+/// Element type for __AnonStruct_59fc16acdd7d0c98
+pub const __AnonStruct_59fc16acdd7d0c98 = if (@sizeOf(usize) == 4) extern struct {
+    code: u32,
+    x: f32,
+    y: f32,
+    kind: u8,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        _ = value;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        _ = value;
+        _ = amount;
+    }
+} else extern struct {
+    code: u32,
+    x: f32,
+    y: f32,
+    kind: u8,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        _ = value;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        _ = value;
+        _ = amount;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(__AnonStruct_59fc16acdd7d0c98) != 16) @compileError("__AnonStruct_59fc16acdd7d0c98 size mismatch");
+        if (@alignOf(__AnonStruct_59fc16acdd7d0c98) != 4) @compileError("__AnonStruct_59fc16acdd7d0c98 alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(__AnonStruct_59fc16acdd7d0c98) != 16) @compileError("__AnonStruct_59fc16acdd7d0c98 size mismatch");
+        if (@alignOf(__AnonStruct_59fc16acdd7d0c98) != 4) @compileError("__AnonStruct_59fc16acdd7d0c98 alignment mismatch");
     }
 }
 
@@ -11912,10 +11970,11 @@ pub const CmdHostRunArg0 = __AnonStruct_3fe396bc5ba0c31c;
 pub const CmdHostRunArg0Envs = __AnonStruct_82a96c5d55d63488;
 pub const CmdHostRun = __AnonStruct_fa110e8829dc221b;
 pub const App_config_for_host = __AnonStruct_a868748fcc059834;
-pub const Update_for_hostArg1 = __AnonStruct_b6ea9d11bc6dc5c3;
+pub const Update_for_hostArg1 = __AnonStruct_cf3def8e4b7f351;
 pub const Update_for_hostArg1Capture = __AnonStruct_681b090756070ab0;
 pub const Update_for_hostArg1Time = __AnonStruct_db5a281b648e1efe;
-pub const Update_for_hostArg1Devices = __AnonStruct_f4abe635a8244379;
+pub const Update_for_hostArg1Devices = __AnonStruct_1339741edbb01404;
+pub const Update_for_hostArg1DevicesEvents = __AnonStruct_59fc16acdd7d0c98;
 pub const Update_for_hostArg1DevicesGamepads = __AnonStruct_1c8617e96852f779;
 pub const Update_for_hostArg1Dropped = __AnonStruct_66bf628355bb7f8e;
 pub const Update_for_hostArg1DroppedPosition = __AnonStruct_2818a50bdccefb1e;
@@ -12691,8 +12750,8 @@ pub const Init_for_hostResultRelease = struct {
     }
 };
 
-pub const __AnonStruct_b6ea9d11bc6dc5c3Release = struct {
-    pub fn release(value: __AnonStruct_b6ea9d11bc6dc5c3, roc_host: *RocHost) void {
+pub const __AnonStruct_cf3def8e4b7f351Release = struct {
+    pub fn release(value: __AnonStruct_cf3def8e4b7f351, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -12703,8 +12762,14 @@ pub const __AnonStruct_681b090756070ab0Release = struct {
     }
 };
 
-pub const __AnonStruct_f4abe635a8244379Release = struct {
-    pub fn release(value: __AnonStruct_f4abe635a8244379, roc_host: *RocHost) void {
+pub const __AnonStruct_1339741edbb01404Release = struct {
+    pub fn release(value: __AnonStruct_1339741edbb01404, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+pub const __AnonStruct_59fc16acdd7d0c98Release = struct {
+    pub fn release(value: __AnonStruct_59fc16acdd7d0c98, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -12981,8 +13046,9 @@ fn rocReleasePolicy(comptime T: type) type {
     if (T == __AnonStruct_def8e181e644dca4) return __AnonStruct_def8e181e644dca4Release;
     if (T == __AnonStruct_8fd71e3705bdb8b5) return __AnonStruct_8fd71e3705bdb8b5Release;
     if (T == __AnonStruct_a868748fcc059834) return __AnonStruct_a868748fcc059834Release;
-    if (T == __AnonStruct_b6ea9d11bc6dc5c3) return __AnonStruct_b6ea9d11bc6dc5c3Release;
-    if (T == __AnonStruct_f4abe635a8244379) return __AnonStruct_f4abe635a8244379Release;
+    if (T == __AnonStruct_cf3def8e4b7f351) return __AnonStruct_cf3def8e4b7f351Release;
+    if (T == __AnonStruct_1339741edbb01404) return __AnonStruct_1339741edbb01404Release;
+    if (T == RocListWith(__AnonStruct_59fc16acdd7d0c98, false)) return RocListSpineRelease(RocListWith(__AnonStruct_59fc16acdd7d0c98, false));
     if (T == __AnonStruct_1c8617e96852f779) return __AnonStruct_1c8617e96852f779Release;
     if (T == RocListWith(f32, false)) return RocListSpineRelease(RocListWith(f32, false));
     if (T == MouseSnapshot) return MouseSnapshotRelease;
@@ -13999,7 +14065,7 @@ pub extern fn app_config_for_host() callconv(.c) __AnonStruct_a868748fcc059834;
 pub extern fn init_for_host() callconv(.c) Init_for_hostResult;
 
 /// Entrypoint: update_for_host!
-pub extern fn update_for_host(arg0: RocBox, arg1: __AnonStruct_b6ea9d11bc6dc5c3) callconv(.c) Update_for_hostResult;
+pub extern fn update_for_host(arg0: RocBox, arg1: __AnonStruct_cf3def8e4b7f351) callconv(.c) Update_for_hostResult;
 
 /// Entrypoint: render_for_host!
 pub extern fn render_for_host(arg0: RocBox) callconv(.c) Render_for_hostResult;

--- a/types/Devices.roc
+++ b/types/Devices.roc
@@ -1,7 +1,18 @@
-## One cycle of sampled keyboard, text, mouse and gamepad state.
+## One cycle of keyboard, text, mouse and gamepad input.
 ##
-## `App.Input` carries the host's start-of-cycle observation as
-## `input.devices`. A snapshot is pure data and grants no device authority.
+## `App.Input` carries the host's observation as `input.devices`. A snapshot is
+## pure data and grants no device authority.
+##
+## Two kinds of information are in it, and each field says which it is. A
+## *state sample* is the latest value at the cycle boundary: a held key, the
+## pointer position, a gamepad axis. An *interval event* is something that
+## happened since the previous input: a press, a release, a typed character,
+## a wheel notch. On a desktop host the keyboard, mouse-button, wheel and text
+## events are recorded from the window system's own event callbacks, so an
+## event that reaches the process is in the next input or reported as an
+## overflow, never silently lost, with a latency of at most one cycle.
+## Gamepad buttons are the exception: raylib polls them with no callback, so
+## their edges are sampled and a press-and-release between two polls is lost.
 ##
 ## Tests can start from `Devices.none` and set only the relevant state with the
 ## `with_key_*` and `with_mouse_*` receivers.
@@ -23,22 +34,41 @@ Devices := [].{
 	Snapshot := {
 
 		## Packed per-key state, one byte per raylib key code. Each byte stores
-		## held, pressed-this-frame, and released-this-frame bits. Use the
+		## a held bit, which is a state sample, and pressed and released bits,
+		## which are interval events: set when at least one press (release) of
+		## that key happened since the previous input. Several presses of one
+		## key in one interval coalesce into one bit; the count and the order
+		## are not retained. A key tapped between two cycles is therefore
+		## pressed and released in one input and held in neither. Use the
 		## `key_down`/`key_pressed`/`key_released` receivers.
 		keys : List(U8),
 
-		## Unicode codepoints retained for this host-cycle input, in event order. This is
-		## distinct from physical key state and respects the active keyboard
-		## layout. At most 32 codepoints are delivered per frame; excess queued
-		## input is discarded.
+		## Unicode codepoints typed since the previous input, in the order
+		## typed. This is distinct from physical key state and respects the
+		## active keyboard layout. At most 32 codepoints are delivered per
+		## input; a longer burst has the rest discarded and `text_input_overflow`
+		## set. Order relative to the key edges of the same interval is not
+		## defined.
 		text_input : List(U32),
 
-		## Gamepad input sampled once per host-cycle input. Use the `gamepad` receiver, or
-		## the `Gamepad` helpers, rather than indexing these flat lists.
+		## Whether more than 32 codepoints were typed in this interval, so
+		## `text_input` is the first 32 of them rather than all. Clear means
+		## nothing was lost.
+		text_input_overflow : Bool,
+
+		## Gamepad input sampled once per host-cycle input. The held bits and
+		## axes are state samples; the pressed and released bits are derived by
+		## comparing two samples, so a button pressed and released between two
+		## cycles is not seen. Use the `gamepad` receiver, or the `Gamepad`
+		## helpers, rather than indexing these flat lists.
 		gamepads : Gamepad.Snapshot,
 
-		## Mouse buttons, position, delta, and two-axis wheel movement sampled
-		## once for this host-cycle input. Receiver helpers are available on `Mouse.State`.
+		## Mouse buttons, position, movement, and wheel for this input. Position
+		## and the held bits are state samples at the cycle boundary; pressed
+		## and released bits are interval events, coalesced per button like
+		## keys; the wheel is the sum of every notch in the interval. Clicks in
+		## one interval share the boundary position. Receivers are on
+		## `Mouse.Snapshot`.
 		mouse : Mouse.Snapshot,
 	}.{
 
@@ -74,9 +104,8 @@ Devices := [].{
 		## Say that one key is held, as `Devices.none.with_key_down(KeyW)`.
 		##
 		## Each `with_key_*` states the complete state of the key it names,
-		## replacing whatever that key had, because the host samples exactly one
-		## of held, pressed, or released per key per cycle. Different keys are
-		## independent bytes, so these compose:
+		## replacing whatever that key had. Different keys are independent
+		## bytes, so these compose:
 		## `Devices.none.with_key_pressed(KeySpace).with_key_down(KeyLeftShift)`.
 		##
 		## Only a snapshot with the host's packed list lengths can carry these.
@@ -141,6 +170,14 @@ Devices := [].{
 		## cycle is no longer held.
 		with_mouse_button_released : Snapshot, Mouse.Button -> Snapshot
 		with_mouse_button_released = |input, button| with_mouse_button_state(input, button, released)
+
+		## Say whether typed text was cut at the interval's capacity, which is
+		## what `text_input_overflow` reports.
+		with_text_input_overflow : Snapshot, Bool -> Snapshot
+		with_text_input_overflow = |input, overflow| {
+			..snapshot_fields(input),
+			text_input_overflow: overflow,
+		}
 	}
 
 	## A neutral snapshot with the host's own packed list lengths, for tests.
@@ -163,6 +200,7 @@ Devices := [].{
 	none = {
 		keys: List.repeat(0, key_state_len),
 		text_input: [],
+		text_input_overflow: Bool.False,
 		gamepads: {
 			connected: List.repeat(0, gamepad_count),
 			buttons: List.repeat(0, gamepad_count * gamepad_button_count),
@@ -193,6 +231,7 @@ Devices := [].{
 	empty = {
 		keys: [],
 		text_input: [],
+		text_input_overflow: Bool.False,
 		gamepads: {
 			connected: [],
 			buttons: [],
@@ -225,6 +264,7 @@ Devices := [].{
 	expect Devices.empty.mouse.delta() == { x: 0, y: 0 }
 	expect Devices.empty.mouse.wheel_delta() == { x: 0, y: 0 }
 	expect List.len(Devices.empty.text_input) == 0
+	expect !(Devices.empty.text_input_overflow)
 }
 
 ## Held bit in a packed key or mouse-button state byte.
@@ -267,6 +307,7 @@ gamepad_axis_count = 6
 snapshot_fields : Devices.Snapshot -> {
 	keys : List(U8),
 	text_input : List(U32),
+	text_input_overflow : Bool,
 	gamepads : Gamepad.Snapshot,
 	mouse : Mouse.Snapshot,
 }
@@ -429,6 +470,12 @@ expect Devices.none.with_mouse_button_down(Middle).mouse.middle
 expect !(Devices.none.with_mouse_button_down(Left).mouse.right)
 expect !(Devices.none.with_mouse_button_released(Left).mouse.left)
 expect !(Devices.none.with_mouse_button_down(Side).mouse.left)
+
+## Text overflow is an ordinary flag on the sample, clear until stated.
+expect !(Devices.none.text_input_overflow)
+expect Devices.none.with_text_input_overflow(Bool.True).text_input_overflow
+expect !(Devices.none.with_text_input_overflow(Bool.True).with_text_input_overflow(Bool.False).text_input_overflow)
+expect Devices.none.with_text_input_overflow(Bool.True).with_key_pressed(KeyR).key_pressed(KeyR)
 
 ## Pointer, movement, and wheel are ordinary scalars on the sample.
 expect Devices.none.with_mouse_position({ x: 40, y: 12 }).mouse.position() == { x: 40, y: 12 }

--- a/types/Devices.roc
+++ b/types/Devices.roc
@@ -14,6 +14,16 @@
 ## Gamepad buttons are the exception: raylib polls them with no callback, so
 ## their edges are sampled and a press-and-release between two polls is lost.
 ##
+## The interval events come in two views. The packed bits behind
+## `key_pressed`, `mouse.button_pressed` and friends are the *coalesced* view:
+## at least one press, at least one release, per key or button. `events` is
+## the *record*: every event in delivery order, with count, order across
+## sources and the pointer position of every click preserved up to a stated
+## capacity. Read the bits for simple held-or-pressed logic; read the list
+## when order or count matters -- a double tap, a drag that ended and began
+## again inside one frame, text editing where a keystroke has to land between
+## two characters.
+##
 ## Tests can start from `Devices.none` and set only the relevant state with the
 ## `with_key_*` and `with_mouse_*` receivers.
 ##
@@ -55,6 +65,25 @@ Devices := [].{
 		## `text_input` is the first 32 of them rather than all. Clear means
 		## nothing was lost.
 		text_input_overflow : Bool,
+
+		## Every key edge, click, wheel notch and typed character since the
+		## previous input, in the order the window system delivered them,
+		## across all of those sources. This is the authoritative record the
+		## packed bits and `text_input` summarize: where the bits coalesce two
+		## taps into one, this holds both; where `text_input` is bounded at
+		## 32, this holds text in order relative to the key edges around it;
+		## a click carries the pointer position it landed at. At most 256
+		## events per input; past that the rest are discarded and
+		## `events_overflow` is set, while the bits, the wheel sum and
+		## `text_input` keep recording regardless, so the coalesced view is
+		## complete even when the list is not. Gamepad buttons are sampled and
+		## never appear here.
+		events : List(Event),
+
+		## Whether more than 256 events arrived in this interval, so `events`
+		## is the first 256 of them rather than all. Clear means the list is
+		## the whole interval.
+		events_overflow : Bool,
 
 		## Gamepad input sampled once per host-cycle input. The held bits and
 		## axes are state samples; the pressed and released bits are derived by
@@ -178,7 +207,74 @@ Devices := [].{
 			..snapshot_fields(input),
 			text_input_overflow: overflow,
 		}
+
+		## State the interval's event record, as
+		## `Devices.none.with_events([KeyPressed(KeySpace), KeyReleased(KeySpace)])`.
+		##
+		## The bits are not derived from it: a test that wants both views to
+		## agree states both, as the host would have. Unlike the `with_key_*`
+		## receivers this works on `Devices.empty` too, since a list has no
+		## fixed length to fit.
+		with_events : Snapshot, List(Event) -> Snapshot
+		with_events = |input, events| {
+			..snapshot_fields(input),
+			events: events,
+		}
+
+		## Say whether the event record was cut at its capacity, which is what
+		## `events_overflow` reports.
+		with_events_overflow : Snapshot, Bool -> Snapshot
+		with_events_overflow = |input, overflow| {
+			..snapshot_fields(input),
+			events_overflow: overflow,
+		}
 	}
+
+	## One input event, as the window system delivered it.
+	##
+	## `KeyPressed` and `KeyReleased` are physical key edges; auto-repeat is
+	## not an event. `ButtonPressed` and `ButtonReleased` carry the pointer
+	## position the click landed at, in the same logical coordinates as
+	## `mouse.position()`. `Wheel` is one scroll event's offsets, which
+	## `mouse.wheel_delta()` sums. `Text` is one typed codepoint, following the
+	## active keyboard layout, which is why it is separate from the key edge
+	## that produced it.
+	Event : [
+		KeyPressed(Keys.Key),
+		KeyReleased(Keys.Key),
+		ButtonPressed(Mouse.Button, { x : F32, y : F32 }),
+		ButtonReleased(Mouse.Button, { x : F32, y : F32 }),
+		Wheel({ x : F32, y : F32 }),
+		Text(U32),
+	]
+
+	## The flat record one event crosses the host boundary as. Not for
+	## applications: the platform decodes it into `Event` before `update!`
+	## sees an input, and `events_from_raw` is the decoder.
+	##
+	## `kind` numbers the `Event` variants in declaration order from 0;
+	## `code` is the key code, mouse button code or codepoint that kind
+	## implies; `x` and `y` are a click's position or a wheel notch's offsets.
+	RawEvent : { kind : U8, code : U32, x : F32, y : F32 }
+
+	## Decode a cycle's flat events into `Event`s, keeping their order.
+	##
+	## A record the decoder cannot read -- a `kind` this package does not
+	## know, or a code past the key or button tables -- is dropped rather
+	## than crashing the app. Such a record can only come from a host newer
+	## than this package, and a kind of event the app could not have matched
+	## on anyway is not one it can act on.
+	events_from_raw : List(RawEvent) -> List(Event)
+	events_from_raw = |raw|
+		List.fold(
+			raw,
+			[],
+			|acc, record|
+				match event_from_raw(record) {
+					Ok(event) => List.append(acc, event)
+					Err(_) => acc
+				},
+		)
 
 	## A neutral snapshot with the host's own packed list lengths, for tests.
 	##
@@ -201,6 +297,8 @@ Devices := [].{
 		keys: List.repeat(0, key_state_len),
 		text_input: [],
 		text_input_overflow: Bool.False,
+		events: [],
+		events_overflow: Bool.False,
 		gamepads: {
 			connected: List.repeat(0, gamepad_count),
 			buttons: List.repeat(0, gamepad_count * gamepad_button_count),
@@ -232,6 +330,8 @@ Devices := [].{
 		keys: [],
 		text_input: [],
 		text_input_overflow: Bool.False,
+		events: [],
+		events_overflow: Bool.False,
 		gamepads: {
 			connected: [],
 			buttons: [],
@@ -265,6 +365,8 @@ Devices := [].{
 	expect Devices.empty.mouse.wheel_delta() == { x: 0, y: 0 }
 	expect List.len(Devices.empty.text_input) == 0
 	expect !(Devices.empty.text_input_overflow)
+	expect Devices.empty.events == []
+	expect !(Devices.empty.events_overflow)
 }
 
 ## Held bit in a packed key or mouse-button state byte.
@@ -308,10 +410,66 @@ snapshot_fields : Devices.Snapshot -> {
 	keys : List(U8),
 	text_input : List(U32),
 	text_input_overflow : Bool,
+	events : List(Devices.Event),
+	events_overflow : Bool,
 	gamepads : Gamepad.Snapshot,
 	mouse : Mouse.Snapshot,
 }
 snapshot_fields = |input| input
+
+## Decode one flat event. The numbering mirrors `InputEventKind` in
+## `src/backend_raylib.zig`; both sides state it so neither can drift alone.
+event_from_raw : Devices.RawEvent -> Try(Devices.Event, [UnknownEvent])
+event_from_raw = |record|
+	match record.kind {
+		0 => Keys.from_code(U32.to_u64(record.code)) |> Try.map_ok(|key| KeyPressed(key)) |> Try.map_err(|_| UnknownEvent)
+		1 => Keys.from_code(U32.to_u64(record.code)) |> Try.map_ok(|key| KeyReleased(key)) |> Try.map_err(|_| UnknownEvent)
+		2 => mouse_button_from_code(U32.to_u64(record.code)) |> Try.map_ok(|button| ButtonPressed(button, { x: record.x, y: record.y })) |> Try.map_err(|_| UnknownEvent)
+		3 => mouse_button_from_code(U32.to_u64(record.code)) |> Try.map_ok(|button| ButtonReleased(button, { x: record.x, y: record.y })) |> Try.map_err(|_| UnknownEvent)
+		4 => Ok(Wheel({ x: record.x, y: record.y }))
+		5 => Ok(Text(record.code))
+		_ => Err(UnknownEvent)
+	}
+
+## The inverse of `mouse_button_code`, for decoding a click's button.
+mouse_button_from_code : U64 -> Try(Mouse.Button, [InvalidMouseButtonCode])
+mouse_button_from_code = |code|
+	match code {
+		0 => Ok(Left)
+		1 => Ok(Right)
+		2 => Ok(Middle)
+		3 => Ok(Side)
+		4 => Ok(Extra)
+		5 => Ok(Forward)
+		6 => Ok(Back)
+		_ => Err(InvalidMouseButtonCode)
+	}
+
+## A flat event for the decode expects below.
+raw : U8, U32, F32, F32 -> Devices.RawEvent
+raw = |kind, code, x, y| { kind, code, x, y }
+
+## Every variant decodes, with its payload intact.
+expect event_from_raw(raw(0, 65, 0, 0)) == Ok(KeyPressed(KeyA))
+expect event_from_raw(raw(1, 256, 0, 0)) == Ok(KeyReleased(KeyEscape))
+expect event_from_raw(raw(2, 0, 12.5, 34)) == Ok(ButtonPressed(Left, { x: 12.5, y: 34 }))
+expect event_from_raw(raw(3, 6, 1, 2)) == Ok(ButtonReleased(Back, { x: 1, y: 2 }))
+expect event_from_raw(raw(4, 0, -0.5, 2)) == Ok(Wheel({ x: -0.5, y: 2 }))
+expect event_from_raw(raw(5, 0x20ac, 0, 0)) == Ok(Text(0x20ac))
+
+## A kind or code this package cannot read is dropped, not a crash.
+expect event_from_raw(raw(6, 0, 0, 0)) == Err(UnknownEvent)
+expect event_from_raw(raw(255, 65, 0, 0)) == Err(UnknownEvent)
+expect event_from_raw(raw(0, 100000, 0, 0)) == Err(UnknownEvent)
+expect event_from_raw(raw(2, 7, 0, 0)) == Err(UnknownEvent)
+expect Devices.events_from_raw([raw(0, 65, 0, 0), raw(9, 0, 0, 0), raw(5, 104, 0, 0)]) == [KeyPressed(KeyA), Text(104)]
+
+## Decoding keeps delivery order.
+expect Devices.events_from_raw([raw(5, 104, 0, 0), raw(2, 1, 3, 4), raw(1, 65, 0, 0)]) == [Text(104), ButtonPressed(Right, { x: 3, y: 4 }), KeyReleased(KeyA)]
+expect Devices.events_from_raw([]) == []
+
+## The button tables agree in both directions.
+expect List.all(every_mouse_button, |button| mouse_button_from_code(mouse_button_code(button)) == Ok(button))
 
 ## The same, for the sampled mouse state nested inside it.
 mouse_fields : Mouse.Snapshot -> {
@@ -470,6 +628,14 @@ expect Devices.none.with_mouse_button_down(Middle).mouse.middle
 expect !(Devices.none.with_mouse_button_down(Left).mouse.right)
 expect !(Devices.none.with_mouse_button_released(Left).mouse.left)
 expect !(Devices.none.with_mouse_button_down(Side).mouse.left)
+
+## The event record is stated directly, on either kind of snapshot.
+expect Devices.none.events == []
+expect Devices.none.with_events([KeyPressed(KeySpace), KeyReleased(KeySpace)]).events == [KeyPressed(KeySpace), KeyReleased(KeySpace)]
+expect Devices.empty.with_events([Text(97)]).events == [Text(97)]
+expect Devices.none.with_events_overflow(Bool.True).events_overflow
+expect !(Devices.none.with_events([Wheel({ x: 0, y: 1 })]).events_overflow)
+expect Devices.none.with_events([KeyPressed(KeyR)]).with_key_pressed(KeyR).key_pressed(KeyR)
 
 ## Text overflow is an ordinary flag on the sample, clear until stated.
 expect !(Devices.none.text_input_overflow)

--- a/types/Gamepad.roc
+++ b/types/Gamepad.roc
@@ -3,7 +3,10 @@
 ## The host samples up to four gamepads once per host cycle. Queries are pure
 ## and do not cross the host boundary or allocate.
 ## Button state uses the same bits as keyboard and mouse input: held is `1`,
-## pressed is `2`, released is `4`.
+## pressed is `2`, released is `4`. Unlike keyboard and mouse edges, which are
+## recorded from the window system's events, gamepad edges come from comparing
+## two consecutive samples: a button pressed and released between two cycles
+## is not seen. Hold a button for at least one cycle to be sure it registers.
 ##
 ## Resolve a `View` from the current `input.devices` during `update!`. Retaining
 ## a view also retains that snapshot's sampled lists.
@@ -78,11 +81,13 @@ Gamepad := [].{
 		button_up : View, Button -> Bool
 		button_up = |pad, button| !(pad.button_down(button))
 
-		## Whether a button was pressed during this input interval.
+		## Whether a button went from up to down between the previous sample and
+		## this one. Sampled, so a press and release inside one cycle is lost.
 		button_pressed : View, Button -> Bool
 		button_pressed = |pad, button| button_state(pad.snapshot, pad.gamepad, button, 2)
 
-		## Whether a button was released during this input interval.
+		## Whether a button went from down to up between the previous sample and
+		## this one, with the same caveat as `button_pressed`.
 		button_released : View, Button -> Bool
 		button_released = |pad, button| button_state(pad.snapshot, pad.gamepad, button, 4)
 
@@ -128,11 +133,13 @@ Gamepad := [].{
 	button_up : { buttons : List(U8), ..state }, Id, Button -> Bool
 	button_up = |snapshot, gamepad, button| !(button_down(snapshot, gamepad, button))
 
-	## Whether a button was pressed during this input interval.
+	## Whether a button went from up to down between the previous sample and
+	## this one. Sampled, so a press and release inside one cycle is lost.
 	button_pressed : { buttons : List(U8), ..state }, Id, Button -> Bool
 	button_pressed = |snapshot, gamepad, button| button_state(snapshot, gamepad, button, 2)
 
-	## Whether a button was released during this input interval.
+	## Whether a button went from down to up between the previous sample and
+	## this one, with the same caveat as `button_pressed`.
 	button_released : { buttons : List(U8), ..state }, Id, Button -> Bool
 	button_released = |snapshot, gamepad, button| button_state(snapshot, gamepad, button, 4)
 

--- a/types/Keys.roc
+++ b/types/Keys.roc
@@ -268,19 +268,23 @@ Keys := [].{
 			Raw(code) => code
 		}
 
-	## Check if a specific key is currently held down. Pass `host` directly.
+	## Check if a specific key is held down at the cycle boundary. A state
+	## sample. Pass `host` directly.
 	key_down : { keys : List(U8), ..state }, Key -> Bool
 	key_down = |host, key| key_state(host.keys, key, 1)
 
-	## Check if a specific key is currently not pressed (up). Pass `host` directly.
+	## Check if a specific key is up at the cycle boundary. Pass `host` directly.
 	key_up : { keys : List(U8), ..state }, Key -> Bool
 	key_up = |host, key| !(key_down(host, key))
 
-	## Check if a key was pressed during this input interval. Pass `host` directly.
+	## Check if a key was pressed at least once since the previous input. An
+	## interval event: a key tapped between two cycles is pressed and released
+	## in the next input and held in neither. Pass `host` directly.
 	key_pressed : { keys : List(U8), ..state }, Key -> Bool
 	key_pressed = |host, key| key_state(host.keys, key, 2)
 
-	## Check if a key was released during this input interval. Pass `host` directly.
+	## Check if a key was released at least once since the previous input. Pass
+	## `host` directly.
 	key_released : { keys : List(U8), ..state }, Key -> Bool
 	key_released = |host, key| key_state(host.keys, key, 4)
 

--- a/types/Keys.roc
+++ b/types/Keys.roc
@@ -143,13 +143,124 @@ Keys := [].{
 			ExitKey(key) => U64.to_i32_wrap(Keys.key_code(key))
 		}
 
-	## Validate and wrap a raw raylib key code.
+	## Validate a raw raylib key code and name it.
+	##
+	## A code with a named key decodes to that key, so a value that came from
+	## the host -- a `Devices.Event` -- pattern-matches on `KeyA` exactly as
+	## one written in the app does. A code in range with no name is `Raw`.
 	from_code : U64 -> Try(Key, [InvalidKeyCode, ..])
 	from_code = |code|
-		if code < key_count {
-			Ok(Raw(code))
-		} else {
-			Err(InvalidKeyCode)
+		match code {
+			4 => Ok(KeyAndroidBack)
+			5 => Ok(KeyAndroidMenu)
+			24 => Ok(KeyVolumeUp)
+			25 => Ok(KeyVolumeDown)
+			32 => Ok(KeySpace)
+			39 => Ok(KeyApostrophe)
+			44 => Ok(KeyComma)
+			45 => Ok(KeyMinus)
+			46 => Ok(KeyPeriod)
+			47 => Ok(KeySlash)
+			48 => Ok(Key0)
+			49 => Ok(Key1)
+			50 => Ok(Key2)
+			51 => Ok(Key3)
+			52 => Ok(Key4)
+			53 => Ok(Key5)
+			54 => Ok(Key6)
+			55 => Ok(Key7)
+			56 => Ok(Key8)
+			57 => Ok(Key9)
+			59 => Ok(KeySemicolon)
+			61 => Ok(KeyEqual)
+			65 => Ok(KeyA)
+			66 => Ok(KeyB)
+			67 => Ok(KeyC)
+			68 => Ok(KeyD)
+			69 => Ok(KeyE)
+			70 => Ok(KeyF)
+			71 => Ok(KeyG)
+			72 => Ok(KeyH)
+			73 => Ok(KeyI)
+			74 => Ok(KeyJ)
+			75 => Ok(KeyK)
+			76 => Ok(KeyL)
+			77 => Ok(KeyM)
+			78 => Ok(KeyN)
+			79 => Ok(KeyO)
+			80 => Ok(KeyP)
+			81 => Ok(KeyQ)
+			82 => Ok(KeyR)
+			83 => Ok(KeyS)
+			84 => Ok(KeyT)
+			85 => Ok(KeyU)
+			86 => Ok(KeyV)
+			87 => Ok(KeyW)
+			88 => Ok(KeyX)
+			89 => Ok(KeyY)
+			90 => Ok(KeyZ)
+			91 => Ok(KeyLeftBracket)
+			92 => Ok(KeyBackslash)
+			93 => Ok(KeyRightBracket)
+			96 => Ok(KeyGrave)
+			256 => Ok(KeyEscape)
+			257 => Ok(KeyEnter)
+			258 => Ok(KeyTab)
+			259 => Ok(KeyBackspace)
+			260 => Ok(KeyInsert)
+			261 => Ok(KeyDelete)
+			262 => Ok(KeyRight)
+			263 => Ok(KeyLeft)
+			264 => Ok(KeyDown)
+			265 => Ok(KeyUp)
+			266 => Ok(KeyPageUp)
+			267 => Ok(KeyPageDown)
+			268 => Ok(KeyHome)
+			269 => Ok(KeyEnd)
+			280 => Ok(KeyCapsLock)
+			281 => Ok(KeyScrollLock)
+			282 => Ok(KeyNumLock)
+			283 => Ok(KeyPrintScreen)
+			284 => Ok(KeyPause)
+			290 => Ok(KeyF1)
+			291 => Ok(KeyF2)
+			292 => Ok(KeyF3)
+			293 => Ok(KeyF4)
+			294 => Ok(KeyF5)
+			295 => Ok(KeyF6)
+			296 => Ok(KeyF7)
+			297 => Ok(KeyF8)
+			298 => Ok(KeyF9)
+			299 => Ok(KeyF10)
+			300 => Ok(KeyF11)
+			301 => Ok(KeyF12)
+			320 => Ok(KeyKp0)
+			321 => Ok(KeyKp1)
+			322 => Ok(KeyKp2)
+			323 => Ok(KeyKp3)
+			324 => Ok(KeyKp4)
+			325 => Ok(KeyKp5)
+			326 => Ok(KeyKp6)
+			327 => Ok(KeyKp7)
+			328 => Ok(KeyKp8)
+			329 => Ok(KeyKp9)
+			330 => Ok(KeyKpDecimal)
+			331 => Ok(KeyKpDivide)
+			332 => Ok(KeyKpMultiply)
+			333 => Ok(KeyKpSubtract)
+			334 => Ok(KeyKpAdd)
+			335 => Ok(KeyKpEnter)
+			336 => Ok(KeyKpEqual)
+			340 => Ok(KeyLeftShift)
+			341 => Ok(KeyLeftControl)
+			342 => Ok(KeyLeftAlt)
+			343 => Ok(KeyLeftSuper)
+			344 => Ok(KeyRightShift)
+			345 => Ok(KeyRightControl)
+			346 => Ok(KeyRightAlt)
+			347 => Ok(KeyRightSuper)
+			348 => Ok(KeyKbMenu)
+			_ => if code < key_count Ok(Raw(code)) else Err(InvalidKeyCode)
 		}
 
 	## raylib key code for a key (index into the snapshot key-state list).
@@ -279,7 +390,9 @@ Keys := [].{
 
 	## Check if a key was pressed at least once since the previous input. An
 	## interval event: a key tapped between two cycles is pressed and released
-	## in the next input and held in neither. Pass `host` directly.
+	## in the next input and held in neither. Coalesced per key; the ordered
+	## record with every press is `Devices.Snapshot.events`. Pass `host`
+	## directly.
 	key_pressed : { keys : List(U8), ..state }, Key -> Bool
 	key_pressed = |host, key| key_state(host.keys, key, 2)
 
@@ -291,7 +404,11 @@ Keys := [].{
 	expect key_code(KeyA) == 65
 	expect key_code(KeyEscape) == 256
 	expect key_code(KeyLeftShift) == 340
-	expect from_code(262) == Ok(Raw(262))
+	expect from_code(262) == Ok(KeyRight)
+	expect from_code(65) == Ok(KeyA)
+	expect from_code(0) == Ok(Raw(0))
+	expect from_code(key_code(KeyKbMenu)) == Ok(KeyKbMenu)
+	expect from_code(key_code(Raw(7))) == Ok(Raw(7))
 	expect from_code(key_count) == Err(InvalidKeyCode)
 	expect key_down({ keys: [7] }, Raw(0)) and key_pressed({ keys: [7] }, Raw(0)) and key_released({ keys: [7] }, Raw(0))
 

--- a/types/Mouse.roc
+++ b/types/Mouse.roc
@@ -1,10 +1,12 @@
-## Pointer state sampled into one host-cycle input.
+## Pointer state and button events for one host-cycle input.
 ##
 ## Pass `input.devices.mouse` directly to the pure position, movement, wheel,
 ## and button-state receivers.
 Mouse := [].{
 
-	## Mouse input sampled once at the start of the current frame.
+	## Mouse input for one cycle. Position, movement and the held bits are
+	## samples at the cycle boundary; the pressed and released bits and the
+	## wheel are events recorded since the previous input.
 	Snapshot := {
 		buttons : List(U8),
 		left : Bool,
@@ -25,11 +27,12 @@ Mouse := [].{
 		button_up : Snapshot, Button -> Bool
 		button_up = |mouse, button| Mouse.button_up(mouse, button)
 
-		## Whether a button was pressed during this input interval.
+		## Whether a button was pressed at least once since the previous input.
+		## A click that began and ended between two cycles still counts.
 		button_pressed : Snapshot, Button -> Bool
 		button_pressed = |mouse, button| Mouse.button_pressed(mouse, button)
 
-		## Whether a button was released during this input interval.
+		## Whether a button was released at least once since the previous input.
 		button_released : Snapshot, Button -> Bool
 		button_released = |mouse, button| Mouse.button_released(mouse, button)
 
@@ -41,7 +44,8 @@ Mouse := [].{
 		delta : Snapshot -> { x : F32, y : F32 }
 		delta = |mouse| Mouse.delta(mouse)
 
-		## Horizontal and vertical wheel movement for this input interval.
+		## Horizontal and vertical wheel movement since the previous input,
+		## every notch in the interval summed.
 		wheel_delta : Snapshot -> { x : F32, y : F32 }
 		wheel_delta = |mouse| Mouse.wheel_delta(mouse)
 	}
@@ -73,7 +77,8 @@ Mouse := [].{
 	delta : { delta_x : F32, delta_y : F32, ..state } -> { x : F32, y : F32 }
 	delta = |mouse| { x: mouse.delta_x, y: mouse.delta_y }
 
-	## Horizontal and vertical wheel movement retained for this input interval.
+	## Horizontal and vertical wheel movement since the previous input, every
+	## notch in the interval summed.
 	wheel_delta : { wheel_x : F32, wheel_y : F32, ..state } -> { x : F32, y : F32 }
 	wheel_delta = |mouse| { x: mouse.wheel_x, y: mouse.wheel_y }
 
@@ -103,11 +108,13 @@ Mouse := [].{
 	button_up : { buttons : List(U8), ..state }, Button -> Bool
 	button_up = |mouse, button| !(button_down(mouse, button))
 
-	## Check if a mouse button was pressed during this input interval.
+	## Check if a mouse button was pressed at least once since the previous
+	## input. A click that began and ended between two cycles still counts.
 	button_pressed : { buttons : List(U8), ..state }, Button -> Bool
 	button_pressed = |mouse, button| button_state(mouse.buttons, button, 2)
 
-	## Check if a mouse button was released during this input interval.
+	## Check if a mouse button was released at least once since the previous
+	## input.
 	button_released : { buttons : List(U8), ..state }, Button -> Bool
 	button_released = |mouse, button| button_state(mouse.buttons, button, 4)
 

--- a/types/Mouse.roc
+++ b/types/Mouse.roc
@@ -83,7 +83,12 @@ Mouse := [].{
 	wheel_delta = |mouse| { x: mouse.wheel_x, y: mouse.wheel_y }
 
 	## Standard mouse buttons sampled by the platform.
-	Button := [Left, Right, Middle, Side, Extra, Forward, Back]
+	Button := [Left, Right, Middle, Side, Extra, Forward, Back].{
+
+		## Compare two of these values, so a `Devices.Event` can be compared
+		## and a click can be matched against a remembered button.
+		is_eq : _
+	}
 
 	## Select hardware pointer samples or deterministic application-provided samples.
 	## Where pointer input comes from: `Hardware`, or a `Virtual` pointer whose
@@ -110,6 +115,8 @@ Mouse := [].{
 
 	## Check if a mouse button was pressed at least once since the previous
 	## input. A click that began and ended between two cycles still counts.
+	## Coalesced per button; the ordered record with every click and its
+	## position is `Devices.Snapshot.events`.
 	button_pressed : { buttons : List(U8), ..state }, Button -> Bool
 	button_pressed = |mouse, button| button_state(mouse.buttons, button, 2)
 


### PR DESCRIPTION
## Problem

The host promised interval events (`key_pressed`, `button_released`, `wheel_delta`: "during this input interval") but manufactured them from two level samples. `src/backend_raylib.zig` ran `nextInputState(previous, rl.IsKeyDown(key))` once per cycle and derived `pressed = down && !was_down`, `released = !down && was_down`; mouse buttons and gamepad buttons did the same.

raylib 6.0's GLFW platform (`rcore_desktop_glfw.c`) stores **levels, not queues**:

- `KeyCallback` does `currentKeyState[key] = 1` on `GLFW_PRESS` and `= 0` on `GLFW_RELEASE` (presses also go to a 16-entry `keyPressedQueue`; there is no release queue);
- `MouseButtonCallback` does `currentButtonState[button] = action`, no queue at all;
- `MouseScrollCallback` does `currentWheelMove = (Vector2){xoffset, yoffset}` -- it overwrites, it does not accumulate;
- `CharCallback` caps its queue at `MAX_CHAR_PRESSED_QUEUE` (16) per poll and drops the rest silently, and the host's `getTextInput` then silently truncated at 32;
- `PollInputEvents` copies current to previous and calls `glfwPollEvents()` once per frame, from `EndDrawing()`.

So a press+release, a release+press, or two wheel notches that landed between two polls collapsed into one level, and because the poll period is the frame time the loss was frame-timing dependent. `design.md` already forbade this: "A bounded event source either reports overflow explicitly or documents that it is intentionally lossy and what is coalesced... silently losing an edge or a message is not equivalent."

## Fix

**Host-owned recording fed by chained GLFW callbacks.** After `InitWindow`, the host installs its own `glfwSetKeyCallback` / `glfwSetMouseButtonCallback` / `glfwSetScrollCallback` / `glfwSetCharCallback` on the current GLFW context and keeps the callback each one returns, forwarding **every** event to raylib's original (so raylib's own state, its `keyRepeatInFrame`, and its exit-key handling inside `KeyCallback` are unchanged). The window comes from `glfwGetCurrentContext()` rather than `GetWindowHandle()`, because the latter returns the native HWND / NSWindow on two of the four targets. The four functions are declared as `extern fn` in `backend_raylib.zig` (still the sole `@cImport` boundary); all four vendored archives (linux-x64, linux-x64-wayland, macos universal, windows-x64) export them, verified with `nm`/`strings`. Callbacks run on the frame thread inside `glfwPollEvents`.

**Two views of the interval: the bits coalesce, the list does not.**

- `Devices.Snapshot.events : List(Devices.Event)` is the authoritative record: every `KeyPressed(Key)`, `KeyReleased(Key)`, `ButtonPressed(Button, {x, y})`, `ButtonReleased(Button, {x, y})`, `Wheel({x, y})` and `Text(U32)` in window-system delivery order across all four sources, with the pointer position each click landed at. Capacity 256 per interval; past that the rest are dropped and `Devices.Snapshot.events_overflow` is set. Auto-repeat is never recorded. A click's position is read inside the button callback with `rl.GetMousePosition()`: GLFW dispatches the motion events that precede a click before the click itself, and raylib's cursor-position callback has already applied its offset and scale, so it matches `mouse.position()` without re-deriving raylib's scaling (comment in `recordMouseButtonAction` / `raylibMousePosition`).
- The packed `keys` / `mouse.buttons` bits (`HELD`, `PRESSED`, `RELEASED`) are the coalesced convenience view: `HELD` is the level at the boundary, `PRESSED`/`RELEASED` are set if at least one press/release was recorded **or** the level changed. A tap between polls reads `PRESSED|RELEASED` with `HELD` clear; a release+re-press reads `HELD|RELEASED|PRESSED`. The per-key accumulators, the wheel sum and the text buffer keep recording when the list is full, so the coalesced view is complete even on an interval whose list overflowed. A level transition with no recorded edge (a scripted held-set change, or a missed callback) is logged into the list at derivation, so every bit has its event.
- Both are taken once per cycle, after both derivations, so an event and the bit it set never split across two inputs (`InputState.updateFromRaylib` / `updateHeadless`).

**Wire shape is flat.** The list crosses the ABI as `List({ kind : U8, code : U32, x : F32, y : F32 })` (`RocListWith(T, false)`, non-refcounted elements, built with `fromSlice` and transferred whole like `dropped`) and `Devices.events_from_raw` in the types package decodes it; the `kind` numbering is stated on both sides (`InputEventKind` in `backend_raylib.zig`, `event_from_raw` in `types/Devices.roc`). A `kind` or code the package cannot read is dropped, not a crash (documented; it can only come from a newer host). `Keys.from_code` now decodes to the named key a code has (`from_code(65) == Ok(KeyA)`; `Raw` only for unnamed codes) so a decoded event pattern-matches on `KeyPressed(KeyA)`, and `Mouse.Button` gains `is_eq` so events compare.

**Wheel:** every scroll event is summed into `wheel_delta` and is also its own `Wheel` entry in the list.

**Text:** the host records codepoints itself from the char callback into a 32-codepoint `text_input` buffer (raylib's 16-per-poll silent cap is bypassed); past 32 the rest are discarded and `Devices.Snapshot.text_input_overflow` is set. Every character is also a `Text` entry in the list, ordered relative to the key edges around it, up to the list's own cap. Scripted text reports overflow the same way. If no GLFW context exists (unreachable on the desktop platform; the host logs a warning) the old drain path is used and a full raylib queue is reported as an overflow.

**Gamepad:** raylib polls gamepads inside `PollInputEvents` with no callback, so gamepad edges stay derived from two samples, never appear in `events`, and are documented as intentionally lossy in `design.md`, `Gamepad.roc` (platform and types) and `Devices.roc`.

**Scripted input:** `Keys.set_source!`, `Mouse.set_source!`, `Keys.set_text!` and `--host-keys` / `--host-text` go through the same derivation and feed the same list -- a `~` tap (`3:ESCAPE~`, new syntax; `~` because it is inert unquoted in cmd, PowerShell, bash and zsh, whereas `^` is cmd's escape character and reached the host as nothing on Windows) as `KeyPressed` then `KeyReleased`, a held-set change as the edge it implies, typed text as `Text` in script order, a scripted wheel as `Wheel` -- through a separate virtual log, and each device (keyboard, mouse, text) takes events from its own source only, so hardware is shut out entirely while a script is that device's source.

**The guarantee now stated in `design.md`:** every key, mouse-button, scroll and character event that reaches the process is delivered in the next `Input`, in order, with count and (for clicks) position preserved up to the stated capacity, or reported as overflow -- never silently lost -- with a latency of at most one cycle. Gamepad buttons remain sampled and lossy and say so.

## Docs and design

- `design.md` "Input: `App.Input(msg)`": classification table with the `events` row and every other `devices` field as state sample / interval event / sampled edge with source, capacity and coalescing; the guarantee above; the bits-vs-list split; the scripted-keyboard note.
- Roc doc comments on `Devices.Snapshot` (every field, `Event`, `RawEvent`, `events_from_raw`, `with_events`, `with_events_overflow`, `with_text_input_overflow`), `Keys.key_pressed/released`, `Keys.from_code`, `Mouse.button_*`, `Mouse.wheel_delta`, `Mouse.Button`, `Gamepad.Snapshot` and `button_*`, `Keys.set_text!` in both `platform/` and `types/`, saying when to read the bits (simple held/pressed logic) and when the list (counts, order, drag/drop, text editing).
- `CONTRIBUTING.md`: the `--host-keys` tap suffix, and a paragraph on flat host-boundary shapes with the event record as the worked example and the checklist for a new `Devices.Snapshot` field.
- `examples/input_inspector` prints each cycle's event record to stdout (`events: KeyPressed(65) KeyReleased(65) ...`) and shows it on screen.
- `types/` changes (`Devices.Snapshot` fields, `Devices.Event`, `Keys.from_code`, `Mouse.Button.is_eq`) mean `roc-ray-types` needs a release before the platform is released (`.types-version` bump per `CONTRIBUTING.md`).
- No CHANGELOG file exists in the repo.

## Test evidence

Regression tests in tree. `backend_raylib.zig`: "events keep window-system delivery order across every source" (key, click, char, wheel, click, key interleaved), "the log keeps every tap where the bits keep one" (two taps -> four events, one `PRESSED|RELEASED`), "past the capacity the list reports overflow while the coalesced view keeps recording", "each device takes events from its own source and the rest are discarded", "a level transition with no recorded edge is logged so the list stays complete", "a click carries the pointer position read at the moment it fired", "a tap between two polls is pressed and released, never held", "a release and re-press between two polls is not one long hold", "recorded edges surface even when the level did not change", "GLFW key actions become edges, except repeats and unknown keys", "every event is forwarded to raylib's callback unchanged", "wheel notches inside one interval are summed, then consumed", "typed text past the interval's capacity is reported, not silently cut". `host_native.zig`: "a quiet cycle delivers no events and reports no overflow", "events are copied out in order and the list is released with the input" (real `RocHost` + testing allocator, modelled on the dropped-files tests, not `std.mem.zeroes`), "a scripted cycle's events reach the snapshot list in delivery order" (tap + text + held set through `applyInputScripts` -> `hostState`), "a scripted tap lands inside one cycle as a press and a release", "a ^ suffix scripts a tap rather than a hold", "scripted text is delivered once and its overflow is reported". `types/Devices.roc`: a decode `expect` per `Event` variant, unknown kind / out-of-range key and button codes, order preservation, the button table round trip, `with_events` on `none` and `empty`. `scripts/test_spec.json`: `pong/tapped-quit` (Escape tapped inside cycle 6, never held) and `input_inspector/events-in-order` (`3:A~+B~` + text `3:hi` must print `events: KeyPressed(65) KeyReleased(65) KeyPressed(66) KeyReleased(66) Text(104) Text(105)`, then the held Q `events: KeyPressed(81)`).

```
$ zig build                      -> exit 0 (all four targets)
$ zig build lint                 -> [OK] All tidy checks passed! / [OK] All lints passed!
$ zig build test                 -> Build Summary: 90/93 steps succeeded; 257/257 tests passed
                                    (2 python steps fail for environment reasons, see below)
$ scripts/roc_platform_abi.py --roc-repo ~/Documents/Github/roc --roc <nightly-2026-08-23-fb208ba> --check
                                 -> Verified generated ABI: src/roc_platform_abi.zig
$ roc check platform/main.roc            -> No errors found
$ roc check platform/main-wayland.roc    -> No errors found
$ roc fmt --check <9 changed .roc files + example> -> All formatting valid.
$ roc test types/Devices.roc     -> All (108) tests passed
$ roc test types/Keys.roc / types/Mouse.roc / types/Gamepad.roc -> 10 / 5 / 8 passed
$ roc test platform/Keys.roc / platform/Mouse.roc / platform/App.roc -> 16 / 6 / 104 passed
$ PATH=<nightly>:$PATH scripts/all_tests.py --only pong,input_inspector --skip-platform-build --skip-bundle-test --skip-interop-test --headless-frames 5
  roc fmt/check/test/build pong, input_inspector ... ok
  headless runs (5 frames) pong, input_inspector ... ok
  real hidden window: pong/sweep ok, pong/serves-and-quits ok, pong/tapped-quit ok,
                      input_inspector/sweep ok, input_inspector/types-and-quits ok,
                      input_inspector/events-in-order ok
  virtual keyboard probe (test/virtual_keys) ok; task delivery/cap, file write, udp, cmd, sqlite, http, model alloc ok
  All tests passed!
```

The two `zig build test` python-step failures are environmental, not from this change: `scripts/test_release_helpers.py` fails because `git commit` in its temp repos cannot GPG-sign in this session (`gpg: signing failed: Timeout`), and `scripts/test_app_transport_privacy.py` fails under `zig build test` because the pinned `roc` is not on that shell's PATH; run with the pinned nightly on PATH it passes all 12 fixtures.

## Open questions / release ordering

- **Release ordering:** this PR changes `types/` (new `Devices.Snapshot` fields, `Devices.Event`, `Keys.from_code` naming, `Mouse.Button.is_eq`), so `roc-ray-types` must be released first and `.types-version` bumped to the new pin; until then the "Release" workflow's "Build release bundles" job is expected to fail with `error: types/ has changed since the pinned roc-ray-types release.` -- that is the repo's intentional guard, not a defect in this PR.
- `--host-keys` / `--host-text` still only apply to windowed runs (`applyInputScripts` is not called from the headless loop); unchanged by this PR. The headless loop does take the event list from the virtual sources, so `Keys.set_source!` / `Keys.set_text!` from the app feed it headless too.
- The windowed sweep ran against the real display (`DISPLAY=:0`, hidden windows); no synthetic desktop input was injected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
