### PR TITLE
Game refactors

### DIFF
--- a/examples/breakout/Assets.roc
+++ b/examples/breakout/Assets.roc
@@ -1,0 +1,45 @@
+## Breakout sounds, fonts, and prepared text loaded during application startup.
+import rr.Audio
+import rr.Draw
+import rr.Text
+
+Assets := {
+	sounds : Sounds,
+	font : Text.Font,
+	title : Text.Prepared,
+	hint : Text.Prepared,
+	launch_line : Text.Prepared,
+	won_line : Text.Prepared,
+	over_line : Text.Prepared,
+	restart_line : Text.Prepared,
+}.{
+	Sounds : {
+		paddle : Audio.Sound,
+		brick : Audio.Sound,
+		wall : Audio.Sound,
+		lose : Audio.Sound,
+		start : Audio.Sound,
+	}
+
+	## Prepares all Breakout sounds, fonts, and text before the first frame.
+	load! : () => Try(Assets, [ResourceLimit, SoundGenerationFailed, ..])
+	load! = || {
+		font = Draw.default_font!()
+		Ok({
+			font,
+			title: Text.from("BREAKOUT", font).size(28).spacing(5).prepare!()?,
+			hint: Text.from("A / D  or  ARROWS  move    SPACE  launch    ESC  quit", font).size(17).prepare!()?,
+			launch_line: Text.from("PRESS SPACE TO LAUNCH", font).size(26).prepare!()?,
+			won_line: Text.from("WALL CLEARED", font).size(34).prepare!()?,
+			over_line: Text.from("GAME OVER", font).size(34).prepare!()?,
+			restart_line: Text.from("PRESS SPACE TO PLAY AGAIN", font).size(19).prepare!()?,
+			sounds: {
+				paddle: Audio.gen_tone!({ freq: 440, ms: 50 })?,
+				brick: Audio.gen_tone!({ freq: 760, ms: 45 })?,
+				wall: Audio.gen_tone!({ freq: 260, ms: 40 })?,
+				lose: Audio.gen_tone!({ freq: 140, ms: 180 })?,
+				start: Audio.gen_tone!({ freq: 520, ms: 70 })?,
+			},
+		})
+	}
+}

--- a/examples/breakout/Ball.roc
+++ b/examples/breakout/Ball.roc
@@ -1,0 +1,34 @@
+## Ball movement and geometry for Breakout.
+import rr.Math
+
+Ball := {
+	pos : Math.Vec2,
+	velocity : Math.Vec2,
+}.{
+	radius = 8.F32
+
+	ready_gap = 2.F32
+
+	bounce_gap = 1.F32
+
+	launch_velocity : Math.Vec2
+	launch_velocity = { x: 170, y: -340 }
+
+	## Places a newly launched ball just above the center of the paddle.
+	on : Math.Rect -> Ball
+	on = |paddle| {
+		pos: {
+			x: Math.center(paddle).x,
+			y: paddle.y - radius - ready_gap,
+		},
+		velocity: launch_velocity,
+	}
+
+	## Advances the ball along its current velocity for `dt` seconds.
+	move : Ball, F32 -> Ball
+	move = |ball, dt| { ..ball, pos: Math.add(ball.pos, Math.scale(ball.velocity, dt)) }
+
+	## Builds the circle used to test this ball against paddles and bricks.
+	circle : Ball -> Math.Circle
+	circle = |ball| Math.circle(ball.pos, radius)
+}

--- a/examples/breakout/Ball.roc
+++ b/examples/breakout/Ball.roc
@@ -1,18 +1,16 @@
 ## Ball movement and geometry for Breakout.
 import rr.Math
 
+ready_gap = 2.F32
+
+launch_velocity : Math.Vec2
+launch_velocity = { x: 170, y: -340 }
+
 Ball := {
 	pos : Math.Vec2,
 	velocity : Math.Vec2,
 }.{
 	radius = 8.F32
-
-	ready_gap = 2.F32
-
-	bounce_gap = 1.F32
-
-	launch_velocity : Math.Vec2
-	launch_velocity = { x: 170, y: -340 }
 
 	## Places a newly launched ball just above the center of the paddle.
 	on : Math.Rect -> Ball

--- a/examples/breakout/Bricks.roc
+++ b/examples/breakout/Bricks.roc
@@ -1,0 +1,97 @@
+## The authored brick wall and operations that change it.
+import rr.Color
+import rr.Math
+
+Bricks := [].{
+	Brick : {
+		id : U64,
+		rect : Math.Rect,
+		color : Color.Rgba,
+	}
+
+	Row := [Red, Orange, Yellow, Green, Blue]
+
+	left = 44.F32
+
+	top = 88.F32
+
+	width = 64.F32
+
+	height = 22.F32
+
+	gap = 8.F32
+
+	per_row = 10.U64
+
+	band_top = 84.F32
+
+	band_bottom = 236.F32
+
+	score = 10.U64
+
+	## Converts a named brick row into its zero-based vertical index.
+	row_index : Row -> U64
+	row_index = |row|
+		match row {
+			Red => 0
+			Orange => 1
+			Yellow => 2
+			Green => 3
+			Blue => 4
+		}
+
+	## Gives each brick row its arcade color.
+	row_color : Row -> Color.Rgba
+	row_color = |row|
+		match row {
+			Red => Color.from_hex_rgb(0xff4f7d)
+			Orange => Color.from_hex_rgb(0xff9f45)
+			Yellow => Color.from_hex_rgb(0xffe066)
+			Green => Color.from_hex_rgb(0x4ce0b3)
+			Blue => Color.from_hex_rgb(0x5a9dff)
+		}
+
+	## Builds the brick at one row and column of the authored wall.
+	brick_at : Row, U64 -> Brick
+	brick_at = |row, column| {
+		id: row_index(row) * per_row + column,
+		rect: Math.rect(
+			left + U64.to_f32(column) * (width + gap),
+			top + U64.to_f32(row_index(row)) * (height + gap),
+			width,
+			height,
+		),
+		color: row_color(row),
+	}
+
+	## Builds all ten bricks in one colored row.
+	row : Row -> List(Brick)
+	row = |kind| [
+		brick_at(kind, 0),
+		brick_at(kind, 1),
+		brick_at(kind, 2),
+		brick_at(kind, 3),
+		brick_at(kind, 4),
+		brick_at(kind, 5),
+		brick_at(kind, 6),
+		brick_at(kind, 7),
+		brick_at(kind, 8),
+		brick_at(kind, 9),
+	]
+
+	fresh : List(Brick)
+	fresh = List.concat(row(Red), List.concat(row(Orange), List.concat(row(Yellow), List.concat(row(Green), row(Blue)))))
+
+	## Finds the first brick touched by the ball, starting at `index`.
+	find_hit : List(Brick), Math.Circle, U64 -> Try(Brick, [NotFound])
+	find_hit = |bricks, ball, index|
+		match List.get(bricks, index) {
+			Ok(brick) =>
+				if Math.circle_rect(ball, brick.rect) Ok(brick) else find_hit(bricks, ball, index + 1)
+			Err(_) => Err(NotFound)
+		}
+
+	## Removes the brick hit by the ball from the remaining wall.
+	remove : List(Brick), Brick -> List(Brick)
+	remove = |bricks, hit| List.keep_if(bricks, |brick| brick.id != hit.id)
+}

--- a/examples/breakout/Bricks.roc
+++ b/examples/breakout/Bricks.roc
@@ -9,89 +9,96 @@ Bricks := [].{
 		color : Color.Rgba,
 	}
 
-	Row := [Red, Orange, Yellow, Green, Blue]
-
-	left = 44.F32
-
-	top = 88.F32
-
-	width = 64.F32
-
-	height = 22.F32
-
-	gap = 8.F32
-
-	per_row = 10.U64
-
-	band_top = 84.F32
-
-	band_bottom = 236.F32
-
 	score = 10.U64
-
-	## Converts a named brick row into its zero-based vertical index.
-	row_index : Row -> U64
-	row_index = |row|
-		match row {
-			Red => 0
-			Orange => 1
-			Yellow => 2
-			Green => 3
-			Blue => 4
-		}
-
-	## Gives each brick row its arcade color.
-	row_color : Row -> Color.Rgba
-	row_color = |row|
-		match row {
-			Red => Color.from_hex_rgb(0xff4f7d)
-			Orange => Color.from_hex_rgb(0xff9f45)
-			Yellow => Color.from_hex_rgb(0xffe066)
-			Green => Color.from_hex_rgb(0x4ce0b3)
-			Blue => Color.from_hex_rgb(0x5a9dff)
-		}
-
-	## Builds the brick at one row and column of the authored wall.
-	brick_at : Row, U64 -> Brick
-	brick_at = |row, column| {
-		id: row_index(row) * per_row + column,
-		rect: Math.rect(
-			left + U64.to_f32(column) * (width + gap),
-			top + U64.to_f32(row_index(row)) * (height + gap),
-			width,
-			height,
-		),
-		color: row_color(row),
-	}
-
-	## Builds all ten bricks in one colored row.
-	row : Row -> List(Brick)
-	row = |kind| [
-		brick_at(kind, 0),
-		brick_at(kind, 1),
-		brick_at(kind, 2),
-		brick_at(kind, 3),
-		brick_at(kind, 4),
-		brick_at(kind, 5),
-		brick_at(kind, 6),
-		brick_at(kind, 7),
-		brick_at(kind, 8),
-		brick_at(kind, 9),
-	]
-
 	fresh : List(Brick)
-	fresh = List.concat(row(Red), List.concat(row(Orange), List.concat(row(Yellow), List.concat(row(Green), row(Blue)))))
+	fresh = List.concat(build_row(Red), List.concat(build_row(Orange), List.concat(build_row(Yellow), List.concat(build_row(Green), build_row(Blue)))))
 
-	## Finds the first brick touched by the ball, starting at `index`.
-	find_hit : List(Brick), Math.Circle, U64 -> Try(Brick, [NotFound])
-	find_hit = |bricks, ball, index|
-		match List.get(bricks, index) {
-			Ok(brick) =>
-				if Math.circle_rect(ball, brick.rect) Ok(brick) else find_hit(bricks, ball, index + 1)
-			Err(_) => Err(NotFound)
+	## Finds the first brick touched by the ball.
+	find_hit : List(Brick), Math.Circle -> Try(Brick, [NotFound])
+	find_hit = |bricks, ball|
+		if ball.center.y + ball.radius < band_top or ball.center.y - ball.radius > band_bottom {
+			Err(NotFound)
+		} else {
+			find_hit_from(bricks, ball, 0)
 		}
 
 	## Removes the brick hit by the ball from the remaining wall.
 	remove : List(Brick), Brick -> List(Brick)
 	remove = |bricks, hit| List.keep_if(bricks, |brick| brick.id != hit.id)
 }
+
+Row := [Red, Orange, Yellow, Green, Blue]
+
+left = 44.F32
+
+top = 88.F32
+
+width = 64.F32
+
+height = 22.F32
+
+gap = 8.F32
+
+per_row = 10.U64
+
+band_top = 84.F32
+
+band_bottom = 236.F32
+
+## Converts a named brick row into its zero-based vertical index.
+row_index : Row -> U64
+row_index = |kind|
+	match kind {
+		Red => 0
+		Orange => 1
+		Yellow => 2
+		Green => 3
+		Blue => 4
+	}
+
+## Gives each brick row its arcade color.
+row_color : Row -> Color.Rgba
+row_color = |kind|
+	match kind {
+		Red => Color.from_hex_rgb(0xff4f7d)
+		Orange => Color.from_hex_rgb(0xff9f45)
+		Yellow => Color.from_hex_rgb(0xffe066)
+		Green => Color.from_hex_rgb(0x4ce0b3)
+		Blue => Color.from_hex_rgb(0x5a9dff)
+	}
+
+## Builds the brick at one row and column of the authored wall.
+brick_at : Row, U64 -> Bricks.Brick
+brick_at = |kind, column| {
+	id: row_index(kind) * per_row + column,
+	rect: Math.rect(
+		left + U64.to_f32(column) * (width + gap),
+		top + U64.to_f32(row_index(kind)) * (height + gap),
+		width,
+		height,
+	),
+	color: row_color(kind),
+}
+
+## Builds all ten bricks in one colored row.
+build_row : Row -> List(Bricks.Brick)
+build_row = |kind| [
+	brick_at(kind, 0),
+	brick_at(kind, 1),
+	brick_at(kind, 2),
+	brick_at(kind, 3),
+	brick_at(kind, 4),
+	brick_at(kind, 5),
+	brick_at(kind, 6),
+	brick_at(kind, 7),
+	brick_at(kind, 8),
+	brick_at(kind, 9),
+]
+
+## Recursively finds the first touched brick from one private list index.
+find_hit_from : List(Bricks.Brick), Math.Circle, U64 -> Try(Bricks.Brick, [NotFound])
+find_hit_from = |bricks, ball, index|
+	match List.get(bricks, index) {
+		Ok(brick) => if Math.circle_rect(ball, brick.rect) Ok(brick) else find_hit_from(bricks, ball, index + 1)
+		Err(_) => Err(NotFound)
+	}

--- a/examples/breakout/Game.roc
+++ b/examples/breakout/Game.roc
@@ -1,0 +1,165 @@
+## Pure Breakout state transitions and their significant gameplay events.
+import rr.Math
+import Ball
+import Bricks
+import Paddle
+
+Game := [].{
+	State := [Ready, Playing, Won, GameOver].{
+		is_eq : _
+	}
+
+	Controls : {
+		move : Paddle.Move,
+		action_pressed : Bool,
+		quit_pressed : Bool,
+	}
+
+	World : {
+		bricks : List(Bricks.Brick),
+		paddle : Paddle,
+		ball : Ball,
+		score : U64,
+		lives : U64,
+		state : State,
+	}
+
+	Event := [GameStarted, WallHit, PaddleHit, BrickHit(Bricks.Brick), LifeLost(State), WallCleared].{
+		is_eq : _
+	}
+
+	initial_lives = 3.U64
+
+	## Creates a ready-to-launch game with a fresh wall and three lives.
+	new_world : () -> World
+	new_world = || {
+		bricks: Bricks.fresh,
+		paddle: Paddle.initial,
+		ball: Ball.on(Paddle.initial.rect()),
+		score: 0,
+		lives: initial_lives,
+		state: Ready,
+	}
+
+	## Respawns the ball above the paddle that will launch it.
+	respawn_ball : World, Paddle -> World
+	respawn_ball = |world, paddle| {
+		..world,
+		paddle,
+		ball: Ball.on(paddle.rect()),
+	}
+
+	## Produces a single gameplay event only when its condition occurred.
+	event_when : Bool, Event -> List(Event)
+	event_when = |condition, event| if condition [event] else []
+
+	## Advances the current match state and reports its significant occurrences.
+	update : World, Controls, F32 -> (World, List(Event))
+	update = |world, controls, dt|
+		match world.state {
+			Ready => update_ready(world, controls, dt)
+			Playing => update_playing(world, controls, dt)
+			Won => update_finished(world, controls)
+			GameOver => update_finished(world, controls)
+		}
+
+	## Moves the waiting paddle and launches the attached ball on request.
+	update_ready : World, Controls, F32 -> (World, List(Event))
+	update_ready = |world, controls, dt| {
+		paddle = world.paddle.move(controls.move, dt)
+		ready_world = respawn_ball(world, paddle)
+
+		if controls.action_pressed {
+			({ ..ready_world, state: Playing }, [GameStarted])
+		} else {
+			(ready_world, [])
+		}
+	}
+
+	## Holds a finished match or replaces it with a fresh one on request.
+	update_finished : World, Controls -> (World, List(Event))
+	update_finished = |world, controls|
+		if controls.action_pressed (new_world(), [GameStarted]) else (world, [])
+
+	## Moves the ball and resolves life, wall, paddle, and brick interactions.
+	update_playing : World, Controls, F32 -> (World, List(Event))
+	update_playing = |world, controls, dt| {
+		paddle = world.paddle.move(controls.move, dt)
+		paddle_rect = paddle.rect()
+		candidate_ball = world.ball.move(dt)
+		lost_life = candidate_ball.pos.y - Ball.radius > 600
+
+		if lost_life {
+			next_lives = if world.lives > 0 world.lives - 1 else 0
+			next_state = if world.lives <= 1 GameOver else Ready
+			next_world = respawn_ball({ ..world, lives: next_lives, state: next_state }, paddle)
+			(next_world, [LifeLost(next_state)])
+		} else {
+			hit_left = candidate_ball.pos.x - Ball.radius < 0
+			hit_right = candidate_ball.pos.x + Ball.radius > 800
+			hit_top = candidate_ball.pos.y - Ball.radius < 58
+			hit_wall = hit_left or hit_right or hit_top
+
+			wall_ball : Ball
+			wall_ball = {
+				pos: {
+					x: if hit_left Ball.radius else if hit_right 800 - Ball.radius else candidate_ball.pos.x,
+					y: if hit_top 58 + Ball.radius else candidate_ball.pos.y,
+				},
+				velocity: {
+					x: if hit_left or hit_right world.ball.velocity.x * -1 else world.ball.velocity.x,
+					y: if hit_top world.ball.velocity.y * -1 else world.ball.velocity.y,
+				},
+			}
+
+			hit_paddle = wall_ball.velocity.y > 0 and Math.circle_rect(wall_ball.circle(), paddle_rect)
+			paddle_center = Math.center(paddle_rect).x
+			paddle_offset = Math.clamp((wall_ball.pos.x - paddle_center) / (Paddle.width * 0.5), -1, 1)
+			paddle_ball = if hit_paddle {
+				pos: { x: wall_ball.pos.x, y: Paddle.y - Ball.radius - Ball.bounce_gap },
+				velocity: {
+					x: paddle_offset * Paddle.bounce_speed,
+					y: F32.abs(wall_ball.velocity.y) * -1,
+				},
+			} else {
+				wall_ball
+			}
+
+			near_bricks = paddle_ball.pos.y + Ball.radius >= Bricks.band_top and paddle_ball.pos.y - Ball.radius <= Bricks.band_bottom
+			hit_result = if near_bricks Bricks.find_hit(world.bricks, paddle_ball.circle(), 0) else Err(NotFound)
+			collision_events = List.concat(event_when(hit_wall, WallHit), event_when(hit_paddle, PaddleHit))
+
+			match hit_result {
+				Ok(hit_brick) => {
+					remaining = Bricks.remove(world.bricks, hit_brick)
+					state = if List.len(remaining) == 0 Won else Playing
+					events = List.concat(collision_events, List.concat([BrickHit(hit_brick)], event_when(state == Won, WallCleared)))
+					(
+						{
+							..world,
+							bricks: remaining,
+							paddle,
+							ball: { ..paddle_ball, velocity: { x: paddle_ball.velocity.x, y: paddle_ball.velocity.y * -1 } },
+							score: world.score + Bricks.score,
+							state,
+						},
+						events,
+					)
+				}
+				Err(_) => ({ ..world, paddle, ball: paddle_ball, state: Playing }, collision_events)
+			}
+		}
+	}
+
+	## Converts the demo's ball tracking into the same controls as a player.
+	demo_controls : World -> Controls
+	demo_controls = |world| {
+		paddle_center = world.paddle.x + Paddle.width * 0.5
+		delta = world.ball.pos.x - paddle_center
+		{
+			move: if delta < -8 Left else if delta > 8 Right else Still,
+			action_pressed: world.state != Playing,
+			quit_pressed: Bool.False,
+		}
+	}
+}

--- a/examples/breakout/Game.roc
+++ b/examples/breakout/Game.roc
@@ -4,6 +4,8 @@ import Ball
 import Bricks
 import Paddle
 
+initial_lives = 3.U64
+
 Game := [].{
 	State := [Ready, Playing, Won, GameOver].{
 		is_eq : _
@@ -24,11 +26,7 @@ Game := [].{
 		state : State,
 	}
 
-	Event := [GameStarted, WallHit, PaddleHit, BrickHit(Bricks.Brick), LifeLost(State), WallCleared].{
-		is_eq : _
-	}
-
-	initial_lives = 3.U64
+	Event := [GameStarted, WallHit, PaddleHit, BrickHit(Bricks.Brick), LifeLost(State), WallCleared]
 
 	## Creates a ready-to-launch game with a fresh wall and three lives.
 	new_world : () -> World
@@ -41,18 +39,6 @@ Game := [].{
 		state: Ready,
 	}
 
-	## Respawns the ball above the paddle that will launch it.
-	respawn_ball : World, Paddle -> World
-	respawn_ball = |world, paddle| {
-		..world,
-		paddle,
-		ball: Ball.on(paddle.rect()),
-	}
-
-	## Produces a single gameplay event only when its condition occurred.
-	event_when : Bool, Event -> List(Event)
-	event_when = |condition, event| if condition [event] else []
-
 	## Advances the current match state and reports its significant occurrences.
 	update : World, Controls, F32 -> (World, List(Event))
 	update = |world, controls, dt|
@@ -62,104 +48,88 @@ Game := [].{
 			Won => update_finished(world, controls)
 			GameOver => update_finished(world, controls)
 		}
+}
 
-	## Moves the waiting paddle and launches the attached ball on request.
-	update_ready : World, Controls, F32 -> (World, List(Event))
-	update_ready = |world, controls, dt| {
-		paddle = world.paddle.move(controls.move, dt)
-		ready_world = respawn_ball(world, paddle)
+## Respawns the ball above the paddle that will launch it.
+respawn_ball : Game.World, Paddle -> Game.World
+respawn_ball = |world, paddle| {
+	..world,
+	paddle,
+	ball: Ball.on(paddle.rect()),
+}
 
-		if controls.action_pressed {
-			({ ..ready_world, state: Playing }, [GameStarted])
-		} else {
-			(ready_world, [])
+## Produces a single gameplay event only when its condition occurred.
+event_when : Bool, Game.Event -> List(Game.Event)
+event_when = |condition, event| if condition [event] else []
+
+## Moves the waiting paddle and launches the attached ball on request.
+update_ready : Game.World, Game.Controls, F32 -> (Game.World, List(Game.Event))
+update_ready = |world, controls, dt| {
+	paddle = world.paddle.move(controls.move, dt)
+	ready_world = respawn_ball(world, paddle)
+	if controls.action_pressed ({ ..ready_world, state: Playing }, [GameStarted]) else (ready_world, [])
+}
+
+## Holds a finished match or replaces it with a fresh one on request.
+update_finished : Game.World, Game.Controls -> (Game.World, List(Game.Event))
+update_finished = |world, controls| if controls.action_pressed (Game.new_world(), [GameStarted]) else (world, [])
+
+## Moves the ball and resolves life, wall, paddle, and brick interactions.
+update_playing : Game.World, Game.Controls, F32 -> (Game.World, List(Game.Event))
+update_playing = |world, controls, dt| {
+	paddle = world.paddle.move(controls.move, dt)
+	paddle_rect = paddle.rect()
+	candidate_ball = world.ball.move(dt)
+	lost_life = candidate_ball.pos.y - Ball.radius > 600
+
+	if lost_life {
+		next_lives = if world.lives > 0 world.lives - 1 else 0
+		next_state = if world.lives <= 1 GameOver else Ready
+		next_world = respawn_ball({ ..world, lives: next_lives, state: next_state }, paddle)
+		(next_world, [LifeLost(next_state)])
+	} else {
+		hit_left = candidate_ball.pos.x - Ball.radius < 0
+		hit_right = candidate_ball.pos.x + Ball.radius > 800
+		hit_top = candidate_ball.pos.y - Ball.radius < 58
+		hit_wall = hit_left or hit_right or hit_top
+
+		wall_ball : Ball
+		wall_ball = Ball.{
+			pos: {
+				x: if hit_left Ball.radius else if hit_right 800 - Ball.radius else candidate_ball.pos.x,
+				y: if hit_top 58 + Ball.radius else candidate_ball.pos.y,
+			},
+			velocity: {
+				x: if hit_left or hit_right world.ball.velocity.x * -1 else world.ball.velocity.x,
+				y: if hit_top world.ball.velocity.y * -1 else world.ball.velocity.y,
+			},
 		}
-	}
 
-	## Holds a finished match or replaces it with a fresh one on request.
-	update_finished : World, Controls -> (World, List(Event))
-	update_finished = |world, controls|
-		if controls.action_pressed (new_world(), [GameStarted]) else (world, [])
+		hit_paddle = wall_ball.velocity.y > 0 and Math.circle_rect(wall_ball.circle(), paddle_rect)
+		paddle_ball = if hit_paddle paddle.bounce(wall_ball) else wall_ball
 
-	## Moves the ball and resolves life, wall, paddle, and brick interactions.
-	update_playing : World, Controls, F32 -> (World, List(Event))
-	update_playing = |world, controls, dt| {
-		paddle = world.paddle.move(controls.move, dt)
-		paddle_rect = paddle.rect()
-		candidate_ball = world.ball.move(dt)
-		lost_life = candidate_ball.pos.y - Ball.radius > 600
+		hit_result = Bricks.find_hit(world.bricks, paddle_ball.circle())
+		collision_events = List.concat(event_when(hit_wall, WallHit), event_when(hit_paddle, PaddleHit))
 
-		if lost_life {
-			next_lives = if world.lives > 0 world.lives - 1 else 0
-			next_state = if world.lives <= 1 GameOver else Ready
-			next_world = respawn_ball({ ..world, lives: next_lives, state: next_state }, paddle)
-			(next_world, [LifeLost(next_state)])
-		} else {
-			hit_left = candidate_ball.pos.x - Ball.radius < 0
-			hit_right = candidate_ball.pos.x + Ball.radius > 800
-			hit_top = candidate_ball.pos.y - Ball.radius < 58
-			hit_wall = hit_left or hit_right or hit_top
-
-			wall_ball : Ball
-			wall_ball = {
-				pos: {
-					x: if hit_left Ball.radius else if hit_right 800 - Ball.radius else candidate_ball.pos.x,
-					y: if hit_top 58 + Ball.radius else candidate_ball.pos.y,
-				},
-				velocity: {
-					x: if hit_left or hit_right world.ball.velocity.x * -1 else world.ball.velocity.x,
-					y: if hit_top world.ball.velocity.y * -1 else world.ball.velocity.y,
-				},
+		match hit_result {
+			Ok(hit_brick) => {
+				remaining = Bricks.remove(world.bricks, hit_brick)
+				cleared = List.len(remaining) == 0
+				state = if cleared Won else Playing
+				events = List.concat(collision_events, List.concat([BrickHit(hit_brick)], event_when(cleared, WallCleared)))
+				(
+					{
+						..world,
+						bricks: remaining,
+						paddle,
+						ball: { ..paddle_ball, velocity: { x: paddle_ball.velocity.x, y: paddle_ball.velocity.y * -1 } },
+						score: world.score + Bricks.score,
+						state,
+					},
+					events,
+				)
 			}
-
-			hit_paddle = wall_ball.velocity.y > 0 and Math.circle_rect(wall_ball.circle(), paddle_rect)
-			paddle_center = Math.center(paddle_rect).x
-			paddle_offset = Math.clamp((wall_ball.pos.x - paddle_center) / (Paddle.width * 0.5), -1, 1)
-			paddle_ball = if hit_paddle {
-				pos: { x: wall_ball.pos.x, y: Paddle.y - Ball.radius - Ball.bounce_gap },
-				velocity: {
-					x: paddle_offset * Paddle.bounce_speed,
-					y: F32.abs(wall_ball.velocity.y) * -1,
-				},
-			} else {
-				wall_ball
-			}
-
-			near_bricks = paddle_ball.pos.y + Ball.radius >= Bricks.band_top and paddle_ball.pos.y - Ball.radius <= Bricks.band_bottom
-			hit_result = if near_bricks Bricks.find_hit(world.bricks, paddle_ball.circle(), 0) else Err(NotFound)
-			collision_events = List.concat(event_when(hit_wall, WallHit), event_when(hit_paddle, PaddleHit))
-
-			match hit_result {
-				Ok(hit_brick) => {
-					remaining = Bricks.remove(world.bricks, hit_brick)
-					state = if List.len(remaining) == 0 Won else Playing
-					events = List.concat(collision_events, List.concat([BrickHit(hit_brick)], event_when(state == Won, WallCleared)))
-					(
-						{
-							..world,
-							bricks: remaining,
-							paddle,
-							ball: { ..paddle_ball, velocity: { x: paddle_ball.velocity.x, y: paddle_ball.velocity.y * -1 } },
-							score: world.score + Bricks.score,
-							state,
-						},
-						events,
-					)
-				}
-				Err(_) => ({ ..world, paddle, ball: paddle_ball, state: Playing }, collision_events)
-			}
-		}
-	}
-
-	## Converts the demo's ball tracking into the same controls as a player.
-	demo_controls : World -> Controls
-	demo_controls = |world| {
-		paddle_center = world.paddle.x + Paddle.width * 0.5
-		delta = world.ball.pos.x - paddle_center
-		{
-			move: if delta < -8 Left else if delta > 8 Right else Still,
-			action_pressed: world.state != Playing,
-			quit_pressed: Bool.False,
+			Err(_) => ({ ..world, paddle, ball: paddle_ball, state: Playing }, collision_events)
 		}
 	}
 }

--- a/examples/breakout/Paddle.roc
+++ b/examples/breakout/Paddle.roc
@@ -1,20 +1,23 @@
 ## Paddle state, movement, and geometry for Breakout.
 import rr.Math
+import Ball
+
+width = 112.F32
+
+height = 16.F32
+
+y = 548.F32
+
+speed = 460.F32
+
+bounce_speed = 360.F32
+
+bounce_gap = 1.F32
 
 Paddle := { x : F32 }.{
 	Move := [Left, Right, Still].{
 		is_eq : _
 	}
-
-	width = 112.F32
-
-	height = 16.F32
-
-	y = 548.F32
-
-	speed = 460.F32
-
-	bounce_speed = 360.F32
 
 	initial : Paddle
 	initial = { x: (800 - width) * 0.5 }
@@ -34,5 +37,16 @@ Paddle := { x : F32 }.{
 			}
 
 		{ x: Math.clamp(paddle.x + amount * speed * dt, 0, 800 - width) }
+	}
+
+	## Rebounds a descending ball from this paddle using its contact offset.
+	bounce : Paddle, Ball -> Ball
+	bounce = |paddle, ball| {
+		paddle_rect = paddle.rect()
+		paddle_offset = Math.clamp((ball.pos.x - Math.center(paddle_rect).x) / (paddle_rect.width * 0.5), -1, 1)
+		Ball.{
+			pos: { x: ball.pos.x, y: paddle_rect.y - Ball.radius - bounce_gap },
+			velocity: { x: paddle_offset * bounce_speed, y: F32.abs(ball.velocity.y) * -1 },
+		}
 	}
 }

--- a/examples/breakout/Paddle.roc
+++ b/examples/breakout/Paddle.roc
@@ -1,0 +1,38 @@
+## Paddle state, movement, and geometry for Breakout.
+import rr.Math
+
+Paddle := { x : F32 }.{
+	Move := [Left, Right, Still].{
+		is_eq : _
+	}
+
+	width = 112.F32
+
+	height = 16.F32
+
+	y = 548.F32
+
+	speed = 460.F32
+
+	bounce_speed = 360.F32
+
+	initial : Paddle
+	initial = { x: (800 - width) * 0.5 }
+
+	## Builds the rectangle used to draw the paddle and collide with the ball.
+	rect : Paddle -> Math.Rect
+	rect = |paddle| Math.rect(paddle.x, y, width, height)
+
+	## Moves the paddle horizontally while keeping it inside the cabinet.
+	move : Paddle, Move, F32 -> Paddle
+	move = |paddle, direction, dt| {
+		amount =
+			match direction {
+				Left => -1
+				Right => 1
+				Still => 0
+			}
+
+		{ x: Math.clamp(paddle.x + amount * speed * dt, 0, 800 - width) }
+	}
+}

--- a/examples/breakout/Render.roc
+++ b/examples/breakout/Render.roc
@@ -1,0 +1,152 @@
+## Breakout assets and drawing, kept separate from its pure game rules.
+import rr.Audio
+import rr.Color
+import rr.Draw
+import rr.Math
+import rr.Text
+import Ball
+import Bricks
+import Game
+import Paddle
+
+Render := [].{
+	Sounds : {
+		paddle : Audio.Sound,
+		brick : Audio.Sound,
+		wall : Audio.Sound,
+		lose : Audio.Sound,
+		start : Audio.Sound,
+	}
+
+	Assets : {
+		sounds : Sounds,
+		font : Text.Font,
+		title : Text.Prepared,
+		hint : Text.Prepared,
+		launch_line : Text.Prepared,
+		won_line : Text.Prepared,
+		over_line : Text.Prepared,
+		restart_line : Text.Prepared,
+	}
+
+	## Prepares all Breakout sounds, fonts, and text before the first frame.
+	load! : () => Try(Assets, [ResourceLimit, SoundGenerationFailed, ..])
+	load! = || {
+		font = Draw.default_font!()
+		Ok({
+			font,
+			title: Text.from("BREAKOUT", font).size(28).spacing(5).prepare!()?,
+			hint: Text.from("A / D  or  ARROWS  move    SPACE  launch    ESC  quit", font).size(17).prepare!()?,
+			launch_line: Text.from("PRESS SPACE TO LAUNCH", font).size(26).prepare!()?,
+			won_line: Text.from("WALL CLEARED", font).size(34).prepare!()?,
+			over_line: Text.from("GAME OVER", font).size(34).prepare!()?,
+			restart_line: Text.from("PRESS SPACE TO PLAY AGAIN", font).size(19).prepare!()?,
+			sounds: {
+				paddle: Audio.gen_tone!({ freq: 440, ms: 50 })?,
+				brick: Audio.gen_tone!({ freq: 760, ms: 45 })?,
+				wall: Audio.gen_tone!({ freq: 260, ms: 40 })?,
+				lose: Audio.gen_tone!({ freq: 140, ms: 180 })?,
+				start: Audio.gen_tone!({ freq: 520, ms: 70 })?,
+			},
+		})
+	}
+
+	## Draws one complete Breakout presentation frame from the resulting world.
+	draw! : Draw.Frame, Assets, Game.World, F32, Bool => Try({}, [ScopeLimit, ..])
+	draw! = |frame, assets, world, elapsed, demo| {
+		frame.clear!(field_bottom)
+		draw_background!(frame)
+		draw_hud!(frame, assets, world, demo)
+		draw_bricks!(frame, world.bricks)
+		draw_glow!(frame, world)?
+		draw_bodies!(frame, world)
+		draw_state_overlay!(frame, assets, world, elapsed)
+		Ok({})
+	}
+
+	## Paints the dark vertical gradient behind the cabinet.
+	draw_background! : Draw.Frame => {}
+	draw_background! = |frame|
+		frame.rectangle_gradient_v!({ x: 0, y: 0, width: 800, height: 600, color_top: field_top, color_bottom: field_bottom })
+
+	## Draws additive neon halos behind the paddle and ball.
+	draw_glow! : Draw.Frame, Game.World => Try({}, [ScopeLimit, ..])
+	draw_glow! = |frame, world|
+		frame.with_blend_mode!(
+			Draw.additive_blend,
+			|glow_frame| {
+				glow_frame.circle_gradient!({ center: Math.center(world.paddle.rect()), radius: 90, color_inner: Color.with_alpha(paddle_neon, 95), color_outer: Color.with_alpha(paddle_neon, 0) })
+				glow_frame.circle_gradient!({ center: world.ball.pos, radius: 46, color_inner: Color.with_alpha(ball_neon, 95), color_outer: Color.with_alpha(ball_neon, 0) })
+				Ok({})
+			},
+		)
+
+	## Draws one colored brick with a bright top-edge sheen.
+	draw_brick! : Draw.Frame, Bricks.Brick => {}
+	draw_brick! = |frame, brick| {
+		frame.rounded_rectangle!({ x: brick.rect.x, y: brick.rect.y, width: brick.rect.width, height: brick.rect.height, radius: 0.28, segments: 6, style: Draw.filled(Color.with_alpha(brick.color, 235)) })
+		frame.rectangle!({ x: brick.rect.x + 5, y: brick.rect.y + 3, width: brick.rect.width - 10, height: 3, style: Draw.filled(Color.with_alpha(Color.white, 110)) })
+	}
+
+	## Draws every brick still remaining in the wall.
+	draw_bricks! : Draw.Frame, List(Bricks.Brick) => {}
+	draw_bricks! = |frame, bricks|
+		for brick in bricks {
+			draw_brick!(frame, brick)
+		}
+
+	## Draws the solid paddle and ball over their glows.
+	draw_bodies! : Draw.Frame, Game.World => {}
+	draw_bodies! = |frame, world| {
+		paddle = world.paddle.rect()
+		frame.rounded_rectangle!({ x: paddle.x, y: paddle.y, width: paddle.width, height: paddle.height, radius: 0.5, segments: 8, style: Draw.filled(paddle_neon) })
+		frame.rectangle!({ x: paddle.x + 8, y: paddle.y + 3, width: paddle.width - 16, height: 3, style: Draw.filled(Color.with_alpha(Color.white, 150)) })
+		frame.circle!({ center: world.ball.pos, radius: Ball.radius, style: Draw.filled(ball_neon) })
+		frame.circle!({ center: { x: world.ball.pos.x - 2, y: world.ball.pos.y - 2 }, radius: Ball.radius * 0.4, style: Draw.filled(Color.with_alpha(Color.white, 210)) })
+	}
+
+	## Draws the title, score, lives, boundary, controls hint, and optional FPS.
+	draw_hud! : Draw.Frame, Assets, Game.World, Bool => {}
+	draw_hud! = |frame, assets, world, demo| {
+		assets.title.draw!(frame, { pos: { x: 44, y: 22 }, color: paddle_neon })
+		frame.text!({ pos: { x: 330, y: 26 }, text: "SCORE ${U64.to_str(world.score)}", size: 22, spacing: Draw.default_spacing, color: hud_color, font: assets.font })
+		frame.text!({ pos: { x: 560, y: 26 }, text: "LIVES ${U64.to_str(world.lives)}", size: 22, spacing: Draw.default_spacing, color: hud_color, font: assets.font })
+		if demo {} else frame.fps!({ pos: { x: 730, y: 28 }, size: 18, color: hint_color })
+		frame.line!({ start: { x: 44, y: 58 }, end: { x: 756, y: 58 }, stroke: Draw.stroke(Color.from_hex_rgb(0x2a3566), 2) })
+		assets.hint.draw!(frame, { pos: { x: 400, y: 580 }, color: hint_color, align: (Middle, Center) })
+	}
+
+	## Pulses waiting-screen text between translucent and opaque.
+	prompt_alpha : F32 -> U8
+	prompt_alpha = |elapsed| F32.to_u8_wrap(150 + 105 * (0.5 + 0.5 * F32.sin(elapsed * 3.4)))
+
+	## Draws the launch prompt or the appropriate finished-match banner.
+	draw_state_overlay! : Draw.Frame, Assets, Game.World, F32 => {}
+	draw_state_overlay! = |frame, assets, world, elapsed|
+		match world.state {
+			Ready => assets.launch_line.draw!(frame, { pos: { x: 400, y: 350 }, color: Color.with_alpha(hud_color, prompt_alpha(elapsed)), align: (Middle, Center) })
+			Playing => {}
+			Won => draw_banner!(frame, assets, assets.won_line, Color.from_hex_rgb(0x4ce0b3), elapsed)
+			GameOver => draw_banner!(frame, assets, assets.over_line, Color.from_hex_rgb(0xff4f7d), elapsed)
+		}
+
+	## Draws a won or game-over panel with its restart prompt.
+	draw_banner! : Draw.Frame, Assets, Text.Prepared, Color.Rgba, F32 => {}
+	draw_banner! = |frame, assets, line, accent, elapsed| {
+		frame.rounded_rectangle!({ x: 190, y: 276, width: 420, height: 124, radius: 0.14, segments: 8, style: Draw.filled_and_outlined(Color.with_alpha(field_bottom, 232), Color.with_alpha(accent, 120), 2) })
+		line.draw!(frame, { pos: { x: 400, y: 318 }, color: accent, align: (Middle, Center) })
+		assets.restart_line.draw!(frame, { pos: { x: 400, y: 362 }, color: Color.with_alpha(hint_color, prompt_alpha(elapsed)), align: (Middle, Center) })
+	}
+}
+
+field_top = Color.from_hex_rgb(0x161d3c)
+
+field_bottom = Color.from_hex_rgb(0x05070f)
+
+paddle_neon = Color.from_hex_rgb(0x38e8ff)
+
+ball_neon = Color.from_hex_rgb(0xffe08a)
+
+hud_color = Color.from_hex_rgb(0xd7e3ff)
+
+hint_color = Color.from_hex_rgb(0x6d7aa8)

--- a/examples/breakout/Render.roc
+++ b/examples/breakout/Render.roc
@@ -1,55 +1,15 @@
-## Breakout assets and drawing, kept separate from its pure game rules.
-import rr.Audio
+## Breakout drawing derived from loaded assets and the resulting world.
 import rr.Color
 import rr.Draw
 import rr.Math
 import rr.Text
+import Assets
 import Ball
 import Bricks
 import Game
 import Paddle
 
 Render := [].{
-	Sounds : {
-		paddle : Audio.Sound,
-		brick : Audio.Sound,
-		wall : Audio.Sound,
-		lose : Audio.Sound,
-		start : Audio.Sound,
-	}
-
-	Assets : {
-		sounds : Sounds,
-		font : Text.Font,
-		title : Text.Prepared,
-		hint : Text.Prepared,
-		launch_line : Text.Prepared,
-		won_line : Text.Prepared,
-		over_line : Text.Prepared,
-		restart_line : Text.Prepared,
-	}
-
-	## Prepares all Breakout sounds, fonts, and text before the first frame.
-	load! : () => Try(Assets, [ResourceLimit, SoundGenerationFailed, ..])
-	load! = || {
-		font = Draw.default_font!()
-		Ok({
-			font,
-			title: Text.from("BREAKOUT", font).size(28).spacing(5).prepare!()?,
-			hint: Text.from("A / D  or  ARROWS  move    SPACE  launch    ESC  quit", font).size(17).prepare!()?,
-			launch_line: Text.from("PRESS SPACE TO LAUNCH", font).size(26).prepare!()?,
-			won_line: Text.from("WALL CLEARED", font).size(34).prepare!()?,
-			over_line: Text.from("GAME OVER", font).size(34).prepare!()?,
-			restart_line: Text.from("PRESS SPACE TO PLAY AGAIN", font).size(19).prepare!()?,
-			sounds: {
-				paddle: Audio.gen_tone!({ freq: 440, ms: 50 })?,
-				brick: Audio.gen_tone!({ freq: 760, ms: 45 })?,
-				wall: Audio.gen_tone!({ freq: 260, ms: 40 })?,
-				lose: Audio.gen_tone!({ freq: 140, ms: 180 })?,
-				start: Audio.gen_tone!({ freq: 520, ms: 70 })?,
-			},
-		})
-	}
 
 	## Draws one complete Breakout presentation frame from the resulting world.
 	draw! : Draw.Frame, Assets, Game.World, F32, Bool => Try({}, [ScopeLimit, ..])
@@ -63,80 +23,80 @@ Render := [].{
 		draw_state_overlay!(frame, assets, world, elapsed)
 		Ok({})
 	}
+}
 
-	## Paints the dark vertical gradient behind the cabinet.
-	draw_background! : Draw.Frame => {}
-	draw_background! = |frame|
-		frame.rectangle_gradient_v!({ x: 0, y: 0, width: 800, height: 600, color_top: field_top, color_bottom: field_bottom })
+## Paints the dark vertical gradient behind the cabinet.
+draw_background! : Draw.Frame => {}
+draw_background! = |frame|
+	frame.rectangle_gradient_v!({ x: 0, y: 0, width: 800, height: 600, color_top: field_top, color_bottom: field_bottom })
 
-	## Draws additive neon halos behind the paddle and ball.
-	draw_glow! : Draw.Frame, Game.World => Try({}, [ScopeLimit, ..])
-	draw_glow! = |frame, world|
-		frame.with_blend_mode!(
-			Draw.additive_blend,
-			|glow_frame| {
-				glow_frame.circle_gradient!({ center: Math.center(world.paddle.rect()), radius: 90, color_inner: Color.with_alpha(paddle_neon, 95), color_outer: Color.with_alpha(paddle_neon, 0) })
-				glow_frame.circle_gradient!({ center: world.ball.pos, radius: 46, color_inner: Color.with_alpha(ball_neon, 95), color_outer: Color.with_alpha(ball_neon, 0) })
-				Ok({})
-			},
-		)
+## Draws additive neon halos behind the paddle and ball.
+draw_glow! : Draw.Frame, Game.World => Try({}, [ScopeLimit, ..])
+draw_glow! = |frame, world|
+	frame.with_blend_mode!(
+		Draw.additive_blend,
+		|glow_frame| {
+			glow_frame.circle_gradient!({ center: Math.center(world.paddle.rect()), radius: 90, color_inner: Color.with_alpha(paddle_neon, 95), color_outer: Color.with_alpha(paddle_neon, 0) })
+			glow_frame.circle_gradient!({ center: world.ball.pos, radius: 46, color_inner: Color.with_alpha(ball_neon, 95), color_outer: Color.with_alpha(ball_neon, 0) })
+			Ok({})
+		},
+	)
 
-	## Draws one colored brick with a bright top-edge sheen.
-	draw_brick! : Draw.Frame, Bricks.Brick => {}
-	draw_brick! = |frame, brick| {
-		frame.rounded_rectangle!({ x: brick.rect.x, y: brick.rect.y, width: brick.rect.width, height: brick.rect.height, radius: 0.28, segments: 6, style: Draw.filled(Color.with_alpha(brick.color, 235)) })
-		frame.rectangle!({ x: brick.rect.x + 5, y: brick.rect.y + 3, width: brick.rect.width - 10, height: 3, style: Draw.filled(Color.with_alpha(Color.white, 110)) })
+## Draws one colored brick with a bright top-edge sheen.
+draw_brick! : Draw.Frame, Bricks.Brick => {}
+draw_brick! = |frame, brick| {
+	frame.rounded_rectangle!({ x: brick.rect.x, y: brick.rect.y, width: brick.rect.width, height: brick.rect.height, radius: 0.28, segments: 6, style: Draw.filled(Color.with_alpha(brick.color, 235)) })
+	frame.rectangle!({ x: brick.rect.x + 5, y: brick.rect.y + 3, width: brick.rect.width - 10, height: 3, style: Draw.filled(Color.with_alpha(Color.white, 110)) })
+}
+
+## Draws every brick still remaining in the wall.
+draw_bricks! : Draw.Frame, List(Bricks.Brick) => {}
+draw_bricks! = |frame, bricks|
+	for brick in bricks {
+		draw_brick!(frame, brick)
 	}
 
-	## Draws every brick still remaining in the wall.
-	draw_bricks! : Draw.Frame, List(Bricks.Brick) => {}
-	draw_bricks! = |frame, bricks|
-		for brick in bricks {
-			draw_brick!(frame, brick)
-		}
+## Draws the solid paddle and ball over their glows.
+draw_bodies! : Draw.Frame, Game.World => {}
+draw_bodies! = |frame, world| {
+	paddle = world.paddle.rect()
+	frame.rounded_rectangle!({ x: paddle.x, y: paddle.y, width: paddle.width, height: paddle.height, radius: 0.5, segments: 8, style: Draw.filled(paddle_neon) })
+	frame.rectangle!({ x: paddle.x + 8, y: paddle.y + 3, width: paddle.width - 16, height: 3, style: Draw.filled(Color.with_alpha(Color.white, 150)) })
+	frame.circle!({ center: world.ball.pos, radius: Ball.radius, style: Draw.filled(ball_neon) })
+	frame.circle!({ center: { x: world.ball.pos.x - 2, y: world.ball.pos.y - 2 }, radius: Ball.radius * 0.4, style: Draw.filled(Color.with_alpha(Color.white, 210)) })
+}
 
-	## Draws the solid paddle and ball over their glows.
-	draw_bodies! : Draw.Frame, Game.World => {}
-	draw_bodies! = |frame, world| {
-		paddle = world.paddle.rect()
-		frame.rounded_rectangle!({ x: paddle.x, y: paddle.y, width: paddle.width, height: paddle.height, radius: 0.5, segments: 8, style: Draw.filled(paddle_neon) })
-		frame.rectangle!({ x: paddle.x + 8, y: paddle.y + 3, width: paddle.width - 16, height: 3, style: Draw.filled(Color.with_alpha(Color.white, 150)) })
-		frame.circle!({ center: world.ball.pos, radius: Ball.radius, style: Draw.filled(ball_neon) })
-		frame.circle!({ center: { x: world.ball.pos.x - 2, y: world.ball.pos.y - 2 }, radius: Ball.radius * 0.4, style: Draw.filled(Color.with_alpha(Color.white, 210)) })
+## Draws the title, score, lives, boundary, controls hint, and optional FPS.
+draw_hud! : Draw.Frame, Assets, Game.World, Bool => {}
+draw_hud! = |frame, assets, world, demo| {
+	assets.title.draw!(frame, { pos: { x: 44, y: 22 }, color: paddle_neon })
+	frame.text!({ pos: { x: 330, y: 26 }, text: "SCORE ${U64.to_str(world.score)}", size: 22, spacing: Draw.default_spacing, color: hud_color, font: assets.font })
+	frame.text!({ pos: { x: 560, y: 26 }, text: "LIVES ${U64.to_str(world.lives)}", size: 22, spacing: Draw.default_spacing, color: hud_color, font: assets.font })
+	if demo {} else frame.fps!({ pos: { x: 730, y: 28 }, size: 18, color: hint_color })
+	frame.line!({ start: { x: 44, y: 58 }, end: { x: 756, y: 58 }, stroke: Draw.stroke(Color.from_hex_rgb(0x2a3566), 2) })
+	assets.hint.draw!(frame, { pos: { x: 400, y: 580 }, color: hint_color, align: (Middle, Center) })
+}
+
+## Pulses waiting-screen text between translucent and opaque.
+prompt_alpha : F32 -> U8
+prompt_alpha = |elapsed| F32.to_u8_wrap(150 + 105 * (0.5 + 0.5 * F32.sin(elapsed * 3.4)))
+
+## Draws the launch prompt or the appropriate finished-match banner.
+draw_state_overlay! : Draw.Frame, Assets, Game.World, F32 => {}
+draw_state_overlay! = |frame, assets, world, elapsed|
+	match world.state {
+		Ready => assets.launch_line.draw!(frame, { pos: { x: 400, y: 350 }, color: Color.with_alpha(hud_color, prompt_alpha(elapsed)), align: (Middle, Center) })
+		Playing => {}
+		Won => draw_banner!(frame, assets, assets.won_line, Color.from_hex_rgb(0x4ce0b3), elapsed)
+		GameOver => draw_banner!(frame, assets, assets.over_line, Color.from_hex_rgb(0xff4f7d), elapsed)
 	}
 
-	## Draws the title, score, lives, boundary, controls hint, and optional FPS.
-	draw_hud! : Draw.Frame, Assets, Game.World, Bool => {}
-	draw_hud! = |frame, assets, world, demo| {
-		assets.title.draw!(frame, { pos: { x: 44, y: 22 }, color: paddle_neon })
-		frame.text!({ pos: { x: 330, y: 26 }, text: "SCORE ${U64.to_str(world.score)}", size: 22, spacing: Draw.default_spacing, color: hud_color, font: assets.font })
-		frame.text!({ pos: { x: 560, y: 26 }, text: "LIVES ${U64.to_str(world.lives)}", size: 22, spacing: Draw.default_spacing, color: hud_color, font: assets.font })
-		if demo {} else frame.fps!({ pos: { x: 730, y: 28 }, size: 18, color: hint_color })
-		frame.line!({ start: { x: 44, y: 58 }, end: { x: 756, y: 58 }, stroke: Draw.stroke(Color.from_hex_rgb(0x2a3566), 2) })
-		assets.hint.draw!(frame, { pos: { x: 400, y: 580 }, color: hint_color, align: (Middle, Center) })
-	}
-
-	## Pulses waiting-screen text between translucent and opaque.
-	prompt_alpha : F32 -> U8
-	prompt_alpha = |elapsed| F32.to_u8_wrap(150 + 105 * (0.5 + 0.5 * F32.sin(elapsed * 3.4)))
-
-	## Draws the launch prompt or the appropriate finished-match banner.
-	draw_state_overlay! : Draw.Frame, Assets, Game.World, F32 => {}
-	draw_state_overlay! = |frame, assets, world, elapsed|
-		match world.state {
-			Ready => assets.launch_line.draw!(frame, { pos: { x: 400, y: 350 }, color: Color.with_alpha(hud_color, prompt_alpha(elapsed)), align: (Middle, Center) })
-			Playing => {}
-			Won => draw_banner!(frame, assets, assets.won_line, Color.from_hex_rgb(0x4ce0b3), elapsed)
-			GameOver => draw_banner!(frame, assets, assets.over_line, Color.from_hex_rgb(0xff4f7d), elapsed)
-		}
-
-	## Draws a won or game-over panel with its restart prompt.
-	draw_banner! : Draw.Frame, Assets, Text.Prepared, Color.Rgba, F32 => {}
-	draw_banner! = |frame, assets, line, accent, elapsed| {
-		frame.rounded_rectangle!({ x: 190, y: 276, width: 420, height: 124, radius: 0.14, segments: 8, style: Draw.filled_and_outlined(Color.with_alpha(field_bottom, 232), Color.with_alpha(accent, 120), 2) })
-		line.draw!(frame, { pos: { x: 400, y: 318 }, color: accent, align: (Middle, Center) })
-		assets.restart_line.draw!(frame, { pos: { x: 400, y: 362 }, color: Color.with_alpha(hint_color, prompt_alpha(elapsed)), align: (Middle, Center) })
-	}
+## Draws a won or game-over panel with its restart prompt.
+draw_banner! : Draw.Frame, Assets, Text.Prepared, Color.Rgba, F32 => {}
+draw_banner! = |frame, assets, line, accent, elapsed| {
+	frame.rounded_rectangle!({ x: 190, y: 276, width: 420, height: 124, radius: 0.14, segments: 8, style: Draw.filled_and_outlined(Color.with_alpha(field_bottom, 232), Color.with_alpha(accent, 120), 2) })
+	line.draw!(frame, { pos: { x: 400, y: 318 }, color: accent, align: (Middle, Center) })
+	assets.restart_line.draw!(frame, { pos: { x: 400, y: 362 }, color: Color.with_alpha(hint_color, prompt_alpha(elapsed)), align: (Middle, Center) })
 }
 
 field_top = Color.from_hex_rgb(0x161d3c)

--- a/examples/breakout/main.roc
+++ b/examples/breakout/main.roc
@@ -1,173 +1,41 @@
-## A complete Breakout game with keyboard controls, sound, and an automated
-## recording mode. Use Left/Right or A/D to move, Space to launch, and Escape
-## to quit. Pass `--record-demo` to create `examples/breakout/demo.gif`. The
-## example separates game rules from input, sound effects, and drawing.
+## Breakout: clear the brick wall before losing all three balls.
+##
+## Use A/D or Left/Right to move, Space to launch or restart, and Escape to
+## quit. Pass `--record-demo` to create `examples/breakout/demo.gif`.
+## File structure:
+##
+## - State (`Game.roc`): ball, paddle, remaining bricks, score, lives, and match
+## - Controls (`main.roc`): horizontal movement, launch/restart, and quit
+## - App wiring (`main.roc`): assets, recording, and event sounds
+## - Rendering (`Render.roc`): cabinet, brick wall, HUD, bodies, and prompts
+## - Gameplay (`Ball.roc`, `Paddle.roc`, `Bricks.roc`): motion and collisions
+## - Tests (`main.roc`): key mapping, launch, wall bounce, and last life lost
 app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
-import rr.Audio
-import rr.Color
 import rr.Capture
-import rr.Draw
 import rr.Devices
-import rr.Math
-import rr.Text
+import rr.Draw
+import Ball
+import Game
+import Render
 
-Brick : {
-	id : U64,
-	rect : Math.Rect,
-	color : Color.Rgba,
-}
-
-Ball : {
-	pos : Math.Vec2,
-	vel : Math.Vec2,
-}
-
-BrickRow := [RedRow, OrangeRow, YellowRow, GreenRow, BlueRow]
-
-PaddleMove := [PaddleLeft, PaddleRight, PaddleStill]
-
-GameState := [Ready, Playing, Won, GameOver].{
-	is_eq : _
-}
-
-StepEvent := [GameStarted, WallHit, BrickHit(Brick), LifeLost(GameState), WallCleared].{
-	is_eq : _
-}
-
-## The complete playable state. `advance` applies one pure game step and reports
-## events for `update!` to turn into sounds.
-Game := {
-	bricks : List(Brick),
-	paddle_x : F32,
-	ball : Ball,
-	score : U64,
-	lives : U64,
-	state : GameState,
-}.{
-	advance : Game, FrameInput -> StepResult
-	advance = |game, input|
-		match game.state {
-			Ready => advance_ready(game, input)
-			Playing => advance_playing(game, input)
-			Won => advance_finished(game, input)
-			GameOver => advance_finished(game, input)
-		}
-}
-
-Sounds : {
-	paddle : Audio.Sound,
-	brick : Audio.Sound,
-	wall : Audio.Sound,
-	lose : Audio.Sound,
-	start : Audio.Sound,
-}
-
-## The Model is the state retained between updates. It keeps the current game,
-## loaded sounds, recording-mode choice, animation time, and prepared text so
-## `render!` can draw without rebuilding resources every frame.
 Model : {
-	game : Game,
-	sounds : Sounds,
+	assets : Render.Assets,
+	world : Game.World,
 	demo : Bool,
-
-	## Presentation only. `elapsed` is wall-clock seconds, used to breathe the
-	## prompts; the rest is text the host measured once at startup.
 	elapsed : F32,
-	title : Text.Prepared,
-	hint : Text.Prepared,
-	launch_line : Text.Prepared,
-	won_line : Text.Prepared,
-	over_line : Text.Prepared,
-	restart_line : Text.Prepared,
-	font : Text.Font,
 }
 
-FrameInput : {
-	paddle_move : PaddleMove,
-	action_pressed : Bool,
-	dt : F32,
-}
-
-StepResult : {
-	game : Game,
-	events : List(StepEvent),
-	paddle_hit : Bool,
-}
+Controls : Game.Controls
 
 program = { init!, update!, render! }
 
-screen_w = 800.F32
-
-screen_h = 600.F32
-
-# --- Palette: a dark cabinet, a cyan paddle, a warm ball ---
-field_top : Color.Rgba
-field_top = Color.from_hex_rgb(0x161d3c)
-
-field_bottom : Color.Rgba
-field_bottom = Color.from_hex_rgb(0x05070f)
-
-paddle_neon : Color.Rgba
-paddle_neon = Color.from_hex_rgb(0x38e8ff)
-
-ball_neon : Color.Rgba
-ball_neon = Color.from_hex_rgb(0xffe08a)
-
-hud_color : Color.Rgba
-hud_color = Color.from_hex_rgb(0xd7e3ff)
-
-hint_color : Color.Rgba
-hint_color = Color.from_hex_rgb(0x6d7aa8)
-
-top_wall_y = 58.F32
-
-paddle_w = 112.F32
-
-paddle_h = 16.F32
-
-paddle_y = 548.F32
-
-paddle_speed = 460.F32
-
-paddle_bounce_speed = 360.F32
-
-ball_radius = 8.F32
-
-ball_ready_gap = 2.F32
-
-ball_bounce_gap = 1.F32
-
-launch_vx = 170.F32
-
-launch_vy = -340.F32
-
-brick_left = 44.F32
-
-brick_top = 88.F32
-
-brick_w = 64.F32
-
-brick_h = 22.F32
-
-brick_gap = 8.F32
-
-bricks_per_row = 10.U64
-
-brick_score = 10.U64
-
-brick_band_top = 84.F32
-
-brick_band_bottom = 236.F32
-
-initial_lives = 3.U64
+record_demo_flag = "--record-demo"
 
 demo_frames = 150.U64
 
-record_demo_flag : Str
-record_demo_flag = "--record-demo"
-
+## Selects an interactive window or a hidden fixed-step GIF recording.
 breakout_config : List(Str) -> App.Config
 breakout_config = |args| {
 	base = App.default.with_title("RocRay Breakout").with_frame_pacing(Capped(120))
@@ -190,325 +58,53 @@ breakout_config = |args| {
 	}
 }
 
+## Loads presentation assets and creates the first ready-to-launch world.
 init! : App.Init(Model, [ResourceLimit, SoundGenerationFailed])
 init! = App.init_for_args(
 	breakout_config,
 	|startup| {
-		font = Draw.default_font!()
-		Ok({
-			game: new_game_state(),
-			demo: List.contains(App.args!(startup), record_demo_flag),
-			elapsed: 0,
-			font: font,
-			title: Text.from("BREAKOUT", font).size(28).spacing(5).prepare!()?,
-			hint: Text.from("A / D  or  ARROWS  move    SPACE  launch    ESC  quit", font).size(17).prepare!()?,
-			launch_line: Text.from("PRESS SPACE TO LAUNCH", font).size(26).prepare!()?,
-			won_line: Text.from("WALL CLEARED", font).size(34).prepare!()?,
-			over_line: Text.from("GAME OVER", font).size(34).prepare!()?,
-			restart_line: Text.from("PRESS SPACE TO PLAY AGAIN", font).size(19).prepare!()?,
-			sounds: {
-				paddle: Audio.gen_tone!({ freq: 440, ms: 50 })?,
-				brick: Audio.gen_tone!({ freq: 760, ms: 45 })?,
-				wall: Audio.gen_tone!({ freq: 260, ms: 40 })?,
-				lose: Audio.gen_tone!({ freq: 140, ms: 180 })?,
-				start: Audio.gen_tone!({ freq: 520, ms: 70 })?,
-			},
-		})
+		demo = List.contains(App.args!(startup), record_demo_flag)
+		Ok({ assets: Render.load!()?, world: Game.new_world(), demo, elapsed: 0 })
 	},
 )
 
-start_paddle_x : F32
-start_paddle_x = (screen_w - paddle_w) * 0.5
-
-launch_ball : F32 -> Ball
-launch_ball = |paddle_x| {
-	pos: {
-		x: paddle_x + paddle_w * 0.5,
-		y: paddle_y - ball_radius - ball_ready_gap,
-	},
-	vel: { x: launch_vx, y: launch_vy },
-}
-
-new_game_state : () -> Game
-new_game_state = || {
-	bricks: fresh_bricks,
-	paddle_x: start_paddle_x,
-	ball: launch_ball(start_paddle_x),
-	score: 0,
-	lives: initial_lives,
-	state: Ready,
-}
-
-brick_row_index : BrickRow -> U64
-brick_row_index = |row|
-	match row {
-		RedRow => 0
-		OrangeRow => 1
-		YellowRow => 2
-		GreenRow => 3
-		BlueRow => 4
-	}
-
-brick_row_color : BrickRow -> Color.Rgba
-brick_row_color = |row|
-	match row {
-		RedRow => Color.from_hex_rgb(0xff4f7d)
-		OrangeRow => Color.from_hex_rgb(0xff9f45)
-		YellowRow => Color.from_hex_rgb(0xffe066)
-		GreenRow => Color.from_hex_rgb(0x4ce0b3)
-		BlueRow => Color.from_hex_rgb(0x5a9dff)
-	}
-
-brick_row_y : BrickRow -> F32
-brick_row_y = |row| brick_top + U64.to_f32(brick_row_index(row)) * (brick_h + brick_gap)
-
-brick_col_x : U64 -> F32
-brick_col_x = |col| brick_left + U64.to_f32(col) * (brick_w + brick_gap)
-
-brick_at : U64, F32, F32, Color.Rgba -> Brick
-brick_at = |id, x, y, color| {
-	id,
-	rect: Math.rect(x, y, brick_w, brick_h),
-	color,
-}
-
-brick_in_row : BrickRow, U64 -> Brick
-brick_in_row = |row, col| {
-	id = brick_row_index(row) * bricks_per_row + col
-	brick_at(id, brick_col_x(col), brick_row_y(row), brick_row_color(row))
-}
-
-brick_row : BrickRow -> List(Brick)
-brick_row = |row| [
-	brick_in_row(row, 0),
-	brick_in_row(row, 1),
-	brick_in_row(row, 2),
-	brick_in_row(row, 3),
-	brick_in_row(row, 4),
-	brick_in_row(row, 5),
-	brick_in_row(row, 6),
-	brick_in_row(row, 7),
-	brick_in_row(row, 8),
-	brick_in_row(row, 9),
-]
-
-fresh_bricks : List(Brick)
-fresh_bricks = List.concat(
-	brick_row(RedRow),
-	List.concat(
-		brick_row(OrangeRow),
-		List.concat(
-			brick_row(YellowRow),
-			List.concat(
-				brick_row(GreenRow),
-				brick_row(BlueRow),
-			),
-		),
-	),
-)
-
-paddle_move_from_input : Devices.Snapshot -> PaddleMove
-paddle_move_from_input = |input| {
-	left = input.key_down(KeyLeft) or input.key_down(KeyA)
-	right = input.key_down(KeyRight) or input.key_down(KeyD)
-
-	if left PaddleLeft else if right PaddleRight else PaddleStill
-}
-
-paddle_move_dir : PaddleMove -> F32
-paddle_move_dir = |move|
-	match move {
-		PaddleLeft => -1
-		PaddleRight => 1
-		PaddleStill => 0
-	}
-
-## The step's own `dt` is a parameter rather than something read off a frame,
-## because the caller decides how much time this step covers -- a fixed step can
-## be handed straight in, which a sampled frame could not express.
-frame_input : Devices.Snapshot, F32 -> FrameInput
-frame_input = |input, dt| {
-	paddle_move: paddle_move_from_input(input),
-	action_pressed: input.key_pressed(KeySpace),
-	dt,
-}
-
-## A demo follows the ball with the ordinary paddle movement rules. It starts
-## immediately and restarts after a life, while interactive play keeps using
-## the sampled keyboard input above.
-demo_frame_input : Game, F32 -> FrameInput
-demo_frame_input = |game, dt| {
-	paddle_center = game.paddle_x + paddle_w * 0.5
-	delta = game.ball.pos.x - paddle_center
-	paddle_move = if delta < -8 PaddleLeft else if delta > 8 PaddleRight else PaddleStill
+## Translates keyboard bindings into Breakout movement and button intentions.
+read_controls : Devices.Snapshot -> Controls
+read_controls = |devices| {
+	left = devices.key_down(KeyLeft) or devices.key_down(KeyA)
+	right = devices.key_down(KeyRight) or devices.key_down(KeyD)
 	{
-		paddle_move,
-		action_pressed: game.state != Playing,
-		dt,
+		move: if left Left else if right Right else Still,
+		action_pressed: devices.key_pressed(KeySpace),
+		quit_pressed: devices.key_pressed(KeyEscape),
 	}
 }
 
-paddle_rect : F32 -> Math.Rect
-paddle_rect = |paddle_x| Math.rect(paddle_x, paddle_y, paddle_w, paddle_h)
-
-move_paddle : F32, PaddleMove, F32 -> F32
-move_paddle = |paddle_x, move, dt|
-	Math.clamp(paddle_x + paddle_move_dir(move) * paddle_speed * dt, 0, screen_w - paddle_w)
-
-ball_circle : Ball -> Math.Circle
-ball_circle = |ball| Math.circle(ball.pos, ball_radius)
-
-move_ball : Ball, F32 -> Ball
-move_ball = |ball, dt| { ..ball, pos: Math.add(ball.pos, Math.scale(ball.vel, dt)) }
-
-ball_on_paddle : Game, F32, U64, GameState -> Game
-ball_on_paddle = |game, paddle_x, lives, state| {
-	..game,
-	paddle_x,
-	ball: launch_ball(paddle_x),
-	lives,
-	state,
-}
-
-event_when : Bool, StepEvent -> List(StepEvent)
-event_when = |condition, event| if condition [event] else []
-
-advance_ready : Game, FrameInput -> StepResult
-advance_ready = |game, input| {
-	paddle_x = move_paddle(game.paddle_x, input.paddle_move, input.dt)
-	ready_game = ball_on_paddle(game, paddle_x, game.lives, Ready)
-
-	if input.action_pressed {
-		{ game: { ..ready_game, state: Playing }, events: [GameStarted], paddle_hit: Bool.False }
-	} else {
-		{ game: ready_game, events: [], paddle_hit: Bool.False }
-	}
-}
-
-advance_finished : Game, FrameInput -> StepResult
-advance_finished = |game, input| {
-	if input.action_pressed {
-		{ game: new_game_state(), events: [GameStarted], paddle_hit: Bool.False }
-	} else {
-		{ game, events: [], paddle_hit: Bool.False }
-	}
-}
-
-find_hit_brick : List(Brick), Math.Circle, U64 -> Try(Brick, [NotFound])
-find_hit_brick = |bricks, ball_shape, index|
-	match List.get(bricks, index) {
-		Ok(brick) =>
-			if Math.circle_rect(ball_shape, brick.rect) {
-				Ok(brick)
-			} else {
-				find_hit_brick(bricks, ball_shape, index + 1)
-			}
-		Err(_) => Err(NotFound)
+## Interprets one pure gameplay event as its corresponding sound effect.
+play_event! : Render.Assets, Game.Event => {}
+play_event! = |assets, event|
+	match event {
+		GameStarted => assets.sounds.start.playback().play!()
+		WallHit => assets.sounds.wall.playback().play!()
+		PaddleHit => assets.sounds.paddle.playback().play!()
+		BrickHit(_) => assets.sounds.brick.playback().play!()
+		LifeLost(_) => assets.sounds.lose.playback().play!()
+		WallCleared => assets.sounds.start.playback().play!()
 	}
 
-advance_playing : Game, FrameInput -> StepResult
-advance_playing = |game, input| {
-	paddle_x = move_paddle(game.paddle_x, input.paddle_move, input.dt)
-	paddle = paddle_rect(paddle_x)
-	next_ball = move_ball(game.ball, input.dt)
-	lost_life = next_ball.pos.y - ball_radius > screen_h
-
-	if lost_life {
-		next_lives = if game.lives > 0 game.lives - 1 else 0
-		next_state = if game.lives <= 1 GameOver else Ready
-		{
-			game: ball_on_paddle(game, paddle_x, next_lives, next_state),
-			events: [LifeLost(next_state)],
-			paddle_hit: Bool.False,
-		}
-	} else {
-		hit_left = next_ball.pos.x - ball_radius < 0
-		hit_right = next_ball.pos.x + ball_radius > screen_w
-		hit_top = next_ball.pos.y - ball_radius < top_wall_y
-		hit_wall = hit_left or hit_right or hit_top
-
-		wall_pos = {
-			x: if hit_left ball_radius else if hit_right screen_w - ball_radius else next_ball.pos.x,
-			y: if hit_top top_wall_y + ball_radius else next_ball.pos.y,
-		}
-		wall_vel = {
-			x: if hit_left or hit_right game.ball.vel.x * -1 else game.ball.vel.x,
-			y: if hit_top game.ball.vel.y * -1 else game.ball.vel.y,
-		}
-		wall_ball = { pos: wall_pos, vel: wall_vel }
-
-		hit_paddle = wall_ball.vel.y > 0 and Math.circle_rect(ball_circle(wall_ball), paddle)
-		paddle_center = Math.center(paddle).x
-		paddle_offset = Math.clamp((wall_ball.pos.x - paddle_center) / (paddle_w * 0.5), -1, 1)
-		paddle_ball = if hit_paddle {
-			pos: { x: wall_ball.pos.x, y: paddle_y - ball_radius - ball_bounce_gap },
-			vel: {
-				x: paddle_offset * paddle_bounce_speed,
-				y: F32.abs(wall_ball.vel.y) * -1,
-			},
-		} else {
-			wall_ball
-		}
-
-		ball_shape = ball_circle(paddle_ball)
-		near_bricks = paddle_ball.pos.y + ball_radius >= brick_band_top and paddle_ball.pos.y - ball_radius <= brick_band_bottom
-		hit_result = if near_bricks find_hit_brick(game.bricks, ball_shape, 0) else Err(NotFound)
-		base_events = event_when(hit_wall, WallHit)
-
-		match hit_result {
-			Ok(hit_brick) => {
-				remaining = List.keep_if(game.bricks, |brick| brick.id != hit_brick.id)
-				state = if List.len(remaining) == 0 Won else Playing
-				events = List.concat(base_events, List.concat([BrickHit(hit_brick)], event_when(state == Won, WallCleared)))
-				{
-					game: {
-						..game,
-						bricks: remaining,
-						paddle_x,
-						ball: { ..paddle_ball, vel: { x: paddle_ball.vel.x, y: paddle_ball.vel.y * -1 } },
-						score: game.score + brick_score,
-						state,
-					},
-					events,
-					paddle_hit: hit_paddle,
-				}
-			}
-			Err(_) => {
-				game: { ..game, paddle_x, ball: paddle_ball, state: Playing },
-				events: base_events,
-				paddle_hit: hit_paddle,
-			}
-		}
-	}
-}
-
-## One sound per event, in the order the step produced them.
-##
-## `List.map` rather than a fold: every event makes exactly one sound, so the
-## playback list is the event list retyped, and two brick hits in one step stay
-## two brick sounds.
-step_event_sounds : Sounds, List(StepEvent) -> List(Audio.Playback)
-step_event_sounds = |sounds, events|
-	List.map(
-		events,
-		|event|
-			match event {
-				GameStarted => sounds.start.playback()
-				WallHit => sounds.wall.playback()
-				BrickHit(_) => sounds.brick.playback()
-				LifeLost(_) => sounds.lose.playback()
-				WallCleared => sounds.start.playback()
-			},
-	)
-
-## `Game.advance` is a pure step returning events, and the events name the
-## sounds they want; `update!` is where those sounds are played.
 Msg : []
 
+## Advances the world, plays its events, and handles quitting or recording end.
 update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
 update! = |model, program_input| {
-	input = program_input.devices
 	dt = program_input.time.elapsed_seconds
+	controls = if model.demo Game.demo_controls(model.world) else read_controls(program_input.devices)
+	(world, events) = Game.update(model.world, controls, dt)
+
+	for event in events {
+		play_event!(model.assets, event)
+	}
+
 	exit =
 		if model.demo {
 			match program_input.capture {
@@ -516,105 +112,43 @@ update! = |model, program_input| {
 				Failed(_) => Err(Exit(1))
 				_ => Ok({})
 			}
-		} else if input.key_pressed(KeyEscape) {
+		} else if controls.quit_pressed {
 			Err(Exit(0))
 		} else {
 			Ok({})
 		}
 
-	game_input = if model.demo demo_frame_input(model.game, dt) else frame_input(input, dt)
-	result = model.game.advance(game_input)
-	if result.paddle_hit {
-		model.sounds.paddle.play!()
-	}
-	for playback in step_event_sounds(model.sounds, result.events) {
-		playback.play!()
-	}
-
 	match exit {
 		Err(code) => Err(code)
-		Ok({}) => Ok({ ..model, game: result.game, elapsed: model.elapsed + dt })
+		Ok({}) => Ok({ ..model, world, elapsed: model.elapsed + dt })
 	}
 }
 
+## Delegates presentation of the retained world to the rendering module.
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ScopeLimit, ..])
-render! = |model, frame| {
-	game = model.game
-	frame.clear!(field_bottom)
-	frame.rectangle_gradient_v!({ x: 0, y: 0, width: screen_w, height: screen_h, color_top: field_top, color_bottom: field_bottom })
-	draw_hud!(frame, model)
-	draw_bricks!(frame, game.bricks)
+render! = |model, frame| Render.draw!(frame, model.assets, model.world, model.elapsed, model.demo)
 
-	# One additive scope for everything that emits light, so the halos add up
-	# rather than stacking as translucent grey.
-	frame.with_blend_mode!(
-		Draw.additive_blend,
-		|glow_frame| {
-			paddle = paddle_rect(game.paddle_x)
-			glow_frame.circle_gradient!({ center: Math.center(paddle), radius: 90, color_inner: Color.with_alpha(paddle_neon, 95), color_outer: Color.with_alpha(paddle_neon, 0) })
-			glow_frame.circle_gradient!({ center: game.ball.pos, radius: 46, color_inner: Color.with_alpha(ball_neon, 95), color_outer: Color.with_alpha(ball_neon, 0) })
-			Ok({})
-		},
-	)?
+no_controls : Controls
+no_controls = { move: Still, action_pressed: Bool.False, quit_pressed: Bool.False }
 
-	draw_bodies!(frame, game)
-	draw_state_overlay!(frame, model)
+expect read_controls(Devices.none.with_key_down(KeyLeft)).move == Left
 
-	Ok({})
+expect {
+	ready = Game.new_world()
+	(world, events) = Game.update(ready, { ..no_controls, action_pressed: Bool.True }, 0)
+	world.state == Playing and List.len(events) == 1
 }
 
-# Each brick is its own colour with a brighter sheen along the top edge, which
-# is what keeps a flat rectangle from reading as a flat rectangle.
-draw_brick! : Draw.Frame, Brick => {}
-draw_brick! = |frame, brick| {
-	frame.rounded_rectangle!({ x: brick.rect.x, y: brick.rect.y, width: brick.rect.width, height: brick.rect.height, radius: 0.28, segments: 6, style: Draw.filled(Color.with_alpha(brick.color, 235)) })
-	frame.rectangle!({ x: brick.rect.x + 5, y: brick.rect.y + 3, width: brick.rect.width - 10, height: 3, style: Draw.filled(Color.with_alpha(Color.white, 110)) })
+expect {
+	playing = { ..Game.new_world(), state: Playing }
+	ball = { ..playing.ball, pos: { ..playing.ball.pos, x: Ball.radius }, velocity: { x: -100, y: -100 } }
+	(world, events) = Game.update({ ..playing, ball }, no_controls, 0.1)
+	world.ball.velocity.x > 0 and List.len(events) == 1
 }
 
-draw_bricks! : Draw.Frame, List(Brick) => {}
-draw_bricks! = |frame, bricks| {
-	for brick in bricks {
-		draw_brick!(frame, brick)
-	}
-}
-
-draw_bodies! : Draw.Frame, Game => {}
-draw_bodies! = |frame, game| {
-	paddle = paddle_rect(game.paddle_x)
-	frame.rounded_rectangle!({ x: paddle.x, y: paddle.y, width: paddle.width, height: paddle.height, radius: 0.5, segments: 8, style: Draw.filled(paddle_neon) })
-	frame.rectangle!({ x: paddle.x + 8, y: paddle.y + 3, width: paddle.width - 16, height: 3, style: Draw.filled(Color.with_alpha(Color.white, 150)) })
-	frame.circle!({ center: game.ball.pos, radius: ball_radius, style: Draw.filled(ball_neon) })
-	frame.circle!({ center: { x: game.ball.pos.x - 2, y: game.ball.pos.y - 2 }, radius: ball_radius * 0.4, style: Draw.filled(Color.with_alpha(Color.white, 210)) })
-}
-
-draw_hud! : Draw.Frame, Model => {}
-draw_hud! = |frame, model| {
-	model.title.draw!(frame, { pos: { x: 44, y: 22 }, color: paddle_neon })
-	frame.text!({ pos: { x: 330, y: 26 }, text: "SCORE ${U64.to_str(model.game.score)}", size: 22, spacing: Draw.default_spacing, color: hud_color, font: model.font })
-	frame.text!({ pos: { x: 560, y: 26 }, text: "LIVES ${U64.to_str(model.game.lives)}", size: 22, spacing: Draw.default_spacing, color: hud_color, font: model.font })
-	if model.demo {} else frame.fps!({ pos: { x: 730, y: 28 }, size: 18, color: hint_color })
-	frame.line!({ start: { x: 44, y: top_wall_y }, end: { x: screen_w - 44, y: top_wall_y }, stroke: Draw.stroke(Color.from_hex_rgb(0x2a3566), 2) })
-	model.hint.draw!(frame, { pos: { x: screen_w * 0.5, y: screen_h - 20 }, color: hint_color, align: (Middle, Center) })
-}
-
-# A prompt that fades in and out on its own clock, so a waiting screen still has
-# a heartbeat.
-prompt_alpha : Model -> U8
-prompt_alpha = |model| F32.to_u8_wrap(150 + 105 * (0.5 + 0.5 * F32.sin(model.elapsed * 3.4)))
-
-draw_state_overlay! : Draw.Frame, Model => {}
-draw_state_overlay! = |frame, model|
-	match model.game.state {
-		Ready =>
-			model.launch_line.draw!(frame, { pos: { x: screen_w * 0.5, y: 350 }, color: Color.with_alpha(hud_color, prompt_alpha(model)), align: (Middle, Center) })
-		Playing => {}
-		Won => draw_banner!(frame, model, model.won_line, Color.from_hex_rgb(0x4ce0b3))
-		GameOver => draw_banner!(frame, model, model.over_line, Color.from_hex_rgb(0xff4f7d))
-	}
-
-draw_banner! : Draw.Frame, Model, Text.Prepared, Color.Rgba => {}
-draw_banner! = |frame, model, line, accent| {
-	frame.rounded_rectangle!({ x: 190, y: 276, width: 420, height: 124, radius: 0.14, segments: 8, style: Draw.filled_and_outlined(Color.with_alpha(field_bottom, 232), Color.with_alpha(accent, 120), 2) })
-	line.draw!(frame, { pos: { x: screen_w * 0.5, y: 318 }, color: accent, align: (Middle, Center) })
-	model.restart_line.draw!(frame, { pos: { x: screen_w * 0.5, y: 362 }, color: Color.with_alpha(hint_color, prompt_alpha(model)), align: (Middle, Center) })
+expect {
+	playing = { ..Game.new_world(), state: Playing, lives: 1 }
+	ball = { ..playing.ball, pos: { ..playing.ball.pos, y: 610 } }
+	(world, events) = Game.update({ ..playing, ball }, no_controls, 0)
+	world.state == GameOver and world.lives == 0 and List.len(events) == 1
 }

--- a/examples/breakout/main.roc
+++ b/examples/breakout/main.roc
@@ -17,9 +17,11 @@ import rr.App
 import rr.Capture
 import rr.Devices
 import rr.Draw
+import rr.Math
 import Assets
 import Ball
 import Game
+import Paddle
 import Render
 
 Model : {
@@ -82,6 +84,21 @@ read_controls = |devices| {
 	}
 }
 
+## Converts demo ball tracking into the same semantic controls as a player.
+demo_controls : Game.World -> Controls
+demo_controls = |world| {
+	paddle_center = Math.center(world.paddle.rect()).x
+	delta = world.ball.pos.x - paddle_center
+	{
+		move: if delta < -8 Left else if delta > 8 Right else Still,
+		action_pressed: match world.state {
+			Playing => Bool.False
+			_ => Bool.True
+		},
+		quit_pressed: Bool.False,
+	}
+}
+
 ## Interprets one pure gameplay event as its corresponding sound effect.
 play_event! : Assets, Game.Event => {}
 play_event! = |assets, event|
@@ -100,7 +117,7 @@ Msg : []
 update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
 update! = |model, program_input| {
 	dt = program_input.time.elapsed_seconds
-	controls = if model.demo Game.demo_controls(model.world) else read_controls(program_input.devices)
+	controls = if model.demo demo_controls(model.world) else read_controls(program_input.devices)
 	(world, events) = Game.update(model.world, controls, dt)
 
 	for event in events {

--- a/examples/breakout/main.roc
+++ b/examples/breakout/main.roc
@@ -6,7 +6,8 @@
 ##
 ## - State (`Game.roc`): ball, paddle, remaining bricks, score, lives, and match
 ## - Controls (`main.roc`): horizontal movement, launch/restart, and quit
-## - App wiring (`main.roc`): assets, recording, and event sounds
+## - Assets (`Assets.roc`): sounds, font, and prepared interface text
+## - App wiring (`main.roc`): recording and event sounds
 ## - Rendering (`Render.roc`): cabinet, brick wall, HUD, bodies, and prompts
 ## - Gameplay (`Ball.roc`, `Paddle.roc`, `Bricks.roc`): motion and collisions
 ## - Tests (`main.roc`): key mapping, launch, wall bounce, and last life lost
@@ -16,12 +17,13 @@ import rr.App
 import rr.Capture
 import rr.Devices
 import rr.Draw
+import Assets
 import Ball
 import Game
 import Render
 
 Model : {
-	assets : Render.Assets,
+	assets : Assets,
 	world : Game.World,
 	demo : Bool,
 	elapsed : F32,
@@ -64,7 +66,7 @@ init! = App.init_for_args(
 	breakout_config,
 	|startup| {
 		demo = List.contains(App.args!(startup), record_demo_flag)
-		Ok({ assets: Render.load!()?, world: Game.new_world(), demo, elapsed: 0 })
+		Ok({ assets: Assets.load!()?, world: Game.new_world(), demo, elapsed: 0 })
 	},
 )
 
@@ -81,7 +83,7 @@ read_controls = |devices| {
 }
 
 ## Interprets one pure gameplay event as its corresponding sound effect.
-play_event! : Render.Assets, Game.Event => {}
+play_event! : Assets, Game.Event => {}
 play_event! = |assets, event|
 	match event {
 		GameStarted => assets.sounds.start.playback().play!()

--- a/examples/pong/main.roc
+++ b/examples/pong/main.roc
@@ -1,8 +1,16 @@
 ## Play Pong against a computer-controlled right paddle.
 ##
-## Use W and S to move, Space to serve or start a new match, and Escape to quit.
-## This example shows frame-rate-independent movement, separating game rules
-## from sound effects, and seeded random serves that can be reproduced.
+## Use W and S to move, Space to start a new match after game over, and Escape
+## to quit. This example shows semantic controls, separate assets and world
+## state, gameplay events, and seeded random serves that can be reproduced.
+## File structure:
+##
+## - State: sounds and text plus the ball, paddles, scores, trail, and serve RNG
+## - Controls: W/S movement, Space restart, and Escape quit
+## - App wiring: loads assets, advances each cycle, and plays event sounds
+## - Rendering: draws the neon court, scores, ball trail, and win banner
+## - Gameplay: pure rules that move paddles, bounce the ball, and report hits and points
+## - Tests: checks key mapping, wall bounces, scoring, and match restart
 app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.Draw
@@ -14,50 +22,66 @@ import rr.App
 import rr.Math
 import rr.Text
 
-## State kept between updates: ball and paddle movement, scores, visual effects,
-## prepared text and sounds, and the random generator used for serves. Keeping
-## both game state and short-lived presentation details here lets `render!`
-## draw the latest result without changing the game.
-Model := {
-	ball_x : F32,
-	ball_y : F32,
-	ball_vx : F32,
-	ball_vy : F32,
-	left_y : F32,
-	right_y : F32,
-	left_score : U64,
-	right_score : U64,
-	# Sound handles, generated once in init! and preserved across restarts.
+## Host resources loaded once at startup and retained for drawing and sound.
+## Keeping them outside `World` lets the game rules operate only on ordinary
+## gameplay data.
+Assets : {
 	hit_sound : Audio.Sound,
 	wall_sound : Audio.Sound,
 	score_sound : Audio.Sound,
 	font : Text.Font,
+	hint : Text.Prepared,
+	digits : List(Text.Prepared),
+	win_lines : List(Text.Prepared),
+	restart_line : Text.Prepared,
+}
+
+## Dynamic game and presentation state advanced by the pure game step.
+Ball : {
+	pos : Math.Vec2,
+	velocity : Math.Vec2,
+}
+
+Player : {
+	paddle_y : F32,
+	score : U64,
+}
+
+World : {
+	ball : Ball,
+	left : Player,
+	right : Player,
 
 	## Presentation state, advanced by the same pure step as the rules.
 	## `trail` is the ball's recent positions, newest first; `flash` decays from
 	## 1 to 0 after a hit or a point and tints a full-screen additive wash.
 	trail : List(Math.Vec2),
-	flash : F32,
-	flash_color : Color.Rgba,
-
-	## Text measured once in `init!`: the HUD hint and one glyph per reachable
-	## score, so no frame pays to lay out a digit that never changes.
-	hint : Text.Prepared,
-	digits : List(Text.Prepared),
-
-	## Index 0 is the left player's banner, index 1 the right player's.
-	win_lines : List(Text.Prepared),
-	restart_line : Text.Prepared,
+	flash : {
+		intensity : F32,
+		color : Color.Rgba,
+	},
 
 	## Simulation randomness lives in the model, so a serve is drawn on the
 	## frame that needs it and a run replays exactly from its seed.
 	rng : Random.State,
-}.{
-
-	## The match ends as soon as either score reaches the winning score.
-	is_over : Model -> Bool
-	is_over = |model| model.left_score >= win_score or model.right_score >= win_score
 }
+
+## The application owns both host resources and the complete changing world.
+Model := {
+	assets : Assets,
+	world : World,
+}
+
+## Gameplay sees intentions, not the keys currently bound to them.
+Controls : {
+	move : F32,
+	new_match_pressed : Bool,
+	quit_pressed : Bool,
+}
+
+## The match ends as soon as either score reaches the winning score.
+is_over : World -> Bool
+is_over = |world| world.left.score >= win_score or world.right.score >= win_score
 
 # --- Constants (screen is 800x600; speeds in pixels/second) ---
 screen_w = 800.F32
@@ -122,29 +146,35 @@ right_paddle = |y| Math.rect(screen_w - paddle_margin - paddle_w, y, paddle_w, p
 ball_circle : F32, F32 -> Math.Circle
 ball_circle = |x, y| Math.circle({ x, y }, ball_r)
 
-# A fresh round: ball centred, scores zeroed, served in a random direction.
-# Sound handles are carried over from the previous model (generated once).
-new_round : Model -> Model
-new_round = |model| {
+# A fresh match: ball centred, scores zeroed, served in a random direction.
+new_match : World -> World
+new_match = |world| {
 	# Direction then speed, drawn in that order from one generator, so the
 	# sequence is the same every time a given seed replays.
-	direction = Random.step(model.rng, Random.bounded_i32(0, 1))
+	direction = Random.step(world.rng, Random.bounded_i32(0, 1))
 	serve = random_serve_vy(direction.state)
 	{
-		..model,
-		ball_x: screen_w * 0.5,
-		ball_y: screen_h * 0.5,
-		ball_vx: if direction.value == 0 (init_vx * -1) else init_vx,
-		ball_vy: serve.value,
+		..world,
+		ball: {
+			pos: { x: screen_w * 0.5, y: screen_h * 0.5 },
+			velocity: {
+				x: if direction.value == 0 (init_vx * -1) else init_vx,
+				y: serve.value,
+			},
+		},
 		rng: serve.state,
-		left_y: 250,
-		right_y: 250,
-		left_score: 0,
-		right_score: 0,
+		left: { paddle_y: 250, score: 0 },
+		right: { paddle_y: 250, score: 0 },
 		trail: [],
-		flash: 0,
-		flash_color: ball_neon,
+		flash: { intensity: 0, color: ball_neon },
 	}
+}
+
+read_controls : Devices.Snapshot -> Controls
+read_controls = |devices| {
+	move: if devices.key_down(KeyW) -1 else if devices.key_down(KeyS) 1 else 0,
+	new_match_pressed: devices.key_pressed(KeySpace),
+	quit_pressed: devices.key_pressed(KeyEscape),
 }
 
 # The trail is sampled by distance, not by frame: at 240 frames a second a
@@ -158,20 +188,13 @@ push_trail = |trail, pos|
 		_ => List.take_first(List.prepend(trail, pos), trail_length)
 	}
 
-# The playback for a sound that should only be heard when `cond` is true.
-#
-# An empty list is the no-op: nothing plays, and the caller can concatenate it
-# unconditionally instead of branching around it.
-play_if : Bool, Audio.Sound -> List(Audio.Playback)
-play_if = |cond, sound| if cond [sound.playback()] else []
-
 program = { init!, update!, render! }
 
 init! : App.Init(Model, [ResourceLimit, SoundGenerationFailed])
 init! = App.init(
 	App.default.with_title("RocRay Pong").with_size({ width: 800, height: 600 }),
 	|startup| {
-		# Generate the sound effects once; new_round carries the handles forward.
+		# Generate and prepare every host resource before the first cycle.
 		font = Draw.default_font!()
 		# Only scores 0..win_score can ever be shown, so the whole scoreboard is
 		# prepared here and a frame just picks the glyph it needs.
@@ -179,29 +202,25 @@ init! = App.init(
 			List.map_with_index(List.repeat({}, win_score + 1), |_unit, index| U64.to_str(index)),
 			|glyph| Text.from(glyph, font).size(64).prepare!(),
 		)?
-		seed = {
-			ball_x: 0,
-			ball_y: 0,
-			ball_vx: 0,
-			ball_vy: 0,
-			left_y: 250,
-			right_y: 250,
-			left_score: 0,
-			right_score: 0,
+		assets = {
 			hit_sound: Audio.gen_tone!({ freq: 440, ms: 60 })?,
 			wall_sound: Audio.gen_tone!({ freq: 220, ms: 50 })?,
 			score_sound: Audio.gen_tone!({ freq: 160, ms: 200 })?,
 			font: font,
-			trail: [],
-			flash: 0,
-			flash_color: ball_neon,
-			hint: Text.from("W / S  move    SPACE  serve    ESC  quit", font).size(18).prepare!()?,
+			hint: Text.from("W / S  move    SPACE  new match    ESC  quit", font).size(18).prepare!()?,
 			digits: digits,
 			win_lines: [
 				Text.from("LEFT PLAYER WINS", font).size(44).prepare!()?,
 				Text.from("RIGHT PLAYER WINS", font).size(44).prepare!()?,
 			],
 			restart_line: Text.from("PRESS SPACE FOR A NEW MATCH", font).size(20).prepare!()?,
+		}
+		world_seed = {
+			ball: { pos: { x: 0, y: 0 }, velocity: { x: 0, y: 0 } },
+			left: { paddle_y: 250, score: 0 },
+			right: { paddle_y: 250, score: 0 },
+			trail: [],
+			flash: { intensity: 0, color: ball_neon },
 			# Entropy is asked for once, here. From this point randomness is
 			# model state that `update!` advances without an effect, so this
 			# whole run reproduces from the one number below. Replace it with
@@ -209,81 +228,89 @@ init! = App.init(
 			rng: Random.seed(U64.to_u32_wrap(App.entropy!(startup))),
 		}
 
-		Ok(new_round(seed))
+		Ok({ assets, world: new_match(world_seed) })
 	},
 )
 
-## A frame's outcome: the model it produced, and the sounds it wants heard.
-##
-## Both steppers return this shape even when one of them can never make a sound,
-## so `update!` joins them without caring which branch it took.
-Stepped : {
-	model : Model,
-	sounds : List(Audio.Playback),
-}
+## Significant gameplay occurrences interpreted by the application boundary.
+GameEvent := [PaddleHit, WallHit, PointScored]
+
+play_event! : Assets, GameEvent => {}
+play_event! = |assets, event|
+	match event {
+		PaddleHit => assets.hit_sound.playback().play!()
+		WallHit => assets.wall_sound.playback().play!()
+		PointScored => assets.score_sound.playback().play!()
+	}
 
 Msg : []
 
 update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
 update! = |model, program_input| {
-	input = program_input.devices
+	controls = read_controls(program_input.devices)
 
 	# Seconds since the previous frame - the basis for all motion this frame.
 	dt = program_input.time.elapsed_seconds
 
-	stepped = if model.is_over() step_game_over(model, input) else step_playing(model, input, dt)
-
-	# The step is pure and says which sounds this frame made; playing them is
-	# the one effect here.
-	for playback in stepped.sounds {
-		playback.play!()
+	(world, events) = if is_over(model.world) {
+		step_game_over(model.world, controls)
+	} else {
+		step_playing(model.world, controls, dt)
 	}
 
-	if input.key_pressed(KeyEscape) {
+	# The step reports gameplay events; the application boundary interprets
+	# those events as effects without putting sound handles in the world.
+	for event in events {
+		play_event!(model.assets, event)
+	}
+
+	if controls.quit_pressed {
 		Err(Exit(0))
 	} else {
-		Ok(stepped.model)
+		Ok({ ..model, world })
 	}
 }
 
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ScopeLimit, ..])
 render! = |model, frame| {
+	assets = model.assets
+	world = model.world
 	frame.clear!(field_bottom)
 	# The field is a vertical gradient rather than flat black, so the paddles
 	# and the glow below have something to sit on.
 	frame.rectangle_gradient_v!({ x: 0, y: 0, width: screen_w, height: screen_h, color_top: field_top, color_bottom: field_bottom })
 	draw_center_line!(frame)
-	draw_scores!(frame, model)
+	draw_scores!(frame, assets, world)
 
 	# One additive scope covers everything that glows, so overlapping light
 	# reads as brighter rather than as stacked grey.
 	frame.with_blend_mode!(
 		Draw.additive_blend,
 		|glow_frame| {
-			draw_trail!(glow_frame, model)
-			draw_glow!(glow_frame, model)
+			draw_trail!(glow_frame, world)
+			draw_glow!(glow_frame, world)
 			# Alpha zero when the flash has decayed, so no branch is needed here.
-			wash = Color.with_alpha(model.flash_color, F32.to_u8_wrap(model.flash * 70))
+			wash = Color.with_alpha(world.flash.color, F32.to_u8_wrap(world.flash.intensity * 70))
 			glow_frame.rectangle!({ x: 0, y: 0, width: screen_w, height: screen_h, style: Draw.filled(wash) })
 			Ok({})
 		},
 	)?
 
-	draw_bodies!(frame, model)
+	draw_bodies!(frame, world)
 
-	if model.is_over() {
+	if is_over(world) {
 		# Dim the frozen field so the banner reads, then name the winner.
 		frame.rectangle!({ x: 0, y: 0, width: screen_w, height: screen_h, style: Draw.filled(Color.with_alpha(field_bottom, 190)) })
-		winner_index = if model.left_score >= win_score 0 else 1
+		winner_index = if world.left.score >= win_score 0 else 1
 		winner_color = if winner_index == 0 left_neon else right_neon
-		match List.get(model.win_lines, winner_index) {
+		match List.get(assets.win_lines, winner_index) {
 			Ok(line) => line.draw!(frame, { pos: { x: screen_w * 0.5, y: 268 }, color: winner_color, align: (Middle, Center) })
 			Err(_) => {}
 		}
-		model.restart_line.draw!(frame, { pos: { x: screen_w * 0.5, y: 326 }, color: hint_color, align: (Middle, Center) })
+		assets.restart_line.draw!(frame, { pos: { x: screen_w * 0.5, y: 326 }, color: hint_color, align: (Middle, Center) })
 	} else {}
 
-	model.hint.draw!(frame, { pos: { x: screen_w * 0.5, y: screen_h - 26 }, color: hint_color, align: (Middle, Center) })
+	assets.hint.draw!(frame, { pos: { x: screen_w * 0.5, y: screen_h - 26 }, color: hint_color, align: (Middle, Center) })
 
 	Ok({})
 }
@@ -300,9 +327,9 @@ draw_center_line! = |frame| {
 
 # Newest position first, so the index is the age of the sample: alpha and radius
 # both fall off with it and the ball drags a short comet tail.
-draw_trail! : Draw.Frame, Model => {}
-draw_trail! = |frame, model| {
-	for sample in List.map_with_index(model.trail, |pos, index| { pos, fade: 1 - U64.to_f32(index) / U64.to_f32(trail_length) }) {
+draw_trail! : Draw.Frame, World => {}
+draw_trail! = |frame, world| {
+	for sample in List.map_with_index(world.trail, |pos, index| { pos, fade: 1 - U64.to_f32(index) / U64.to_f32(trail_length) }) {
 		frame.circle!({
 			center: sample.pos,
 			radius: ball_r * (0.35 + 0.55 * sample.fade),
@@ -313,8 +340,8 @@ draw_trail! = |frame, model| {
 
 # Radial gradients fading to fully transparent, drawn additively, are the
 # cheapest convincing bloom available without a shader.
-draw_glow! : Draw.Frame, Model => {}
-draw_glow! = |frame, model| {
+draw_glow! : Draw.Frame, World => {}
+draw_glow! = |frame, world| {
 	halo! = |center, color, radius| frame.circle_gradient!({
 		center: center,
 		radius: radius,
@@ -322,70 +349,67 @@ draw_glow! = |frame, model| {
 		color_outer: Color.with_alpha(color, 0),
 	})
 
-	halo!(Math.center(left_paddle(model.left_y)), left_neon, 68)
-	halo!(Math.center(right_paddle(model.right_y)), right_neon, 68)
-	halo!({ x: model.ball_x, y: model.ball_y }, ball_neon, 46)
+	halo!(Math.center(left_paddle(world.left.paddle_y)), left_neon, 68)
+	halo!(Math.center(right_paddle(world.right.paddle_y)), right_neon, 68)
+	halo!(world.ball.pos, ball_neon, 46)
 }
 
 # The solid bodies, drawn over their own glow so the edges stay crisp.
-draw_bodies! : Draw.Frame, Model => {}
-draw_bodies! = |frame, model| {
-	left_rect = left_paddle(model.left_y)
-	right_rect = right_paddle(model.right_y)
+draw_bodies! : Draw.Frame, World => {}
+draw_bodies! = |frame, world| {
+	left_rect = left_paddle(world.left.paddle_y)
+	right_rect = right_paddle(world.right.paddle_y)
 
 	frame.rounded_rectangle!({ x: left_rect.x, y: left_rect.y, width: left_rect.width, height: left_rect.height, radius: 0.5, segments: 8, style: Draw.filled(left_neon) })
 	frame.rounded_rectangle!({ x: right_rect.x, y: right_rect.y, width: right_rect.width, height: right_rect.height, radius: 0.5, segments: 8, style: Draw.filled(right_neon) })
-	frame.circle!({ center: { x: model.ball_x, y: model.ball_y }, radius: ball_r, style: Draw.filled(ball_neon) })
-	frame.circle!({ center: { x: model.ball_x - 2, y: model.ball_y - 3 }, radius: ball_r * 0.42, style: Draw.filled(Color.white) })
+	frame.circle!({ center: world.ball.pos, radius: ball_r, style: Draw.filled(ball_neon) })
+	frame.circle!({ center: { x: world.ball.pos.x - 2, y: world.ball.pos.y - 3 }, radius: ball_r * 0.42, style: Draw.filled(Color.white) })
 }
 
 # Scores are prepared glyphs picked by value, so a frame lays out no text.
-draw_scores! : Draw.Frame, Model => {}
-draw_scores! = |frame, model| {
+draw_scores! : Draw.Frame, Assets, World => {}
+draw_scores! = |frame, assets, world| {
 	draw_score! = |score, x, color|
-		match List.get(model.digits, score) {
+		match List.get(assets.digits, score) {
 			Ok(glyph) => glyph.draw!(frame, { pos: { x: x, y: 30 }, color: color, align: (Top, Center) })
 			Err(_) => {}
 		}
 
-	draw_score!(model.left_score, screen_w * 0.32, Color.with_alpha(left_neon, 220))
-	draw_score!(model.right_score, screen_w * 0.68, Color.with_alpha(right_neon, 220))
+	draw_score!(world.left.score, screen_w * 0.32, Color.with_alpha(left_neon, 220))
+	draw_score!(world.right.score, screen_w * 0.68, Color.with_alpha(right_neon, 220))
 }
 
 # --- Win screen: freeze the field and wait for SPACE to start a new game ---
-step_game_over : Model, Devices.Snapshot -> Stepped
-step_game_over = |model, input| {
-	model: if input.key_pressed(KeySpace) new_round(model) else { ..model, flash: F32.max(model.flash - 0.02, 0) },
-	sounds: [],
+step_game_over : World, Controls -> (World, List(GameEvent))
+step_game_over = |world, controls| {
+	next_world = if controls.new_match_pressed new_match(world) else { ..world, flash: { ..world.flash, intensity: F32.max(world.flash.intensity - 0.02, 0) } }
+	(next_world, [])
 }
 
 # --- Active play ---
 ## Play is a function of the sampled input and how much time to advance by, so
 ## the caller passes both rather than a whole frame the stepper would only take
 ## one field from.
-step_playing : Model, Devices.Snapshot, F32 -> Stepped
-step_playing = |model, input, dt| {
+step_playing : World, Controls, F32 -> (World, List(GameEvent))
+step_playing = |world, controls, dt| {
 
-	# --- Left paddle: player input (W up, S down) ---
-	w_down = input.key_down(KeyW)
-	s_down = input.key_down(KeyS)
-	left_dir = if w_down (paddle_speed * -1) else if s_down paddle_speed else 0
-	left_y = Math.clamp(model.left_y + left_dir * dt, 0, screen_h - paddle_h)
+	# --- Left paddle: semantic player movement ---
+	left_y = Math.clamp(world.left.paddle_y + controls.move * paddle_speed * dt, 0, screen_h - paddle_h)
 
 	# --- Right paddle: simple AI tracks the ball's vertical position ---
-	right_center = model.right_y + paddle_h * 0.5
-	right_dir = if model.ball_y < right_center - 4 (ai_speed * -1) else if model.ball_y > right_center + 4 ai_speed else 0
-	right_y = Math.clamp(model.right_y + right_dir * dt, 0, screen_h - paddle_h)
+	right_center = world.right.paddle_y + paddle_h * 0.5
+	right_dir = if world.ball.pos.y < right_center - 4 (ai_speed * -1) else if world.ball.pos.y > right_center + 4 ai_speed else 0
+	right_y = Math.clamp(world.right.paddle_y + right_dir * dt, 0, screen_h - paddle_h)
 
 	# --- Move ball ---
-	nx0 = model.ball_x + model.ball_vx * dt
-	ny0 = model.ball_y + model.ball_vy * dt
+	nx0 = world.ball.pos.x + world.ball.velocity.x * dt
+	ny0 = world.ball.pos.y + world.ball.velocity.y * dt
 
 	# Bounce off top / bottom walls
 	hit_top = ny0 - ball_r < 0
 	hit_bottom = ny0 + ball_r > screen_h
 	ny = if hit_top ball_r else if hit_bottom (screen_h - ball_r) else ny0
-	vy_wall = if hit_top (model.ball_vy * -1) else if hit_bottom (model.ball_vy * -1) else model.ball_vy
+	vy_wall = if hit_top (world.ball.velocity.y * -1) else if hit_bottom (world.ball.velocity.y * -1) else world.ball.velocity.y
 
 	# Paddle geometry
 	left_rect = left_paddle(left_y)
@@ -393,14 +417,14 @@ step_playing = |model, input, dt| {
 	ball_shape = ball_circle(nx0, ny)
 
 	# Paddle collisions (reflect horizontally; set vy from where the ball struck)
-	hit_left = model.ball_vx < 0 and nx0 >= Math.left(left_rect) and Math.circle_rect(ball_shape, left_rect)
-	hit_right = model.ball_vx > 0 and nx0 <= Math.right(right_rect) and Math.circle_rect(ball_shape, right_rect)
+	hit_left = world.ball.velocity.x < 0 and nx0 >= Math.left(left_rect) and Math.circle_rect(ball_shape, left_rect)
+	hit_right = world.ball.velocity.x > 0 and nx0 <= Math.right(right_rect) and Math.circle_rect(ball_shape, right_rect)
 
 	left_paddle_center = Math.center(left_rect).y
 	right_paddle_center = Math.center(right_rect).y
 
 	nx = if hit_left (Math.right(left_rect) + ball_r) else if hit_right (Math.left(right_rect) - ball_r) else nx0
-	vx = if hit_left (model.ball_vx * -1) else if hit_right (model.ball_vx * -1) else model.ball_vx
+	vx = if hit_left (world.ball.velocity.x * -1) else if hit_right (world.ball.velocity.x * -1) else world.ball.velocity.x
 	vy = if hit_left ((ny - left_paddle_center) * bounce_factor) else if hit_right ((ny - right_paddle_center) * bounce_factor) else vy_wall
 
 	# --- Scoring: ball left the field on the left or right edge ---
@@ -409,15 +433,21 @@ step_playing = |model, input, dt| {
 	# Draw randomness only when a new serve is actually needed.
 	# The generator only advances when a serve is actually needed, so an idle
 	# rally does not consume draws.
-	serve = if out_left or out_right random_serve_vy(model.rng) else { value: vy, state: model.rng }
+	serve = if out_left or out_right random_serve_vy(world.rng) else { value: vy, state: world.rng }
 
-	final_ball_x = if out_left (screen_w * 0.5) else if out_right (screen_w * 0.5) else nx
-	final_ball_y = if out_left (screen_h * 0.5) else if out_right (screen_h * 0.5) else ny
-	final_vx = if out_left (init_vx * -1) else if out_right init_vx else vx
-	final_vy = if out_left serve.value else if out_right serve.value else vy
+	final_ball = {
+		pos: {
+			x: if out_left or out_right (screen_w * 0.5) else nx,
+			y: if out_left or out_right (screen_h * 0.5) else ny,
+		},
+		velocity: {
+			x: if out_left (init_vx * -1) else if out_right init_vx else vx,
+			y: if out_left or out_right serve.value else vy,
+		},
+	}
 
-	left_score = if out_right model.left_score + 1 else model.left_score
-	right_score = if out_left model.right_score + 1 else model.right_score
+	left = { paddle_y: left_y, score: if out_right world.left.score + 1 else world.left.score }
+	right = { paddle_y: right_y, score: if out_left world.right.score + 1 else world.right.score }
 
 	scored = out_left or out_right
 	paddled = hit_left or hit_right
@@ -425,102 +455,95 @@ step_playing = |model, input, dt| {
 	# Presentation, derived from the events this frame already computed: a point
 	# flashes hard in the scorer's colour, a hit gently, and otherwise the
 	# previous flash decays.
-	flash =
+	flash_intensity =
 		if scored 1.0
 		else if paddled 0.45
 		else if hit_top or hit_bottom 0.22
-		else F32.max(model.flash - dt * 2.4, 0)
+		else F32.max(world.flash.intensity - dt * 2.4, 0)
 	flash_color =
 		if out_right left_neon
 		else if out_left right_neon
 		else if hit_left left_neon
 		else if hit_right right_neon
-		else model.flash_color
+		else world.flash.color
 
 	# A serve teleports the ball, so the trail is cleared rather than stretched
 	# across the field as one long streak.
-	trail = if scored [] else push_trail(model.trail, { x: final_ball_x, y: final_ball_y })
+	trail = if scored [] else push_trail(world.trail, final_ball.pos)
 
 	next = {
-		..model,
-		ball_x: final_ball_x,
-		ball_y: final_ball_y,
-		ball_vx: final_vx,
-		ball_vy: final_vy,
-		left_y: left_y,
-		right_y: right_y,
-		left_score: left_score,
-		right_score: right_score,
+		..world,
+		ball: final_ball,
+		left: left,
+		right: right,
 		rng: serve.state,
 		trail: trail,
-		flash: flash,
-		flash_color: flash_color,
+		flash: { intensity: flash_intensity, color: flash_color },
 	}
 
-	# Sound effects for this frame's events, in the order they are played.
-	{
-		model: next,
-		sounds: List.concat(
-			play_if(hit_left or hit_right, model.hit_sound),
+	# Gameplay events for this frame, in the order the boundary handles them.
+	(
+		next,
+		List.concat(
+			if hit_left or hit_right [PaddleHit] else [],
 			List.concat(
-				play_if(hit_top or hit_bottom, model.wall_sound),
-				play_if(out_left or out_right, model.score_sound),
+				if hit_top or hit_bottom [WallHit] else [],
+				if out_left or out_right [PointScored] else [],
 			),
 		),
-	}
+	)
 }
 
-## A model with no host resources behind it, so the steppers above can be
-## exercised from an `expect`. The stubs are a font that measures nothing and
-## sounds that play nothing, which is all a pure test asks of them.
-test_model : Model
-test_model = {
-	ball_x: screen_w * 0.5,
-	ball_y: screen_h * 0.5,
-	ball_vx: init_vx,
-	ball_vy: 0,
-	left_y: 250,
-	right_y: 250,
-	left_score: 0,
-	right_score: 0,
-	hit_sound: Audio.Sound.stub,
-	wall_sound: Audio.Sound.stub,
-	score_sound: Audio.Sound.stub,
-	font: Text.font_stub,
+## Ordinary game data and neutral controls make the simulation directly
+## testable without host resources or platform input.
+test_world : World
+test_world = {
+	ball: {
+		pos: { x: screen_w * 0.5, y: screen_h * 0.5 },
+		velocity: { x: init_vx, y: 0 },
+	},
+	left: { paddle_y: 250, score: 0 },
+	right: { paddle_y: 250, score: 0 },
 	trail: [],
-	flash: 0,
-	flash_color: ball_neon,
-	hint: Text.Prepared.stub,
-	digits: [],
-	win_lines: [],
-	restart_line: Text.Prepared.stub,
+	flash: { intensity: 0, color: ball_neon },
 	rng: Random.seed(1),
 }
 
-expect !test_model.is_over()
-expect { ..test_model, right_score: win_score }.is_over()
+no_controls : Controls
+no_controls = { move: 0, new_match_pressed: Bool.False, quit_pressed: Bool.False }
 
-## The empty list is the no-op, so a caller can concatenate unconditionally.
-expect List.is_empty(play_if(Bool.False, Audio.Sound.stub))
-expect List.len(play_if(Bool.True, Audio.Sound.stub)) == 1
+expect !is_over(test_world)
+expect is_over({ ..test_world, right: { ..test_world.right, score: win_score } })
 
-## The top wall reflects the ball and asks for one sound.
+## Raw key bindings are translated once at the edge of the application.
+expect read_controls(Devices.none.with_key_down(KeyW)).move == -1
+expect read_controls(Devices.none.with_key_pressed(KeyEscape)).quit_pressed
+
+## The top wall reflects the ball and reports one event.
 expect {
-	stepped = step_playing({ ..test_model, ball_y: ball_r, ball_vy: -100 }, Devices.none, 0.1)
-	stepped.model.ball_vy > 0 and List.len(stepped.sounds) == 1
+	ball = {
+		..test_world.ball,
+		pos: { ..test_world.ball.pos, y: ball_r },
+		velocity: { ..test_world.ball.velocity, y: -100 },
+	}
+	(world, events) = step_playing({ ..test_world, ball }, no_controls, 0.1)
+	world.ball.velocity.y > 0 and List.len(events) == 1
 }
 
 ## A ball past the right edge scores for the left player and re-serves from the
 ## centre.
 expect {
-	stepped = step_playing({ ..test_model, ball_x: screen_w - 5 }, Devices.none, 0.1)
-	stepped.model.left_score == 1 and stepped.model.ball_x == screen_w * 0.5
+	ball = { ..test_world.ball, pos: { ..test_world.ball.pos, x: screen_w - 5 } }
+	(world, _) = step_playing({ ..test_world, ball }, no_controls, 0.1)
+	world.left.score == 1 and world.ball.pos.x == screen_w * 0.5
 }
 
 ## The win screen holds until SPACE, and SPACE starts a whole new match rather
 ## than resuming the old one.
 expect {
-	finished = { ..test_model, left_score: win_score }
-	step_game_over(finished, Devices.none).model.left_score == win_score
-		and step_game_over(finished, Devices.none.with_key_pressed(KeySpace)).model.left_score == 0
+	finished = { ..test_world, left: { ..test_world.left, score: win_score } }
+	new_match_controls = { ..no_controls, new_match_pressed: Bool.True }
+	(waiting_world, _) = step_game_over(finished, no_controls)
+	(restarted_world, _) = step_game_over(finished, new_match_controls)
+	waiting_world.left.score == win_score and restarted_world.left.score == 0
 }

--- a/examples/snake/Assets.roc
+++ b/examples/snake/Assets.roc
@@ -1,0 +1,37 @@
+## Snake sounds, fonts, and prepared text loaded during application startup.
+import rr.Audio
+import rr.Draw
+import rr.Text
+
+Assets := {
+	sounds : Sounds,
+	font : Text.Font,
+	title : Text.Prepared,
+	hint : Text.Prepared,
+	over_title : Text.Prepared,
+	over_hint : Text.Prepared,
+}.{
+	Sounds : {
+		eat : Audio.Sound,
+		crash_sound : Audio.Sound,
+		start : Audio.Sound,
+	}
+
+	## Prepares all Snake sounds, fonts, and text before the first frame.
+	load! : () => Try(Assets, [ResourceLimit, SoundGenerationFailed, ..])
+	load! = || {
+		font = Draw.default_font!()
+		Ok({
+			font,
+			title: Text.from("SNAKE", font).size(30).spacing(6).prepare!()?,
+			hint: Text.from("ARROWS / WASD  turn    SPACE  restart    ESC  quit", font).size(17).prepare!()?,
+			over_title: Text.from("GAME OVER", font).size(40).prepare!()?,
+			over_hint: Text.from("PRESS SPACE TO PLAY AGAIN", font).size(19).prepare!()?,
+			sounds: {
+				eat: Audio.gen_tone!({ freq: 620, ms: 70 })?,
+				crash_sound: Audio.gen_tone!({ freq: 120, ms: 180 })?,
+				start: Audio.gen_tone!({ freq: 360, ms: 80 })?,
+			},
+		})
+	}
+}

--- a/examples/snake/Board.roc
+++ b/examples/snake/Board.roc
@@ -21,19 +21,6 @@ Board := [].{
 	cell_rect : Cell -> Math.Rect
 	cell_rect = |cell| { x: origin.x + I32.to_f32(cell.x) * cell_size, y: origin.y + I32.to_f32(cell.y) * cell_size, width: cell_size, height: cell_size }
 
-	## Walks forward from a candidate until it finds a cell outside the snake.
-	find_open_cell : Cell, List(Cell), I32 -> Cell
-	find_open_cell = |seed, occupied, attempt| {
-		cell_count = columns * rows
-		if attempt >= cell_count {
-			seed
-		} else {
-			flat_index = (seed.y * columns + seed.x + attempt) % cell_count
-			candidate = { x: flat_index % columns, y: flat_index // columns }
-			if List.contains(occupied, candidate) find_open_cell(seed, occupied, attempt + 1) else candidate
-		}
-	}
-
 	## Chooses a reproducible unoccupied food cell and advances the random state.
 	spawn_food : Random.State, List(Cell) -> { cell : Cell, state : Random.State }
 	spawn_food = |state, occupied| {
@@ -42,3 +29,18 @@ Board := [].{
 		{ cell: find_open_cell({ x: column.value, y: row.value }, occupied, 0), state: row.state }
 	}
 }
+
+## Walks forward from a candidate until it finds a cell outside the snake.
+find_open_cell : Board.Cell, List(Board.Cell), I32 -> Board.Cell
+find_open_cell = |seed, occupied, attempt| {
+	cell_count = Board.columns * Board.rows
+	if attempt >= cell_count {
+		seed
+	} else {
+		flat_index = (seed.y * Board.columns + seed.x + attempt) % cell_count
+		candidate = { x: flat_index % Board.columns, y: flat_index // Board.columns }
+		if List.contains(occupied, candidate) find_open_cell(seed, occupied, attempt + 1) else candidate
+	}
+}
+
+expect find_open_cell({ x: 12, y: 9 }, [{ x: 12, y: 9 }, { x: 11, y: 9 }, { x: 10, y: 9 }], 0) == { x: 13, y: 9 }

--- a/examples/snake/Board.roc
+++ b/examples/snake/Board.roc
@@ -1,0 +1,44 @@
+## Snake board geometry and reproducible food placement.
+import rr.Math
+import rr.Random
+
+Board := [].{
+	Cell : { x : I32, y : I32 }
+
+	columns = 25.I32
+	rows = 18.I32
+	columns_count = 25.U64
+	rows_count = 18.U64
+	origin : Math.Vec2
+	origin = { x: 75, y: 80 }
+	cell_size = 26.F32
+
+	## Reports whether a cell lies inside the playable grid.
+	contains : Cell -> Bool
+	contains = |cell| cell.x >= 0 and cell.x < columns and cell.y >= 0 and cell.y < rows
+
+	## Converts a grid cell into its screen-space rectangle.
+	cell_rect : Cell -> Math.Rect
+	cell_rect = |cell| { x: origin.x + I32.to_f32(cell.x) * cell_size, y: origin.y + I32.to_f32(cell.y) * cell_size, width: cell_size, height: cell_size }
+
+	## Walks forward from a candidate until it finds a cell outside the snake.
+	find_open_cell : Cell, List(Cell), I32 -> Cell
+	find_open_cell = |seed, occupied, attempt| {
+		cell_count = columns * rows
+		if attempt >= cell_count {
+			seed
+		} else {
+			flat_index = (seed.y * columns + seed.x + attempt) % cell_count
+			candidate = { x: flat_index % columns, y: flat_index // columns }
+			if List.contains(occupied, candidate) find_open_cell(seed, occupied, attempt + 1) else candidate
+		}
+	}
+
+	## Chooses a reproducible unoccupied food cell and advances the random state.
+	spawn_food : Random.State, List(Cell) -> { cell : Cell, state : Random.State }
+	spawn_food = |state, occupied| {
+		column = Random.step(state, Random.bounded_i32(0, columns - 1))
+		row = Random.next(column, Random.bounded_i32(0, rows - 1))
+		{ cell: find_open_cell({ x: column.value, y: row.value }, occupied, 0), state: row.state }
+	}
+}

--- a/examples/snake/Game.roc
+++ b/examples/snake/Game.roc
@@ -1,0 +1,88 @@
+## Pure Snake timing, state transitions, and gameplay events.
+import rr.Random
+import Board
+import Snake
+
+Game := [].{
+	State := [Playing, GameOver].{
+		is_eq : _
+	}
+	RequestedDirection := [KeepDirection, Turn(Snake.Direction)].{
+		is_eq : _
+	}
+	Controls : { requested_direction : RequestedDirection, restart_pressed : Bool, quit_pressed : Bool }
+	World : { snake : Snake, food : Board.Cell, score : U64, accumulator : F32, state : State, rng : Random.State }
+	Event := [FoodEaten, SnakeCrashed, GameStarted].{
+		is_eq : _
+	}
+	step_time = 0.115.F32
+
+	## Creates a playing world with a fresh snake and reproducibly placed food.
+	new_world : Random.State -> World
+	new_world = |rng| {
+		spawned = Board.spawn_food(rng, Snake.initial.cells)
+		{ snake: Snake.initial, food: spawned.cell, score: 0, accumulator: 0, state: Playing, rng: spawned.state }
+	}
+
+	## Applies a requested legal turn before the next fixed movement step.
+	apply_controls : World, Controls -> World
+	apply_controls = |world, controls|
+		match controls.requested_direction {
+			KeepDirection => world
+			Turn(direction) => { ..world, snake: world.snake.request_turn(direction) }
+		}
+
+	## Moves the snake once and reports eating or crashing as gameplay events.
+	step_snake : World -> (World, List(Event))
+	step_snake = |world| {
+		next = world.snake.next_head()
+		ate = next == world.food
+		crashed = !Board.contains(next) or world.snake.hits_self(next, ate)
+		if crashed {
+			({ ..world, accumulator: 0, state: GameOver }, [SnakeCrashed])
+		} else {
+			snake = world.snake.advance(next, ate)
+			if ate {
+				spawned = Board.spawn_food(world.rng, snake.cells)
+				({ ..world, snake, food: spawned.cell, score: world.score + 1, rng: spawned.state }, [FoodEaten])
+			} else {
+				({ ..world, snake }, [])
+			}
+		}
+	}
+
+	## Runs every fixed snake step currently paid for by the accumulator.
+	advance_fixed_steps : World, List(Event) -> (World, List(Event))
+	advance_fixed_steps = |world, events| {
+		if world.accumulator < step_time {
+			(world, events)
+		} else {
+			(next_world, step_events) = step_snake({ ..world, accumulator: world.accumulator - step_time })
+			all_events = List.concat(events, step_events)
+			match next_world.state {
+				Playing => advance_fixed_steps(next_world, all_events)
+				GameOver => (next_world, all_events)
+			}
+		}
+	}
+
+	## Advances playing rules by bounded elapsed time at a fixed movement rate.
+	update_playing : World, Controls, F32 -> (World, List(Event))
+	update_playing = |world, controls, dt| {
+		controlled = apply_controls(world, controls)
+		advance_fixed_steps({ ..controlled, accumulator: controlled.accumulator + dt }, [])
+	}
+
+	## Holds a crashed world or starts a fresh run when restart is pressed.
+	update_game_over : World, Controls -> (World, List(Event))
+	update_game_over = |world, controls|
+		if controls.restart_pressed (new_world(world.rng), [GameStarted]) else (world, [])
+
+	## Advances the current Snake state and returns its ordered gameplay events.
+	update : World, Controls, F32 -> (World, List(Event))
+	update = |world, controls, dt|
+		match world.state {
+			Playing => update_playing(world, controls, dt)
+			GameOver => update_game_over(world, controls)
+		}
+}

--- a/examples/snake/Game.roc
+++ b/examples/snake/Game.roc
@@ -3,6 +3,8 @@ import rr.Random
 import Board
 import Snake
 
+step_time = 0.115.F32
+
 Game := [].{
 	State := [Playing, GameOver].{
 		is_eq : _
@@ -15,7 +17,6 @@ Game := [].{
 	Event := [FoodEaten, SnakeCrashed, GameStarted].{
 		is_eq : _
 	}
-	step_time = 0.115.F32
 
 	## Creates a playing world with a fresh snake and reproducibly placed food.
 	new_world : Random.State -> World
@@ -24,60 +25,6 @@ Game := [].{
 		{ snake: Snake.initial, food: spawned.cell, score: 0, accumulator: 0, state: Playing, rng: spawned.state }
 	}
 
-	## Applies a requested legal turn before the next fixed movement step.
-	apply_controls : World, Controls -> World
-	apply_controls = |world, controls|
-		match controls.requested_direction {
-			KeepDirection => world
-			Turn(direction) => { ..world, snake: world.snake.request_turn(direction) }
-		}
-
-	## Moves the snake once and reports eating or crashing as gameplay events.
-	step_snake : World -> (World, List(Event))
-	step_snake = |world| {
-		next = world.snake.next_head()
-		ate = next == world.food
-		crashed = !Board.contains(next) or world.snake.hits_self(next, ate)
-		if crashed {
-			({ ..world, accumulator: 0, state: GameOver }, [SnakeCrashed])
-		} else {
-			snake = world.snake.advance(next, ate)
-			if ate {
-				spawned = Board.spawn_food(world.rng, snake.cells)
-				({ ..world, snake, food: spawned.cell, score: world.score + 1, rng: spawned.state }, [FoodEaten])
-			} else {
-				({ ..world, snake }, [])
-			}
-		}
-	}
-
-	## Runs every fixed snake step currently paid for by the accumulator.
-	advance_fixed_steps : World, List(Event) -> (World, List(Event))
-	advance_fixed_steps = |world, events| {
-		if world.accumulator < step_time {
-			(world, events)
-		} else {
-			(next_world, step_events) = step_snake({ ..world, accumulator: world.accumulator - step_time })
-			all_events = List.concat(events, step_events)
-			match next_world.state {
-				Playing => advance_fixed_steps(next_world, all_events)
-				GameOver => (next_world, all_events)
-			}
-		}
-	}
-
-	## Advances playing rules by bounded elapsed time at a fixed movement rate.
-	update_playing : World, Controls, F32 -> (World, List(Event))
-	update_playing = |world, controls, dt| {
-		controlled = apply_controls(world, controls)
-		advance_fixed_steps({ ..controlled, accumulator: controlled.accumulator + dt }, [])
-	}
-
-	## Holds a crashed world or starts a fresh run when restart is pressed.
-	update_game_over : World, Controls -> (World, List(Event))
-	update_game_over = |world, controls|
-		if controls.restart_pressed (new_world(world.rng), [GameStarted]) else (world, [])
-
 	## Advances the current Snake state and returns its ordered gameplay events.
 	update : World, Controls, F32 -> (World, List(Event))
 	update = |world, controls, dt|
@@ -85,4 +32,86 @@ Game := [].{
 			Playing => update_playing(world, controls, dt)
 			GameOver => update_game_over(world, controls)
 		}
+}
+
+## Applies a requested legal turn before the next fixed movement step.
+apply_controls : Game.World, Game.Controls -> Game.World
+apply_controls = |world, controls|
+	match controls.requested_direction {
+		KeepDirection => world
+		Turn(direction) => { ..world, snake: world.snake.request_turn(direction) }
+	}
+
+## Moves the snake once and reports eating or crashing as gameplay events.
+step_snake : Game.World -> (Game.World, List(Game.Event))
+step_snake = |world| {
+	next = world.snake.next_head()
+	ate = next == world.food
+	crashed = !Board.contains(next) or world.snake.hits_self(next, ate)
+	if crashed {
+		({ ..world, accumulator: 0, state: GameOver }, [SnakeCrashed])
+	} else {
+		snake = world.snake.advance(next, ate)
+		if ate {
+			spawned = Board.spawn_food(world.rng, snake.cells)
+			({ ..world, snake, food: spawned.cell, score: world.score + 1, rng: spawned.state }, [FoodEaten])
+		} else {
+			({ ..world, snake }, [])
+		}
+	}
+}
+
+## Runs every fixed snake step currently paid for by the accumulator.
+advance_fixed_steps : Game.World, List(Game.Event) -> (Game.World, List(Game.Event))
+advance_fixed_steps = |world, events| {
+	if world.accumulator < step_time {
+		(world, events)
+	} else {
+		(next_world, step_events) = step_snake({ ..world, accumulator: world.accumulator - step_time })
+		all_events = List.concat(events, step_events)
+		match next_world.state {
+			Playing => advance_fixed_steps(next_world, all_events)
+			GameOver => (next_world, all_events)
+		}
+	}
+}
+
+## Advances playing rules by bounded elapsed time at a fixed movement rate.
+update_playing : Game.World, Game.Controls, F32 -> (Game.World, List(Game.Event))
+update_playing = |world, controls, dt| {
+	controlled = apply_controls(world, controls)
+	advance_fixed_steps({ ..controlled, accumulator: controlled.accumulator + dt }, [])
+}
+
+## Holds a crashed world or starts a fresh run when restart is pressed.
+update_game_over : Game.World, Game.Controls -> (Game.World, List(Game.Event))
+update_game_over = |world, controls| if controls.restart_pressed (Game.new_world(world.rng), [GameStarted]) else (world, [])
+
+no_controls : Game.Controls
+no_controls = { requested_direction: KeepDirection, restart_pressed: Bool.False, quit_pressed: Bool.False }
+
+expect {
+	world = Game.new_world(Random.seed(1))
+	(next, events) = step_snake(world)
+	next.snake.head() == { x: 13, y: 9 } and List.len(next.snake.cells) == 3 and List.is_empty(events)
+}
+
+expect {
+	world = { ..Game.new_world(Random.seed(1)), food: { x: 13, y: 9 } }
+	(next, events) = step_snake(world)
+	List.len(next.snake.cells) == 4 and next.score == 1 and events == [FoodEaten]
+}
+
+expect {
+	world = Game.new_world(Random.seed(1))
+	snake : Snake
+	snake = Snake.{ cells: [{ x: 24, y: 9 }], direction: world.snake.direction, pending_direction: world.snake.pending_direction }
+	(next, events) = step_snake({ ..world, snake })
+	next.state == GameOver and events == [SnakeCrashed]
+}
+
+expect {
+	world = Game.new_world(Random.seed(1))
+	(next, _events) = Game.update(world, no_controls, step_time * 2)
+	next.snake.head() == { x: 14, y: 9 }
 }

--- a/examples/snake/Render.roc
+++ b/examples/snake/Render.roc
@@ -1,0 +1,135 @@
+## Snake drawing derived from loaded assets and the resulting world.
+import rr.Color
+import rr.Draw
+import rr.Math
+import rr.Text
+import Assets
+import Board
+import Game
+import Snake
+
+Render := [].{
+
+	## Draws one complete Snake presentation frame from the resulting world.
+	draw! : Draw.Frame, Assets, Game.World, F32 => Try({}, [ScopeLimit, ..])
+	draw! = |frame, assets, world, elapsed| {
+		frame.clear!(field_bottom)
+		draw_background!(frame)
+		draw_hud!(frame, assets, world)
+		draw_board!(frame)
+		draw_snake!(frame, world.snake)
+		draw_glow!(frame, world, elapsed)?
+		draw_food_body!(frame, world.food, elapsed)
+		draw_cell!(frame, world.snake.head(), snake_head, Color.with_alpha(Color.white, 200))
+		draw_game_over!(frame, assets, world, elapsed)
+		Ok({})
+	}
+}
+
+## Paints the dark vertical gradient behind the board.
+draw_background! : Draw.Frame => {}
+draw_background! = |frame| frame.rectangle_gradient_v!({ x: 0, y: 0, width: 800, height: 600, color_top: field_top, color_bottom: field_bottom })
+
+## Draws the title, score, and keyboard controls around the board.
+draw_hud! : Draw.Frame, Assets, Game.World => {}
+draw_hud! = |frame, assets, world| {
+	assets.title.draw!(frame, { pos: { x: Board.origin.x, y: 26 }, color: snake_head })
+	Text.from("SCORE ${U64.to_str(world.score)}", assets.font).size(24).draw!(frame, { pos: { x: 800 - Board.origin.x, y: 30 }, color: hud_color, align: (Top, Right) })
+	assets.hint.draw!(frame, { pos: { x: 400, y: 580 }, color: hint_color, align: (Middle, Center) })
+}
+
+## Draws the bordered playfield and its faint cell lattice.
+draw_board! : Draw.Frame => {}
+draw_board! = |frame| {
+	board_w = I32.to_f32(Board.columns) * Board.cell_size
+	board_h = I32.to_f32(Board.rows) * Board.cell_size
+	frame.rounded_rectangle!({ x: Board.origin.x - 8, y: Board.origin.y - 8, width: board_w + 16, height: board_h + 16, radius: 0.06, segments: 8, style: Draw.filled_and_outlined(board_fill, Color.from_hex_rgb(0x2a3566), 2) })
+	for column in List.map_with_index(List.repeat({}, Board.columns_count + 1), |_unit, index| Board.origin.x + U64.to_f32(index) * Board.cell_size) {
+		frame.line!({ start: { x: column, y: Board.origin.y }, end: { x: column, y: Board.origin.y + board_h }, stroke: Draw.stroke(grid_line, 1) })
+	}
+	for row in List.map_with_index(List.repeat({}, Board.rows_count + 1), |_unit, index| Board.origin.y + U64.to_f32(index) * Board.cell_size) {
+		frame.line!({ start: { x: Board.origin.x, y: row }, end: { x: Board.origin.x + board_w, y: row }, stroke: Draw.stroke(grid_line, 1) })
+	}
+}
+
+## Draws one rounded snake cell with a fill and outline.
+draw_cell! : Draw.Frame, Board.Cell, Color.Rgba, Color.Rgba => {}
+draw_cell! = |frame, cell, fill, outline| {
+	rect = Board.cell_rect(cell)
+	frame.rounded_rectangle!({ x: rect.x + 2, y: rect.y + 2, width: rect.width - 4, height: rect.height - 4, radius: 0.35, segments: 6, style: Draw.filled_and_outlined(fill, outline, 1) })
+}
+
+## Blends the snake color from its bright head toward its blue tail.
+segment_color : U64, U64 -> Color.Rgba
+segment_color = |index, length| {
+	t = if length <= 1 0 else U64.to_f32(index) / U64.to_f32(length - 1)
+	mix = |from, to| F32.to_u8_wrap(U8.to_f32(from) + (U8.to_f32(to) - U8.to_f32(from)) * t)
+	Color.rgba(mix(snake_head.r, snake_tail.r), mix(snake_head.g, snake_tail.g), mix(snake_head.b, snake_tail.b), 255)
+}
+
+## Draws every snake segment with a head-to-tail color gradient.
+draw_snake! : Draw.Frame, Snake => {}
+draw_snake! = |frame, snake| {
+	length = List.len(snake.cells)
+	for segment in List.map_with_index(snake.cells, |cell, index| { cell, color: segment_color(index, length) }) {
+		draw_cell!(frame, segment.cell, segment.color, Color.with_alpha(segment.color, 90))
+	}
+}
+
+## Produces the shared breathing pulse for food and restart presentation.
+pulse : F32 -> F32
+pulse = |elapsed| 0.5 + 0.5 * F32.sin(elapsed * 3.4)
+
+## Draws additive halos behind the food and snake's head.
+draw_glow! : Draw.Frame, Game.World, F32 => Try({}, [ScopeLimit, ..])
+draw_glow! = |frame, world, elapsed|
+	frame.with_blend_mode!(
+		Draw.additive_blend,
+		|glow_frame| {
+			food_pulse = pulse(elapsed)
+			glow_frame.circle_gradient!({ center: Math.center(Board.cell_rect(world.food)), radius: Board.cell_size * (1.0 + 0.5 * food_pulse), color_inner: Color.with_alpha(food_neon, F32.to_u8_wrap(70 + 60 * food_pulse)), color_outer: Color.with_alpha(food_neon, 0) })
+			glow_frame.circle_gradient!({ center: Math.center(Board.cell_rect(world.snake.head())), radius: Board.cell_size * 1.5, color_inner: Color.with_alpha(snake_head, 90), color_outer: Color.with_alpha(snake_head, 0) })
+			Ok({})
+		},
+	)
+
+## Draws the pulsing apple body and its small highlight.
+draw_food_body! : Draw.Frame, Board.Cell, F32 => {}
+draw_food_body! = |frame, food, elapsed| {
+	center = Math.center(Board.cell_rect(food))
+	radius = Board.cell_size * (0.3 + 0.04 * pulse(elapsed))
+	frame.circle!({ center, radius, style: Draw.filled(food_neon) })
+	frame.circle!({ center: { x: center.x - radius * 0.3, y: center.y - radius * 0.35 }, radius: radius * 0.32, style: Draw.filled(Color.with_alpha(Color.white, 190)) })
+}
+
+## Draws the game-over panel and breathing restart prompt after a crash.
+draw_game_over! : Draw.Frame, Assets, Game.World, F32 => {}
+draw_game_over! = |frame, assets, world, elapsed|
+	match world.state {
+		Playing => {}
+		GameOver => {
+			board_w = I32.to_f32(Board.columns) * Board.cell_size
+			frame.rectangle!({ x: Board.origin.x - 8, y: 236, width: board_w + 16, height: 140, style: Draw.filled(Color.with_alpha(field_bottom, 225)) })
+			assets.over_title.draw!(frame, { pos: { x: 400, y: 282 }, color: food_neon, align: (Middle, Center) })
+			prompt_alpha = F32.to_u8_wrap(150 + 105 * pulse(elapsed))
+			assets.over_hint.draw!(frame, { pos: { x: 400, y: 336 }, color: Color.with_alpha(hint_color, prompt_alpha), align: (Middle, Center) })
+		}
+	}
+
+field_top = Color.from_hex_rgb(0x151d3a)
+
+field_bottom = Color.from_hex_rgb(0x060810)
+
+board_fill = Color.from_hex_rgb(0x0b1226)
+
+grid_line = Color.from_hex_rgb(0x16203f)
+
+snake_head = Color.from_hex_rgb(0x7ef7d1)
+
+snake_tail = Color.from_hex_rgb(0x1d7fb8)
+
+food_neon = Color.from_hex_rgb(0xff6b8b)
+
+hud_color = Color.from_hex_rgb(0xd7e3ff)
+
+hint_color = Color.from_hex_rgb(0x6d7aa8)

--- a/examples/snake/Snake.roc
+++ b/examples/snake/Snake.roc
@@ -4,30 +4,8 @@ import Board
 Snake := { cells : List(Board.Cell), direction : Direction, pending_direction : Direction }.{
 	Direction := [Up, Down, Left, Right].{
 		is_eq : _
-
-		## Returns the one-cell displacement for this direction.
-		delta : Direction -> Board.Cell
-		delta = |direction|
-			match direction {
-				Up => { x: 0, y: -1 }
-				Down => { x: 0, y: 1 }
-				Left => { x: -1, y: 0 }
-				Right => { x: 1, y: 0 }
-			}
-
-		## Rejects only a turn directly back into the snake's neck.
-		can_turn_to : Direction, Direction -> Bool
-		can_turn_to = |current, requested|
-			match current {
-				Up => requested != Down
-				Down => requested != Up
-				Left => requested != Right
-				Right => requested != Left
-			}
 	}
 
-	initial_cells : List(Board.Cell)
-	initial_cells = [{ x: 12, y: 9 }, { x: 11, y: 9 }, { x: 10, y: 9 }]
 	initial : Snake
 	initial = { cells: initial_cells, direction: Right, pending_direction: Right }
 
@@ -42,14 +20,14 @@ Snake := { cells : List(Board.Cell), direction : Direction, pending_direction : 
 	## Queues a direction unless it would reverse into the snake's neck.
 	request_turn : Snake, Direction -> Snake
 	request_turn = |snake, requested| {
-		pending_direction = if snake.direction.can_turn_to(requested) requested else snake.pending_direction
+		pending_direction = if can_turn_to(snake.direction, requested) requested else snake.pending_direction
 		{ ..snake, pending_direction }
 	}
 
 	## Computes the cell the snake will enter on its next fixed step.
 	next_head : Snake -> Board.Cell
 	next_head = |snake| {
-		move = snake.pending_direction.delta()
+		move = direction_delta(snake.pending_direction)
 		head_cell = snake.head()
 		{ x: head_cell.x + move.x, y: head_cell.y + move.y }
 	}
@@ -68,3 +46,26 @@ Snake := { cells : List(Board.Cell), direction : Direction, pending_direction : 
 		{ cells: List.prepend(body, next), direction: snake.pending_direction, pending_direction: snake.pending_direction }
 	}
 }
+
+initial_cells : List(Board.Cell)
+initial_cells = [{ x: 12, y: 9 }, { x: 11, y: 9 }, { x: 10, y: 9 }]
+
+## Returns the private one-cell displacement for a direction.
+direction_delta : Snake.Direction -> Board.Cell
+direction_delta = |direction|
+	match direction {
+		Up => { x: 0, y: -1 }
+		Down => { x: 0, y: 1 }
+		Left => { x: -1, y: 0 }
+		Right => { x: 1, y: 0 }
+	}
+
+## Reports whether a requested direction avoids reversing into the neck.
+can_turn_to : Snake.Direction, Snake.Direction -> Bool
+can_turn_to = |current, requested|
+	match current {
+		Up => requested != Down
+		Down => requested != Up
+		Left => requested != Right
+		Right => requested != Left
+	}

--- a/examples/snake/Snake.roc
+++ b/examples/snake/Snake.roc
@@ -1,0 +1,70 @@
+## Snake body movement and legal direction changes.
+import Board
+
+Snake := { cells : List(Board.Cell), direction : Direction, pending_direction : Direction }.{
+	Direction := [Up, Down, Left, Right].{
+		is_eq : _
+
+		## Returns the one-cell displacement for this direction.
+		delta : Direction -> Board.Cell
+		delta = |direction|
+			match direction {
+				Up => { x: 0, y: -1 }
+				Down => { x: 0, y: 1 }
+				Left => { x: -1, y: 0 }
+				Right => { x: 1, y: 0 }
+			}
+
+		## Rejects only a turn directly back into the snake's neck.
+		can_turn_to : Direction, Direction -> Bool
+		can_turn_to = |current, requested|
+			match current {
+				Up => requested != Down
+				Down => requested != Up
+				Left => requested != Right
+				Right => requested != Left
+			}
+	}
+
+	initial_cells : List(Board.Cell)
+	initial_cells = [{ x: 12, y: 9 }, { x: 11, y: 9 }, { x: 10, y: 9 }]
+	initial : Snake
+	initial = { cells: initial_cells, direction: Right, pending_direction: Right }
+
+	## Returns the leading cell of a non-empty snake.
+	head : Snake -> Board.Cell
+	head = |snake|
+		match List.first(snake.cells) {
+			Ok(cell) => cell
+			Err(_) => { x: 0, y: 0 }
+		}
+
+	## Queues a direction unless it would reverse into the snake's neck.
+	request_turn : Snake, Direction -> Snake
+	request_turn = |snake, requested| {
+		pending_direction = if snake.direction.can_turn_to(requested) requested else snake.pending_direction
+		{ ..snake, pending_direction }
+	}
+
+	## Computes the cell the snake will enter on its next fixed step.
+	next_head : Snake -> Board.Cell
+	next_head = |snake| {
+		move = snake.pending_direction.delta()
+		head_cell = snake.head()
+		{ x: head_cell.x + move.x, y: head_cell.y + move.y }
+	}
+
+	## Reports whether entering a cell collides with the body that will remain.
+	hits_self : Snake, Board.Cell, Bool -> Bool
+	hits_self = |snake, next, growing| {
+		body = if growing snake.cells else List.drop_last(snake.cells, 1)
+		List.contains(body, next)
+	}
+
+	## Moves into a cell, retaining the tail only when food was eaten.
+	advance : Snake, Board.Cell, Bool -> Snake
+	advance = |snake, next, growing| {
+		body = if growing snake.cells else List.drop_last(snake.cells, 1)
+		{ cells: List.prepend(body, next), direction: snake.pending_direction, pending_direction: snake.pending_direction }
+	}
+}

--- a/examples/snake/main.roc
+++ b/examples/snake/main.roc
@@ -1,568 +1,128 @@
-## Play Snake with the arrow keys; press Space after a crash to restart and
-## Escape to quit. The game demonstrates movement at a fixed rate independent
-## of drawing speed, reproducible random food placement, and sound effects
-## chosen by game rules and played from `update!`.
+## Snake: grow by eating food without hitting the walls or your own body.
+##
+## Use Arrow keys or WASD to turn, Space to restart, and Escape to quit.
+## File structure:
+##
+## - State (`Game.roc`): snake, food, score, fixed-step timing, and run state
+## - Controls (`main.roc`): requested turn, restart, and quit
+## - Assets (`Assets.roc`): sounds, font, and prepared interface text
+## - App wiring (`main.roc`): reproducible random seed and event sounds
+## - Rendering (`Render.roc`): board, HUD, snake, food, glow, and game over
+## - Gameplay (`Snake.roc`, `Board.roc`): legal turns, growth, collisions, and food
+## - Tests (`main.roc`): turns, food placement, movement, eating, and crashes
 app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
-import rr.Time
-import rr.Audio
-import rr.Color
-import rr.Draw
 import rr.Devices
-import rr.Random
+import rr.Draw
 import rr.Math
-import rr.Text
+import rr.Random
+import Assets
+import Board
+import Game
+import Render
+import Snake
 
-Cell : {
-	x : I32,
-	y : I32,
-}
+Model : { assets : Assets, world : Game.World, elapsed : F32 }
 
-Direction := [DirUp, DirDown, DirLeft, DirRight].{
-	is_eq : _
-
-	delta : Direction -> Cell
-	delta = |direction|
-		match direction {
-			DirUp => { x: 0, y: -1 }
-			DirDown => { x: 0, y: 1 }
-			DirLeft => { x: -1, y: 0 }
-			DirRight => { x: 1, y: 0 }
-		}
-
-	can_turn_to : Direction, Direction -> Bool
-	can_turn_to = |current, requested|
-		match current {
-			DirUp => requested != DirDown
-			DirDown => requested != DirUp
-			DirLeft => requested != DirRight
-			DirRight => requested != DirLeft
-		}
-}
-
-GameState := [Playing, GameOver]
-
-## State retained between updates: the snake board and score, queued direction,
-## fixed-rate timing, repeatable random state, audio and font resources, and a
-## small animation timer. These values are enough for the next update to
-## continue the same game and for `render!` to draw it.
-Model : {
-	snake : List(Cell),
-	direction : Direction,
-	pending_direction : Direction,
-	food : Cell,
-	score : U64,
-	accumulator : F32,
-	state : GameState,
-	eat_sound : Audio.Sound,
-	crash_sound : Audio.Sound,
-	start_sound : Audio.Sound,
-	font : Text.Font,
-
-	## Wall-clock seconds since launch, advanced by `update!` and used only by
-	## the renderer, to pulse the food and breathe the restart prompt.
-	elapsed : F32,
-
-	## Text measured once in `init!`. Only the score changes per frame, and it
-	## is short enough to lay out inline.
-	title : Text.Prepared,
-	hint : Text.Prepared,
-	over_title : Text.Prepared,
-	over_hint : Text.Prepared,
-
-	## Simulation randomness lives in the model, so food appears on the frame it
-	## was eaten and a run replays exactly from its seed.
-	rng : Random.State,
-}
-
-## What a slice of simulation produced: the model it left behind, and the sounds
-## it made getting there.
-##
-## One frame can run several fixed steps, and each of them can crash or eat, so
-## the sounds have to be carried out of the recursion rather than returned by
-## whichever step happened to be last.
-Stepped : {
-	model : Model,
-	sounds : List(Audio.Playback),
-}
+Controls : Game.Controls
 
 program = { init!, update!, render! }
 
-screen_w = 800.F32
-
-screen_h = 600.F32
-
-board_x = 75.F32
-
-board_y = 80.F32
-
-cell_size = 26.F32
-
-grid_cols = 25.I32
-
-grid_rows = 18.I32
-
-# The same two counts as `U64`, for the list-shaped loops the renderer uses.
-grid_cols_count = 25.U64
-
-grid_rows_count = 18.U64
-
-step_time = 0.115.F32
-
-# --- Palette: one dark cabinet, a cyan snake, a warm apple ---
-field_top : Color.Rgba
-field_top = Color.from_hex_rgb(0x151d3a)
-
-field_bottom : Color.Rgba
-field_bottom = Color.from_hex_rgb(0x060810)
-
-board_fill : Color.Rgba
-board_fill = Color.from_hex_rgb(0x0b1226)
-
-grid_line : Color.Rgba
-grid_line = Color.from_hex_rgb(0x16203f)
-
-snake_head : Color.Rgba
-snake_head = Color.from_hex_rgb(0x7ef7d1)
-
-snake_tail : Color.Rgba
-snake_tail = Color.from_hex_rgb(0x1d7fb8)
-
-food_neon : Color.Rgba
-food_neon = Color.from_hex_rgb(0xff6b8b)
-
-hint_color : Color.Rgba
-hint_color = Color.from_hex_rgb(0x6d7aa8)
-
-start_snake : List(Cell)
-start_snake = [{ x: 12, y: 9 }, { x: 11, y: 9 }, { x: 10, y: 9 }]
-
+## Loads presentation assets and seeds the first reproducible Snake world.
 init! : App.Init(Model, [ResourceLimit, SoundGenerationFailed])
 init! = App.init(
 	App.default.with_title("RocRay Snake").with_size({ width: 800, height: 600 }).with_frame_pacing(Capped(120)),
 	|startup| {
-		font = Draw.default_font!()
-		seed = {
-			snake: start_snake,
-			direction: DirRight,
-			pending_direction: DirRight,
-			food: { x: 18, y: 9 },
-			score: 0,
-			accumulator: 0,
-			state: Playing,
-			eat_sound: Audio.gen_tone!({ freq: 620, ms: 70 })?,
-			crash_sound: Audio.gen_tone!({ freq: 120, ms: 180 })?,
-			start_sound: Audio.gen_tone!({ freq: 360, ms: 80 })?,
-			font: font,
-			elapsed: 0,
-			title: Text.from("SNAKE", font).size(30).spacing(6).prepare!()?,
-			hint: Text.from("ARROWS / WASD  turn    SPACE  restart    ESC  quit", font).size(17).prepare!()?,
-			over_title: Text.from("GAME OVER", font).size(40).prepare!()?,
-			over_hint: Text.from("PRESS SPACE TO PLAY AGAIN", font).size(19).prepare!()?,
-			# Entropy is asked for once, here. From this point randomness is
-			# model state that `update!` advances without an effect, so this
-			# whole run reproduces from the one number below. Replace it with
-			# a constant to get the same game every time.
-			rng: Random.seed(U64.to_u32_wrap(App.entropy!(startup))),
-		}
-
-		Ok(new_game(seed))
+		rng = Random.seed(U64.to_u32_wrap(App.entropy!(startup)))
+		Ok({ assets: Assets.load!()?, world: Game.new_world(rng), elapsed: 0 })
 	},
 )
 
-new_game : Model -> Model
-new_game = |model| {
-	spawned = spawn_food(model.rng, start_snake)
-	{
-		..model,
-		rng: spawned.state,
-		snake: start_snake,
-		direction: DirRight,
-		pending_direction: DirRight,
-		food: spawned.cell,
-		score: 0,
-		accumulator: 0,
-		state: Playing,
-	}
-}
-
-head_of : List(Cell) -> Cell
-head_of = |snake|
-	match List.first(snake) {
-		Ok(head) => head
-		Err(_) => { x: 0, y: 0 }
-	}
-
-find_open_cell : Cell, List(Cell), I32 -> Cell
-find_open_cell = |seed, snake, attempt| {
-	cell_count = grid_cols * grid_rows
-	if attempt >= cell_count {
-		seed
-	} else {
-		flat_index = (seed.y * grid_cols + seed.x + attempt) % cell_count
-		candidate = {
-			x: flat_index % grid_cols,
-			y: flat_index // grid_cols,
-		}
-		if List.contains(snake, candidate) find_open_cell(seed, snake, attempt + 1) else candidate
-	}
-}
-
-# Drawing from the model's generator rather than an effect keeps food placement
-# immediate, and makes a run replay exactly from its seed.
-spawn_food : Random.State, List(Cell) -> { cell : Cell, state : Random.State }
-spawn_food = |state, snake| {
-	column = Random.step(state, Random.bounded_i32(0, grid_cols - 1))
-	row = Random.next(column, Random.bounded_i32(0, grid_rows - 1))
-	{ cell: find_open_cell({ x: column.value, y: row.value }, snake, 0), state: row.state }
-}
-
-requested_direction : Model, Devices.Snapshot -> Direction
-requested_direction = |model, input| {
-	up = input.key_pressed(KeyUp) or input.key_pressed(KeyW)
-	down = input.key_pressed(KeyDown) or input.key_pressed(KeyS)
-	left = input.key_pressed(KeyLeft) or input.key_pressed(KeyA)
-	right = input.key_pressed(KeyRight) or input.key_pressed(KeyD)
-
-	if up {
-		DirUp
-	} else if down {
-		DirDown
-	} else if left {
-		DirLeft
-	} else if right {
-		DirRight
-	} else {
-		model.pending_direction
-	}
-}
-
-apply_input : Model, Devices.Snapshot -> Model
-apply_input = |model, input| {
-	requested = requested_direction(model, input)
-	pending = if model.direction.can_turn_to(requested) requested else model.pending_direction
-	{ ..model, pending_direction: pending }
-}
-
-step_snake : Model -> Stepped
-step_snake = |model| {
-	move = model.pending_direction.delta()
-	head = head_of(model.snake)
-	next_head = { x: head.x + move.x, y: head.y + move.y }
-	ate = next_head == model.food
-	body_for_collision = if ate model.snake else List.drop_last(model.snake, 1)
-	hit_wall = next_head.x < 0 or next_head.x >= grid_cols or next_head.y < 0 or next_head.y >= grid_rows
-	hit_self = List.contains(body_for_collision, next_head)
-
-	if hit_wall or hit_self {
-		{
-			model: { ..model, accumulator: 0, state: GameOver },
-			sounds: [model.crash_sound.playback()],
-		}
-	} else {
-		next_body = if ate model.snake else List.drop_last(model.snake, 1)
-		next_snake = List.prepend(next_body, next_head)
-
-		if ate {
-			spawned = spawn_food(model.rng, next_snake)
-			{
-				model: {
-					..model,
-					snake: next_snake,
-					direction: model.pending_direction,
-					pending_direction: model.pending_direction,
-					food: spawned.cell,
-					rng: spawned.state,
-					score: model.score + 1,
-					accumulator: model.accumulator,
-					state: Playing,
-				},
-				sounds: [model.eat_sound.playback()],
-			}
+## Translates keyboard bindings into a requested Snake turn and buttons.
+read_controls : Devices.Snapshot -> Controls
+read_controls = |devices| {
+	requested_direction =
+		if devices.key_pressed(KeyUp) or devices.key_pressed(KeyW) {
+			Turn(Up)
+		} else if devices.key_pressed(KeyDown) or devices.key_pressed(KeyS) {
+			Turn(Down)
+		} else if devices.key_pressed(KeyLeft) or devices.key_pressed(KeyA) {
+			Turn(Left)
+		} else if devices.key_pressed(KeyRight) or devices.key_pressed(KeyD) {
+			Turn(Right)
 		} else {
-			{
-				model: {
-					..model,
-					snake: next_snake,
-					direction: model.pending_direction,
-					pending_direction: model.pending_direction,
-					accumulator: model.accumulator,
-					state: Playing,
-				},
-				sounds: [],
-			}
+			KeepDirection
 		}
+	{ requested_direction, restart_pressed: devices.key_pressed(KeySpace), quit_pressed: devices.key_pressed(KeyEscape) }
+}
+
+## Interprets one pure Snake event as its corresponding sound effect.
+play_event! : Assets, Game.Event => {}
+play_event! = |assets, event|
+	match event {
+		FoodEaten => assets.sounds.eat.playback().play!()
+		SnakeCrashed => assets.sounds.crash_sound.playback().play!()
+		GameStarted => assets.sounds.start.playback().play!()
 	}
-}
-
-## Run as many fixed steps as the accumulator has paid for, carrying the sounds
-## along.
-##
-## `sounds` is the running total rather than something the tail returns: a
-## frame that catches up over three steps can eat twice and then crash, and all
-## three sounds have to survive, in that order. Returning only the last step's
-## sounds would silently drop the earlier ones.
-advance_fixed_steps : Model, List(Audio.Playback) -> Stepped
-advance_fixed_steps = |model, sounds| {
-	if model.accumulator < step_time {
-		{ model, sounds }
-	} else {
-		stepped = step_snake({ ..model, accumulator: model.accumulator - step_time })
-		so_far = List.concat(sounds, stepped.sounds)
-		match stepped.model.state {
-			Playing => advance_fixed_steps(stepped.model, so_far)
-			GameOver => { model: stepped.model, sounds: so_far }
-		}
-	}
-}
-
-## Fold one frame's worth of time into the accumulator and run the steps it pays
-## for.
-##
-## `dt` arrives already bounded rather than being read from a frame here: this
-## takes the seconds it should advance by, so a caller can hand it a real
-## cycle's elapsed time or a fixed step without inventing a `Time.Cycle` that
-## never happened.
-advance_playing : Model, Devices.Snapshot, F32 -> Stepped
-advance_playing = |model, input, dt| {
-	input_model = apply_input(model, input)
-	accumulator = input_model.accumulator + dt
-	with_accumulator = { ..input_model, accumulator }
-	advance_fixed_steps(with_accumulator, [])
-}
-
-## A model with no host resources behind it, so the rules above can be exercised
-## from an `expect`. `Audio.Sound.stub` is a sound that plays nothing, which is
-## all a pure test needs of one.
-test_model : Model
-test_model = {
-	snake: start_snake,
-	direction: DirRight,
-	pending_direction: DirRight,
-	food: { x: 18, y: 9 },
-	score: 0,
-	accumulator: 0,
-	state: Playing,
-	eat_sound: Audio.Sound.stub,
-	crash_sound: Audio.Sound.stub,
-	start_sound: Audio.Sound.stub,
-	font: Text.font_stub,
-	elapsed: 0,
-	title: Text.Prepared.stub,
-	hint: Text.Prepared.stub,
-	over_title: Text.Prepared.stub,
-	over_hint: Text.Prepared.stub,
-	rng: Random.seed(1),
-}
-
-expect {
-	direction : Direction
-	direction = DirUp
-	direction.delta() == { x: 0, y: -1 }
-}
-
-## A turn into the body is refused; any other turn is allowed.
-expect {
-	direction : Direction
-	direction = DirRight
-	!direction.can_turn_to(DirLeft)
-}
-
-expect {
-	direction : Direction
-	direction = DirRight
-	direction.can_turn_to(DirUp)
-}
-
-## Food never lands on the snake: the probe walks on until it finds a free cell.
-expect find_open_cell({ x: 12, y: 9 }, start_snake, 0) == { x: 13, y: 9 }
-
-## An ordinary step moves the head one cell and drops the tail, so the length
-## holds and nothing sounds.
-expect {
-	stepped = step_snake(test_model)
-	head_of(stepped.model.snake) == { x: 13, y: 9 } and List.len(stepped.model.snake) == 3 and List.is_empty(stepped.sounds)
-}
-
-## Eating keeps the tail, scores, and asks for a sound.
-expect {
-	stepped = step_snake({ ..test_model, food: { x: 13, y: 9 } })
-	List.len(stepped.model.snake) == 4 and stepped.model.score == 1 and List.len(stepped.sounds) == 1
-}
-
-## Walking off the board ends the run.
-expect {
-	stepped = step_snake({ ..test_model, snake: [{ x: 24, y: 9 }] })
-	match stepped.model.state {
-		GameOver => Bool.True
-		Playing => Bool.False
-	}
-}
-
-## The accumulator is what makes speed independent of frame rate: two steps'
-## worth of seconds runs two steps, whether that arrived as one frame or four.
-expect {
-	stepped = advance_playing(test_model, Devices.none, step_time * 2)
-	head_of(stepped.model.snake) == { x: 14, y: 9 }
-}
 
 Msg : []
 
+## Advances pure rules, plays their events, and handles the quit control.
 update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
 update! = |model, program_input| {
-	input = program_input.devices
-
-	# Bound catch-up after a breakpoint or stalled window, but retain the fixed
-	# step remainder so normal frame-rate variation does not change game speed.
+	controls = read_controls(program_input.devices)
 	dt = Math.clamp(program_input.time.elapsed_seconds, 0, 0.25)
-
-	stepped = match model.state {
-		Playing => advance_playing(model, input, dt)
-		GameOver =>
-			if input.key_pressed(KeySpace) {
-				{ model: new_game(model), sounds: [model.start_sound.playback()] }
-			} else {
-				{ model, sounds: [] }
-			}
-		}
-
-	# The step is pure and says which sounds it made, in order; this is where
-	# they are played.
-	for playback in stepped.sounds {
-		playback.play!()
+	(world, events) = Game.update(model.world, controls, dt)
+	for event in events {
+		play_event!(model.assets, event)
 	}
-
-	if input.key_pressed(KeyEscape) {
-		Err(Exit(0))
-	} else {
-		Ok({ ..stepped.model, elapsed: stepped.model.elapsed + dt })
-	}
+	if controls.quit_pressed Err(Exit(0)) else Ok({ ..model, world, elapsed: model.elapsed + dt })
 }
 
+## Delegates presentation of the retained world to the rendering module.
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ScopeLimit, ..])
-render! = |model, frame| {
-	frame.clear!(field_bottom)
-	frame.rectangle_gradient_v!({ x: 0, y: 0, width: screen_w, height: screen_h, color_top: field_top, color_bottom: field_bottom })
-	draw_hud!(frame, model)
-	draw_board!(frame)
-	draw_snake_cells!(frame, model.snake)
+render! = |model, frame| Render.draw!(frame, model.assets, model.world, model.elapsed)
 
-	# Everything that glows shares one additive scope, so overlapping light adds
-	# up instead of stacking as translucent grey.
-	frame.with_blend_mode!(
-		Draw.additive_blend,
-		|glow_frame| {
-			draw_food!(glow_frame, model)
-			head_rect = cell_rect(head_of(model.snake))
-			glow_frame.circle_gradient!({
-				center: Math.center(head_rect),
-				radius: cell_size * 1.5,
-				color_inner: Color.with_alpha(snake_head, 90),
-				color_outer: Color.with_alpha(snake_head, 0),
-			})
-			Ok({})
-		},
-	)?
+no_controls : Controls
+no_controls = { requested_direction: KeepDirection, restart_pressed: Bool.False, quit_pressed: Bool.False }
 
-	draw_food_body!(frame, model)
-	draw_cell!(frame, head_of(model.snake), snake_head, Color.with_alpha(Color.white, 200))
-	draw_game_over!(frame, model)
-
-	Ok({})
+expect read_controls(Devices.none.with_key_pressed(KeyUp)).requested_direction == Turn(Up)
+expect {
+	direction : Snake.Direction
+	direction = Right
+	!direction.can_turn_to(Left)
 }
 
-cell_rect : Cell -> Math.Rect
-cell_rect = |cell| {
-	x: board_x + I32.to_f32(cell.x) * cell_size,
-	y: board_y + I32.to_f32(cell.y) * cell_size,
-	width: cell_size,
-	height: cell_size,
+expect {
+	direction : Snake.Direction
+	direction = Right
+	direction.can_turn_to(Up)
+}
+expect Board.find_open_cell({ x: 12, y: 9 }, Snake.initial.cells, 0) == { x: 13, y: 9 }
+
+expect {
+	world = Game.new_world(Random.seed(1))
+	(next, events) = Game.step_snake(world)
+	next.snake.head() == { x: 13, y: 9 } and List.len(next.snake.cells) == 3 and List.is_empty(events)
 }
 
-draw_cell! : Draw.Frame, Cell, Color.Rgba, Color.Rgba => {}
-draw_cell! = |frame, cell, fill, outline| {
-	rect = cell_rect(cell)
-	frame.rounded_rectangle!({ x: rect.x + 2, y: rect.y + 2, width: rect.width - 4, height: rect.height - 4, radius: 0.35, segments: 6, style: Draw.filled_and_outlined(fill, outline, 1) })
+expect {
+	world = { ..Game.new_world(Random.seed(1)), food: { x: 13, y: 9 } }
+	(next, events) = Game.step_snake(world)
+	List.len(next.snake.cells) == 4 and next.score == 1 and events == [FoodEaten]
 }
 
-# The apple breathes: one sine of the model's own clock drives both the halo
-# radius and its brightness, so the board never sits completely still.
-food_pulse : Model -> F32
-food_pulse = |model| 0.5 + 0.5 * F32.sin(model.elapsed * 3.4)
-
-draw_food! : Draw.Frame, Model => {}
-draw_food! = |frame, model| {
-	pulse = food_pulse(model)
-	frame.circle_gradient!({
-		center: Math.center(cell_rect(model.food)),
-		radius: cell_size * (1.0 + 0.5 * pulse),
-		color_inner: Color.with_alpha(food_neon, F32.to_u8_wrap(70 + 60 * pulse)),
-		color_outer: Color.with_alpha(food_neon, 0),
-	})
+expect {
+	world = Game.new_world(Random.seed(1))
+	snake : Snake
+	snake = { ..world.snake, cells: [{ x: 24, y: 9 }] }
+	(next, events) = Game.step_snake({ ..world, snake })
+	next.state == GameOver and events == [SnakeCrashed]
 }
 
-draw_food_body! : Draw.Frame, Model => {}
-draw_food_body! = |frame, model| {
-	center = Math.center(cell_rect(model.food))
-	radius = cell_size * (0.3 + 0.04 * food_pulse(model))
-	frame.circle!({ center: center, radius: radius, style: Draw.filled(food_neon) })
-	frame.circle!({ center: { x: center.x - radius * 0.3, y: center.y - radius * 0.35 }, radius: radius * 0.32, style: Draw.filled(Color.with_alpha(Color.white, 190)) })
+expect {
+	world = Game.new_world(Random.seed(1))
+	(next, _events) = Game.update(world, no_controls, Game.step_time * 2)
+	next.snake.head() == { x: 14, y: 9 }
 }
-
-# The body fades from head to tail. Mixing the two palette colors by position
-# rather than giving every segment one color is what reads as a direction of
-# travel when the snake is long.
-segment_color : U64, U64 -> Color.Rgba
-segment_color = |index, length| {
-	t = if length <= 1 0 else U64.to_f32(index) / U64.to_f32(length - 1)
-	mix = |from, to| F32.to_u8_wrap(U8.to_f32(from) + (U8.to_f32(to) - U8.to_f32(from)) * t)
-	Color.rgba(mix(snake_head.r, snake_tail.r), mix(snake_head.g, snake_tail.g), mix(snake_head.b, snake_tail.b), 255)
-}
-
-draw_snake_cells! : Draw.Frame, List(Cell) => {}
-draw_snake_cells! = |frame, snake| {
-	length = List.len(snake)
-	for segment in List.map_with_index(snake, |cell, index| { cell, color: segment_color(index, length) }) {
-		draw_cell!(frame, segment.cell, segment.color, Color.with_alpha(segment.color, 90))
-	}
-}
-
-draw_board! : Draw.Frame => {}
-draw_board! = |frame| {
-	board_w = I32.to_f32(grid_cols) * cell_size
-	board_h = I32.to_f32(grid_rows) * cell_size
-	frame.rounded_rectangle!({ x: board_x - 8, y: board_y - 8, width: board_w + 16, height: board_h + 16, radius: 0.06, segments: 8, style: Draw.filled_and_outlined(board_fill, Color.from_hex_rgb(0x2a3566), 2) })
-
-	# A faint lattice, so a cell is a place rather than an empty field.
-	for column in List.map_with_index(List.repeat({}, grid_cols_count + 1), |_unit, index| board_x + U64.to_f32(index) * cell_size) {
-		frame.line!({ start: { x: column, y: board_y }, end: { x: column, y: board_y + board_h }, stroke: Draw.stroke(grid_line, 1) })
-	}
-	for row in List.map_with_index(List.repeat({}, grid_rows_count + 1), |_unit, index| board_y + U64.to_f32(index) * cell_size) {
-		frame.line!({ start: { x: board_x, y: row }, end: { x: board_x + board_w, y: row }, stroke: Draw.stroke(grid_line, 1) })
-	}
-}
-
-draw_hud! : Draw.Frame, Model => {}
-draw_hud! = |frame, model| {
-	model.title.draw!(frame, { pos: { x: board_x, y: 26 }, color: snake_head })
-	Text.from("SCORE ${U64.to_str(model.score)}", model.font)
-		.size(24)
-		.draw!(frame, { pos: { x: screen_w - board_x, y: 30 }, color: Color.from_hex_rgb(0xd7e3ff), align: (Top, Right) })
-	model.hint.draw!(frame, { pos: { x: screen_w * 0.5, y: screen_h - 20 }, color: hint_color, align: (Middle, Center) })
-}
-
-draw_game_over! : Draw.Frame, Model => {}
-draw_game_over! = |frame, model|
-	match model.state {
-		Playing => {}
-		GameOver => {
-			board_w = I32.to_f32(grid_cols) * cell_size
-			frame.rectangle!({ x: board_x - 8, y: 236, width: board_w + 16, height: 140, style: Draw.filled(Color.with_alpha(field_bottom, 225)) })
-			model.over_title.draw!(frame, { pos: { x: screen_w * 0.5, y: 282 }, color: food_neon, align: (Middle, Center) })
-			# The prompt breathes on the same clock as the food, so a waiting
-			# screen still has a heartbeat.
-			prompt_alpha = F32.to_u8_wrap(150 + 105 * food_pulse(model))
-			model.over_hint.draw!(frame, { pos: { x: screen_w * 0.5, y: 336 }, color: Color.with_alpha(hint_color, prompt_alpha), align: (Middle, Center) })
-		}
-	}

--- a/examples/snake/main.roc
+++ b/examples/snake/main.roc
@@ -9,7 +9,7 @@
 ## - App wiring (`main.roc`): reproducible random seed and event sounds
 ## - Rendering (`Render.roc`): board, HUD, snake, food, glow, and game over
 ## - Gameplay (`Snake.roc`, `Board.roc`): legal turns, growth, collisions, and food
-## - Tests (`main.roc`): turns, food placement, movement, eating, and crashes
+## - Tests (`main.roc`, `Board.roc`, `Game.roc`): controls, turns, food placement, movement, eating, and crashes
 app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-08-23-fb208ba" }
 
 import rr.App
@@ -18,7 +18,6 @@ import rr.Draw
 import rr.Math
 import rr.Random
 import Assets
-import Board
 import Game
 import Render
 import Snake
@@ -84,45 +83,6 @@ update! = |model, program_input| {
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ScopeLimit, ..])
 render! = |model, frame| Render.draw!(frame, model.assets, model.world, model.elapsed)
 
-no_controls : Controls
-no_controls = { requested_direction: KeepDirection, restart_pressed: Bool.False, quit_pressed: Bool.False }
-
 expect read_controls(Devices.none.with_key_pressed(KeyUp)).requested_direction == Turn(Up)
-expect {
-	direction : Snake.Direction
-	direction = Right
-	!direction.can_turn_to(Left)
-}
-
-expect {
-	direction : Snake.Direction
-	direction = Right
-	direction.can_turn_to(Up)
-}
-expect Board.find_open_cell({ x: 12, y: 9 }, Snake.initial.cells, 0) == { x: 13, y: 9 }
-
-expect {
-	world = Game.new_world(Random.seed(1))
-	(next, events) = Game.step_snake(world)
-	next.snake.head() == { x: 13, y: 9 } and List.len(next.snake.cells) == 3 and List.is_empty(events)
-}
-
-expect {
-	world = { ..Game.new_world(Random.seed(1)), food: { x: 13, y: 9 } }
-	(next, events) = Game.step_snake(world)
-	List.len(next.snake.cells) == 4 and next.score == 1 and events == [FoodEaten]
-}
-
-expect {
-	world = Game.new_world(Random.seed(1))
-	snake : Snake
-	snake = { ..world.snake, cells: [{ x: 24, y: 9 }] }
-	(next, events) = Game.step_snake({ ..world, snake })
-	next.state == GameOver and events == [SnakeCrashed]
-}
-
-expect {
-	world = Game.new_world(Random.seed(1))
-	(next, _events) = Game.update(world, no_controls, Game.step_time * 2)
-	next.snake.head() == { x: 14, y: 9 }
-}
+expect Snake.initial.request_turn(Left).pending_direction == Right
+expect Snake.initial.request_turn(Up).pending_direction == Up

--- a/examples/top_down/Game.roc
+++ b/examples/top_down/Game.roc
@@ -1,0 +1,275 @@
+## Pure Spark Run world updates and their ordered gameplay events.
+import rr.Math
+import Hazard
+import Level
+import Player
+import Spark
+
+Game := [].{
+	State := [Playing, Won, GameOver].{
+		is_eq : _
+	}
+	Gate := [GateLocked, GateOpen].{
+		is_eq : _
+
+		## Reports whether every spark has unlocked the exit gate.
+		is_open : Gate -> Bool
+		is_open = |gate|
+			match gate {
+				GateLocked => Bool.False
+				GateOpen => Bool.True
+			}
+	}
+	Controls : { move : Math.Vec2, dash_pressed : Bool, restart_pressed : Bool, quit_pressed : Bool }
+	World : {
+		player : Player,
+		sparks : List(Spark),
+		score : U64,
+		lives : U64,
+		phase : F32,
+		shake : F32,
+		flash : F32,
+		burst_pos : Math.Vec2,
+		burst_timer : F32,
+		gate : Gate,
+		gate_flash : F32,
+		state : State,
+	}
+	Event := [DashStarted(Math.Vec2), SparkCollected(Spark), GateOpened, Escaped, Damaged(State), GameStarted].{
+		is_eq : _
+	}
+	burst_duration = 0.36.F32
+
+	## Creates a playing world from immutable level spawn data.
+	new : Level -> World
+	new = |level| {
+		player: Player.new(level.spawn),
+		sparks: level.sparks,
+		score: 0,
+		lives: 3,
+		phase: 0,
+		shake: 0,
+		flash: 0,
+		burst_pos: level.spawn,
+		burst_timer: 0,
+		gate: GateLocked,
+		gate_flash: 0,
+		state: Playing,
+	}
+
+	## Advances gameplay or restarts a finished run and returns ordered events.
+	update : Level, World, Controls, F32 -> (World, List(Event))
+	update = |level, world, controls, dt|
+		match world.state {
+			Playing => advance_world(level, world, controls, dt)
+			Won => restart_if_requested(level, world, controls)
+			GameOver => restart_if_requested(level, world, controls)
+		}
+}
+
+CollectResult : { world : Game.World, collected : Try(Spark, [NoSpark]), gate_opened : Bool }
+
+EscapeResult : { world : Game.World, escaped : Bool }
+
+DamageResult : { world : Game.World, damaged : Bool }
+
+## Restarts a finished run when the semantic restart control is pressed.
+restart_if_requested : Level, Game.World, Game.Controls -> (Game.World, List(Game.Event))
+restart_if_requested = |level, world, controls| if controls.restart_pressed (Game.new(level), [GameStarted]) else (world, [])
+
+## Keeps a proposed player center inside the authored world bounds.
+clamp_to_world : Level, Math.Vec2 -> Math.Vec2
+clamp_to_world = |level, pos| {
+	x: Math.clamp(pos.x, Math.left(level.bounds) + Player.radius, Math.right(level.bounds) - Player.radius),
+	y: Math.clamp(pos.y, Math.top(level.bounds) + Player.radius, Math.bottom(level.bounds) - Player.radius),
+}
+
+## Reports whether a player circle touches an object or solid tile.
+any_obstacle_hit : Level, Math.Circle -> Bool
+any_obstacle_hit = |level, circle| {
+	var $hit = Bool.False
+	for obstacle in level.obstacles {
+		if obstacle.hit_by(circle) {
+			$hit = Bool.True
+		}
+	}
+	if level.tilemap.circle_touches_solid(circle) {
+		$hit = Bool.True
+	}
+	$hit
+}
+
+## Moves the player at a chosen speed unless the destination is blocked.
+move_player_speed : Level, Math.Vec2, Math.Vec2, F32, F32 -> Math.Vec2
+move_player_speed = |level, player, raw_dir, dt, speed| {
+	dir = Math.normalize(raw_dir)
+	candidate = clamp_to_world(level, Math.add(player, Math.scale(dir, speed * dt)))
+	if any_obstacle_hit(level, Math.circle(candidate, Player.radius)) player else candidate
+}
+
+## Wraps the shared hazard phase into the unit interval.
+wrap_unit : F32 -> F32
+wrap_unit = |value| if value >= 1 value - 1 else if value < 0 value + 1 else value
+
+## Counts a positive feedback timer down without crossing below zero.
+tick_timer : F32, F32 -> F32
+tick_timer = |timer, dt| if timer <= dt 0 else timer - dt
+
+## Finds the first remaining spark touched by the player circle.
+find_hit_spark : List(Spark), Math.Circle, U64 -> Try(Spark, [NoSpark])
+find_hit_spark = |sparks, player_circle, index|
+	match List.get(sparks, index) {
+		Ok(spark) => if spark.hit_by(player_circle) Ok(spark) else find_hit_spark(sparks, player_circle, index + 1)
+		Err(_) => Err(NoSpark)
+	}
+
+## Chooses the gate state from the remaining collectible sparks.
+gate_after_collect : List(Spark) -> Game.Gate
+gate_after_collect = |remaining| if List.len(remaining) == 0 GateOpen else GateLocked
+
+## Removes a touched spark, scores it, and opens the gate when it was last.
+collect_spark : Game.World -> CollectResult
+collect_spark = |world|
+	match find_hit_spark(world.sparks, world.player.circle(), 0) {
+		Ok(spark) => {
+			remaining = List.keep_if(world.sparks, |item| item.id != spark.id)
+			next_gate = gate_after_collect(remaining)
+			gate_opened = next_gate == GateOpen and !(world.gate.is_open())
+			{
+				world: {
+					..world,
+					sparks: remaining,
+					score: world.score + 1,
+					shake: 0,
+					flash: 0,
+					burst_pos: spark.pos,
+					burst_timer: Game.burst_duration,
+					gate: next_gate,
+					gate_flash: if gate_opened 1 else world.gate_flash,
+					state: Playing,
+				},
+				collected: Ok(spark),
+				gate_opened,
+			}
+		}
+		Err(_) => { world, collected: Err(NoSpark), gate_opened: Bool.False }
+	}
+
+## Reports whether any moving hazard touches the player.
+any_hazard_hit : Level, Math.Circle, F32 -> Bool
+any_hazard_hit = |level, circle, phase| {
+	var $hit = Bool.False
+	for hazard in level.hazards {
+		if hazard.hit_by(circle, phase) {
+			$hit = Bool.True
+		}
+	}
+	$hit
+}
+
+## Applies hazard damage, respawn, lives, and game-over rules when vulnerable.
+damage_if_needed : Level, Game.World -> DamageResult
+damage_if_needed = |level, world| {
+	if world.player.invuln <= 0 and any_hazard_hit(level, world.player.circle(), world.phase) {
+		next_lives = if world.lives > 0 world.lives - 1 else 0
+		next_state = if world.lives <= 1 GameOver else Playing
+		{
+			world: {
+				..world,
+				player: world.player.damage_respawn(level.spawn),
+				lives: next_lives,
+				shake: 10,
+				flash: 0.28,
+				burst_pos: world.player.pos,
+				burst_timer: Game.burst_duration,
+				state: next_state,
+			},
+			damaged: Bool.True,
+		}
+	} else {
+		{ world, damaged: Bool.False }
+	}
+}
+
+## Wins the run when the player touches the open exit.
+escape_if_needed : Level, Game.World -> EscapeResult
+escape_if_needed = |level, world| {
+	if world.gate.is_open() and Math.circle_overlaps(world.player.circle(), Math.circle(level.exit_center, level.exit_radius)) {
+		{
+			world: {
+				..world,
+				shake: 10,
+				flash: 0,
+				burst_pos: level.exit_center,
+				burst_timer: Game.burst_duration,
+				gate_flash: 1,
+				state: Won,
+			},
+			escaped: Bool.True,
+		}
+	} else {
+		{ world, escaped: Bool.False }
+	}
+}
+
+## Includes a gameplay event only when its rule fired.
+event_when : Bool, Game.Event -> List(Game.Event)
+event_when = |condition, event| if condition [event] else []
+
+## Converts an optional collected spark into its gameplay event.
+spark_collected_events : Try(Spark, [NoSpark]) -> List(Game.Event)
+spark_collected_events = |collected|
+	match collected {
+		Ok(spark) => [SparkCollected(spark)]
+		Err(_) => []
+	}
+
+## Orders all events produced by one playing-world update.
+game_events : Bool, Try(Spark, [NoSpark]), Bool, Bool, Bool, Game.State, Math.Vec2 -> List(Game.Event)
+game_events = |dash_started, collected, gate_opened, escaped, damaged, damage_state, dash_pos|
+	List.concat(
+		event_when(dash_started, DashStarted(dash_pos)),
+		List.concat(
+			spark_collected_events(collected),
+			List.concat(event_when(gate_opened, GateOpened), List.concat(event_when(escaped, Escaped), event_when(damaged, Damaged(damage_state)))),
+		),
+	)
+
+## Advances player movement, hazards, collection, escape, and damage once.
+advance_world : Level, Game.World, Game.Controls, F32 -> (Game.World, List(Game.Event))
+advance_world = |level, world, controls, dt| {
+	moving = controls.move.x != 0 or controls.move.y != 0
+	dash_started = controls.dash_pressed and world.player.dash_ready()
+	dash_active = dash_started or world.player.dash_active()
+	move_dir = if dash_active and !(moving) world.player.facing_dir() else controls.move
+	speed = if dash_active Player.dash_speed else Player.speed
+	player_pos = move_player_speed(level, world.player.pos, move_dir, dt, speed)
+	player = world.player.step({ pos: player_pos, raw_dir: controls.move, move_dir, dash_started, dash_active, dt })
+	hazard_speed = 0.15 + U64.to_f32(world.score) * 0.012
+	phase = wrap_unit(world.phase + dt * hazard_speed)
+	moved = {
+		..world,
+		player,
+		phase,
+		shake: Math.clamp(world.shake - dt * 36, 0, 99),
+		flash: tick_timer(world.flash, dt * 1.8),
+		burst_timer: tick_timer(world.burst_timer, dt),
+		gate_flash: tick_timer(world.gate_flash, dt * 1.15),
+		state: Playing,
+	}
+	collect_result = collect_spark(moved)
+	escape_result = escape_if_needed(level, collect_result.world)
+	damage_result = if escape_result.world.state == Won { world: escape_result.world, damaged: Bool.False } else damage_if_needed(level, escape_result.world)
+	(
+		damage_result.world,
+		game_events(
+			dash_started,
+			collect_result.collected,
+			collect_result.gate_opened,
+			escape_result.escaped,
+			damage_result.damaged,
+			damage_result.world.state,
+			world.player.pos,
+		),
+	)
+}

--- a/examples/top_down/GameAssets.roc
+++ b/examples/top_down/GameAssets.roc
@@ -1,0 +1,77 @@
+## Spark Run textures, font, music, and sound effects loaded at startup.
+import rr.Assets
+import rr.Audio
+import rr.Draw
+import rr.Text
+
+GameAssets := {
+	characters : Draw.Texture,
+	tiles : Draw.Texture,
+	font : Text.Font,
+	sounds : Sounds,
+}.{
+	Sounds : {
+		collect : Audio.Sound,
+		hurt : Audio.Sound,
+		win : Audio.Sound,
+		lose : Audio.Sound,
+		gate : Audio.Sound,
+		dash : Audio.Sound,
+		sparkle : Audio.Sound,
+		music : Audio.Music,
+	}
+
+	## Loads every texture, font, sound, and music stream before the first frame.
+	load! = || {
+		store = Assets.Store.open!(Assets.working_directory("examples/top_down/assets"))?
+		characters = Assets.load_texture!(store, "kenney-topdown/characters.png")?
+		tiles = Assets.load_texture!(store, "kenney-topdown/tiles.png")?
+		font = Draw.default_font!()
+		sounds = load_sounds!()?
+		Ok({ characters, tiles, font, sounds })
+	}
+}
+
+collect_path = "examples/top_down/assets/kenney-audio/sfx/collect.ogg"
+
+hurt_path = "examples/top_down/assets/kenney-audio/sfx/hurt.ogg"
+
+win_path = "examples/top_down/assets/kenney-audio/sfx/win.ogg"
+
+lose_path = "examples/top_down/assets/kenney-audio/sfx/lose.ogg"
+
+gate_path = "examples/top_down/assets/kenney-audio/sfx/gate.ogg"
+
+dash_path = "examples/top_down/assets/kenney-audio/sfx/dash.ogg"
+
+music_path = "examples/top_down/assets/kenney-audio/music/spark_loop.wav"
+
+music_volume = 0.13.F32
+
+## Generates a compact fallback effect when an audio file cannot be loaded.
+make_sound! : Audio.Waveform, F32, F32, I32, F32 => Try(Audio.Sound, [ResourceLimit, SoundGenerationFailed, ..])
+make_sound! = |waveform, from, to, ms, volume|
+	Audio.gen_sound!({ waveform, freq_start: from, freq_end: to, ms, attack_ms: 2, decay_ms: 24, sustain: 0.45, release_ms: 45, volume })
+
+## Loads a sound file or retains its generated fallback.
+load_sound_or! : Str, Audio.Sound => Audio.Sound
+load_sound_or! = |path, fallback|
+	match Audio.load_sound!(path) {
+		Ok(sound) => sound
+		Err(_) => fallback
+	}
+
+## Loads the complete sound set and configures looping background music.
+load_sounds! = || {
+	collect = load_sound_or!(collect_path, make_sound!(Sine, 880, 1160, 110, 0.55)?)
+	hurt = load_sound_or!(hurt_path, make_sound!(Noise, 180, 70, 220, 0.7)?)
+	win = load_sound_or!(win_path, make_sound!(Square, 640, 1280, 520, 0.45)?)
+	lose = load_sound_or!(lose_path, make_sound!(Saw, 120, 45, 520, 0.5)?)
+	gate = load_sound_or!(gate_path, make_sound!(Square, 220, 390, 240, 0.45)?)
+	dash = load_sound_or!(dash_path, make_sound!(Noise, 520, 120, 130, 0.38)?)
+	sparkle = make_sound!(Sine, 980, 1620, 140, 0.36)?
+	music = Audio.load_music!(music_path)?
+	music.set_volume!(music_volume)
+	music.set_looping!(Bool.True)
+	Ok({ collect, hurt, win, lose, gate, dash, sparkle, music })
+}

--- a/examples/top_down/Hazard.roc
+++ b/examples/top_down/Hazard.roc
@@ -1,0 +1,56 @@
+## Moving arena hazards, their lanes, and collision bodies.
+import rr.Color
+import rr.Math
+
+Hazard := {
+	center : Math.Vec2,
+	span : F32,
+	lane : Lane,
+	offset : F32,
+	radius : F32,
+	color : Color.Rgba,
+}.{
+	Lane := [Horizontal, Vertical]
+
+	## Returns the hazard position for the shared animation phase.
+	pos : Hazard, F32 -> Math.Vec2
+	pos = |hazard, phase| {
+		amount = ping_pong(wrap_unit(phase + hazard.offset))
+		match hazard.lane {
+			Vertical => { x: hazard.center.x, y: hazard.center.y - hazard.span * 0.5 + hazard.span * amount }
+			Horizontal => { x: hazard.center.x - hazard.span * 0.5 + hazard.span * amount, y: hazard.center.y }
+		}
+	}
+
+	## Returns the first endpoint of the visible hazard lane.
+	lane_start : Hazard -> Math.Vec2
+	lane_start = |hazard|
+		match hazard.lane {
+			Vertical => { x: hazard.center.x, y: hazard.center.y - hazard.span * 0.5 }
+			Horizontal => { x: hazard.center.x - hazard.span * 0.5, y: hazard.center.y }
+		}
+
+	## Returns the second endpoint of the visible hazard lane.
+	lane_end : Hazard -> Math.Vec2
+	lane_end = |hazard|
+		match hazard.lane {
+			Vertical => { x: hazard.center.x, y: hazard.center.y + hazard.span * 0.5 }
+			Horizontal => { x: hazard.center.x + hazard.span * 0.5, y: hazard.center.y }
+		}
+
+	## Reports whether another circle touches this moving hazard.
+	hit_by : Hazard, Math.Circle, F32 -> Bool
+	hit_by = |hazard, other, phase| Math.circle_overlaps(other, hazard_circle(hazard, phase))
+}
+
+## Returns the private circular collision body for a moving hazard.
+hazard_circle : Hazard, F32 -> Math.Circle
+hazard_circle = |hazard, phase| Math.circle(hazard.pos(phase), hazard.radius)
+
+## Wraps an animation phase into the unit interval.
+wrap_unit : F32 -> F32
+wrap_unit = |value| if value >= 1 value - 1 else if value < 0 value + 1 else value
+
+## Maps a wrapped phase to a back-and-forth lane amount.
+ping_pong : F32 -> F32
+ping_pong = |phase| if phase < 0.5 phase * 2 else (1 - phase) * 2

--- a/examples/top_down/Level.roc
+++ b/examples/top_down/Level.roc
@@ -1,0 +1,283 @@
+## Static arena data loaded from Tiled, with a complete fallback layout.
+import rr.Color
+import rr.Draw
+import rr.Math
+import rr.Tilemap
+import Hazard
+import Spark
+
+Level := {
+	tilemap : Tilemap,
+	spawn : Math.Vec2,
+	exit_center : Math.Vec2,
+	exit_radius : F32,
+	sparks : List(Spark),
+	spark_total : U64,
+	obstacles : List(Obstacle),
+	hazards : List(Hazard),
+	decorations : List(Decoration),
+	bounds : Math.Rect,
+}.{
+	Tile := [
+		TileFloor,
+		TileBlockA,
+		TileBlockB,
+		TileMarker,
+		TileRockA,
+		TilePlantA,
+		TilePlantB,
+		TileFlowerA,
+		TileFlowerB,
+		TileCrystalA,
+		TileCrystalB,
+		TileSparkA,
+		TileSparkB,
+	]
+
+	Decoration : { pos : Math.Vec2, tile : Tile, scale : F32, rotation : F32 }
+
+	Obstacle := { rect : Math.Rect, tile : Tile, rotation : F32 }.{
+
+		## Returns the obstacle center used to place its decoration.
+		center : Obstacle -> Math.Vec2
+		center = |obstacle| Math.center(obstacle.rect)
+
+		## Reports whether a circle touches the solid obstacle.
+		hit_by : Obstacle, Math.Circle -> Bool
+		hit_by = |obstacle, circle| Math.circle_rect(circle, obstacle.rect)
+	}
+
+	## Loads the authored Tiled map and binds its visible layers to the tile texture.
+	load! = |tiles| {
+		raw_map = Tilemap.load_tmx!("examples/top_down/assets/top_down.tmx")?
+		tilemap = Tilemap.from_raw(raw_map)
+			.with_origin({ x: world_left, y: world_top })
+			.with_tileset_texture(1, tiles)
+			.layer_role("Ground", Drawn)
+			.layer_role("Decor", Drawn)
+			.layer_role("Walls", Solid)
+			.object_role("spawn", Spawn)
+			.object_role("spark", Collectible)
+			.object_role("hazard", Hazard)
+			.object_role("exit", Exit)
+			.build()?
+		Ok(from_tilemap(tilemap))
+	}
+
+}
+
+world_left = -720.F32
+
+world_top = -520.F32
+
+world_right = 1456.F32
+
+world_bottom = 1144.F32
+
+fallback_spawn : Math.Vec2
+fallback_spawn = { x: -560, y: -360 }
+
+fallback_exit_center : Math.Vec2
+fallback_exit_center = { x: 1185, y: 920 }
+
+fallback_exit_radius = 58.F32
+
+world_bounds : Math.Rect
+world_bounds = Math.rect(world_left, world_top, world_right - world_left, world_bottom - world_top)
+
+## Converts a configured Tiled map into immutable gameplay data.
+from_tilemap : Tilemap -> Level
+from_tilemap = |tilemap| {
+	raw = tilemap.raw_map()
+	spawn_object = first_typed_object(tilemap, "spawn")
+	exit_object = first_typed_object(tilemap, "exit")
+	sparks = sparks_from_tilemap(tilemap)
+	{
+		tilemap,
+		spawn: object_center_or(tilemap, spawn_object, fallback_spawn),
+		exit_center: object_center_or(tilemap, exit_object, fallback_exit_center),
+		exit_radius: object_radius_or(exit_object, fallback_exit_radius),
+		sparks,
+		spark_total: List.len(sparks),
+		obstacles: obstacles_from_tilemap(raw, tilemap),
+		hazards: hazards_from_tilemap(raw, tilemap),
+		decorations: decorations_from_tilemap(raw, tilemap),
+		bounds: world_bounds,
+	}
+}
+
+fallback_sparks : List(Spark)
+fallback_sparks = [
+	Spark.{ id: 0, pos: { x: -430, y: -150 } },
+	Spark.{ id: 1, pos: { x: -55, y: -350 } },
+	Spark.{ id: 2, pos: { x: 315, y: -295 } },
+	Spark.{ id: 3, pos: { x: 760, y: -405 } },
+	Spark.{ id: 4, pos: { x: 1110, y: -65 } },
+	Spark.{ id: 5, pos: { x: 910, y: 350 } },
+	Spark.{ id: 6, pos: { x: 560, y: 820 } },
+	Spark.{ id: 7, pos: { x: 105, y: 640 } },
+	Spark.{ id: 8, pos: { x: -280, y: 895 } },
+	Spark.{ id: 9, pos: { x: -540, y: 410 } },
+]
+
+fallback_obstacles : List(Level.Obstacle)
+fallback_obstacles = [
+	Level.Obstacle.{ rect: Math.rect(-305, -300, 150, 440), tile: TileBlockA, rotation: 0 },
+	Level.Obstacle.{ rect: Math.rect(85, -430, 150, 295), tile: TileBlockB, rotation: 11 },
+	Level.Obstacle.{ rect: Math.rect(210, -45, 510, 120), tile: TileBlockA, rotation: 22 },
+	Level.Obstacle.{ rect: Math.rect(705, 150, 140, 425), tile: TileBlockB, rotation: 33 },
+	Level.Obstacle.{ rect: Math.rect(5, 505, 480, 115), tile: TileBlockA, rotation: 44 },
+	Level.Obstacle.{ rect: Math.rect(-535, 515, 340, 105), tile: TileBlockB, rotation: 55 },
+	Level.Obstacle.{ rect: Math.rect(965, -300, 145, 450), tile: TileBlockA, rotation: 66 },
+]
+
+fallback_hazards : List(Hazard)
+fallback_hazards = [
+	Hazard.{ center: { x: -445, y: 165 }, span: 520, lane: Horizontal, offset: 0, radius: 30, color: Color.from_hex_rgb(0xf94144) },
+	Hazard.{ center: { x: 25, y: 320 }, span: 650, lane: Vertical, offset: 0.22, radius: 34, color: Color.from_hex_rgb(0xf3722c) },
+	Hazard.{ center: { x: 600, y: -255 }, span: 650, lane: Horizontal, offset: 0.48, radius: 32, color: Color.from_hex_rgb(0xf8961e) },
+	Hazard.{ center: { x: 1035, y: 455 }, span: 700, lane: Vertical, offset: 0.72, radius: 36, color: Color.from_hex_rgb(0xf94144) },
+]
+
+fallback_decorations : List(Level.Decoration)
+fallback_decorations = [
+	{ pos: { x: -640, y: 80 }, tile: TileCrystalA, scale: 1.35, rotation: 0 },
+	{ pos: { x: -575, y: 585 }, tile: TileCrystalB, scale: 1.2, rotation: 0 },
+	{ pos: { x: -85, y: -455 }, tile: TilePlantA, scale: 1.35, rotation: 0 },
+	{ pos: { x: 190, y: 185 }, tile: TileMarker, scale: 1.15, rotation: 0 },
+	{ pos: { x: 780, y: -210 }, tile: TileBlockA, scale: 1.1, rotation: 12 },
+	{ pos: { x: 1110, y: 190 }, tile: TileRockA, scale: 1.45, rotation: 0 },
+	{ pos: { x: 1035, y: 785 }, tile: TileBlockB, scale: 1.2, rotation: -14 },
+	{ pos: { x: 315, y: 975 }, tile: TileFlowerA, scale: 1.05, rotation: 0 },
+	{ pos: { x: -395, y: 960 }, tile: TileFlowerB, scale: 0.9, rotation: 0 },
+	{ pos: { x: 1185, y: 735 }, tile: TileSparkA, scale: 0.7, rotation: 20 },
+	{ pos: { x: 1280, y: -395 }, tile: TileSparkB, scale: 0.72, rotation: -18 },
+	{ pos: { x: -615, y: -405 }, tile: TilePlantB, scale: 1.1, rotation: 0 },
+]
+
+## Finds the first map object with the requested authored type.
+first_typed_object : Tilemap, Str -> Try(Tilemap.RawObject, [NotFound])
+first_typed_object = |tilemap, type_name|
+	match List.first(tilemap.objects_typed(type_name)) {
+		Ok(object) => Ok(object)
+		Err(_) => Err(NotFound)
+	}
+
+## Returns an object's world center or a supplied fallback position.
+object_center_or : Tilemap, Try(Tilemap.RawObject, [NotFound]), Math.Vec2 -> Math.Vec2
+object_center_or = |tilemap, object_result, fallback|
+	match object_result {
+		Ok(object) => tilemap.object_world_center(object)
+		Err(_) => fallback
+	}
+
+## Returns an object's radius or a supplied fallback radius.
+object_radius_or : Try(Tilemap.RawObject, [NotFound]), F32 -> F32
+object_radius_or = |object_result, fallback|
+	match object_result {
+		Ok(object) => if object.width == 0 and object.height == 0 fallback else F32.max(object.width, object.height) * 0.5
+		Err(_) => fallback
+	}
+
+## Reads collectible sparks from the map or uses the fallback route.
+sparks_from_tilemap : Tilemap -> List(Spark)
+sparks_from_tilemap = |tilemap| {
+	var $sparks = []
+	for object in tilemap.objects_typed("spark") {
+		pos = tilemap.object_world_center(object)
+		$sparks = List.append($sparks, Spark.{ id: object.id, pos })
+	}
+	if List.len($sparks) == 0 fallback_sparks else $sparks
+}
+
+## Reads solid obstacles from the map or uses the fallback arrangement.
+obstacles_from_tilemap : Tilemap.RawMap, Tilemap -> List(Level.Obstacle)
+obstacles_from_tilemap = |raw, tilemap| {
+	var $items = []
+	for object in tilemap.objects_typed("obstacle") {
+		rect = tilemap.object_world_rect(object)
+		tile = tile_from_name(Tilemap.property_str(raw, object, "tile", "TileBlockA"))
+		rotation = Tilemap.property_f32(raw, object, "rotation", object.rotation)
+		$items = List.append($items, Level.Obstacle.{ rect, tile, rotation })
+	}
+	if List.len($items) == 0 fallback_obstacles else $items
+}
+
+## Reads moving hazards from the map or uses the fallback lanes.
+hazards_from_tilemap : Tilemap.RawMap, Tilemap -> List(Hazard)
+hazards_from_tilemap = |raw, tilemap| {
+	var $items = []
+	for object in tilemap.objects_typed("hazard") {
+		center = tilemap.object_world_center(object)
+		lane = lane_from_name(Tilemap.property_str(raw, object, "lane", "Horizontal"))
+		span = Tilemap.property_f32(raw, object, "span", 520)
+		offset = Tilemap.property_f32(raw, object, "offset", 0)
+		radius = Tilemap.property_f32(raw, object, "radius", 30)
+		$items = List.append($items, Hazard.{ center, span, lane, offset, radius, color: hazard_color(object.id) })
+	}
+	if List.len($items) == 0 fallback_hazards else $items
+}
+
+## Reads decorative props from the map or uses the fallback scenery.
+decorations_from_tilemap : Tilemap.RawMap, Tilemap -> List(Level.Decoration)
+decorations_from_tilemap = |raw, tilemap| {
+	var $items = []
+	for object in tilemap.objects_typed("decoration") {
+		$items = List.append(
+			$items,
+			{
+				pos: tilemap.object_world_center(object),
+				tile: tile_from_name(Tilemap.property_str(raw, object, "tile", "TilePlantA")),
+				scale: Tilemap.property_f32(raw, object, "scale", 1),
+				rotation: Tilemap.property_f32(raw, object, "rotation", object.rotation),
+			},
+		)
+	}
+	if List.len($items) == 0 fallback_decorations else $items
+}
+
+## Decodes an authored tile name into the renderable tile tag.
+tile_from_name : Str -> Level.Tile
+tile_from_name = |name|
+	if name == "TileBlockB" {
+		TileBlockB
+	} else if name == "TileMarker" {
+		TileMarker
+	} else if name == "TileRockA" {
+		TileRockA
+	} else if name == "TilePlantA" {
+		TilePlantA
+	} else if name == "TilePlantB" {
+		TilePlantB
+	} else if name == "TileFlowerA" {
+		TileFlowerA
+	} else if name == "TileFlowerB" {
+		TileFlowerB
+	} else if name == "TileCrystalA" {
+		TileCrystalA
+	} else if name == "TileCrystalB" {
+		TileCrystalB
+	} else if name == "TileSparkA" {
+		TileSparkA
+	} else if name == "TileSparkB" {
+		TileSparkB
+	} else {
+		TileBlockA
+	}
+
+## Decodes an authored lane name into a hazard lane.
+lane_from_name : Str -> Hazard.Lane
+lane_from_name = |name| if name == "Vertical" Vertical else Horizontal
+
+## Chooses a hazard color deterministically from its map identifier.
+hazard_color : U64 -> Color.Rgba
+hazard_color = |id|
+	match id % 4 {
+		0 => Color.from_hex_rgb(0xf94144)
+		1 => Color.from_hex_rgb(0xf3722c)
+		2 => Color.from_hex_rgb(0xf8961e)
+		_ => Color.from_hex_rgb(0xf94144)
+	}
+
+expect Level.Obstacle.{ rect: Math.rect(0, 0, 10, 10), tile: TileBlockA, rotation: 0 }.hit_by(Math.circle({ x: 5, y: 5 }, 1))
+expect !(Level.Obstacle.{ rect: Math.rect(0, 0, 10, 10), tile: TileBlockA, rotation: 0 }.hit_by(Math.circle({ x: 30, y: 30 }, 1)))

--- a/examples/top_down/Player.roc
+++ b/examples/top_down/Player.roc
@@ -1,0 +1,156 @@
+## Player movement, facing, dash timing, animation, and damage recovery.
+import rr.Math
+import rr.Sprite
+
+dash_cooldown_time = 0.62.F32
+
+dash_duration = 0.18.F32
+
+Player := {
+	pos : Math.Vec2,
+	invuln : F32,
+	dash_cooldown : F32,
+	dash_timer : F32,
+	animation : Sprite.Animation,
+	facing : Facing,
+}.{
+	Facing := [North, NorthEast, East, SouthEast, South, SouthWest, West, NorthWest]
+
+	Step : {
+		pos : Math.Vec2,
+		raw_dir : Math.Vec2,
+		move_dir : Math.Vec2,
+		dash_started : Bool,
+		dash_active : Bool,
+		dt : F32,
+	}
+
+	radius = 22.F32
+	speed = 330.F32
+	dash_speed = 760.F32
+
+	## Creates a player at the level spawn facing east.
+	new : Math.Vec2 -> Player
+	new = |pos| {
+		pos,
+		invuln: 0,
+		dash_cooldown: 0,
+		dash_timer: 0,
+		animation: Sprite.animation({ frame_count: 4, fps: 10 }),
+		facing: East,
+	}
+
+	## Returns the player's circular collision body.
+	circle : Player -> Math.Circle
+	circle = |player| Math.circle(player.pos, radius)
+
+	## Returns the unit direction represented by the current facing.
+	facing_dir : Player -> Math.Vec2
+	facing_dir = |player| facing_to_vec(player.facing)
+
+	## Returns the sprite rotation represented by the current facing.
+	rotation : Player -> F32
+	rotation = |player| facing_to_rotation(player.facing)
+
+	## Reports whether the dash cooldown has finished.
+	dash_ready : Player -> Bool
+	dash_ready = |player| player.dash_cooldown <= 0
+
+	## Reports whether the player is currently dashing.
+	dash_active : Player -> Bool
+	dash_active = |player| player.dash_timer > 0
+
+	## Returns normalized dash recharge progress for the HUD.
+	dash_charge : Player -> F32
+	dash_charge = |player| if player.dash_ready() 1 else 1 - player.dash_cooldown / dash_cooldown_time
+
+	## Applies one movement result to timers, animation, and facing.
+	step : Player, Step -> Player
+	step = |player, frame| {
+		raw_moving = is_moving(frame.raw_dir)
+		move_moving = is_moving(frame.move_dir)
+		{
+			..player,
+			pos: frame.pos,
+			invuln: tick_timer(player.invuln, frame.dt),
+			dash_cooldown: if frame.dash_started dash_cooldown_time else tick_timer(player.dash_cooldown, frame.dt),
+			dash_timer: if frame.dash_started dash_duration else tick_timer(player.dash_timer, frame.dt),
+			animation: if move_moving Sprite.step(player.animation, frame.dt) else idle_animation(player.animation),
+			facing: if frame.dash_active and !(raw_moving) player.facing else facing_from_input(frame.raw_dir, player.facing),
+		}
+	}
+
+	## Returns the player at spawn with temporary invulnerability after damage.
+	damage_respawn : Player, Math.Vec2 -> Player
+	damage_respawn = |player, respawn_pos| {
+		..player,
+		pos: respawn_pos,
+		invuln: 1.2,
+		dash_timer: 0,
+		facing: East,
+	}
+}
+
+## Reports whether an input vector requests movement.
+is_moving : Math.Vec2 -> Bool
+is_moving = |dir| dir.x != 0 or dir.y != 0
+
+## Chooses an eight-way facing from movement input.
+facing_from_input : Math.Vec2, Player.Facing -> Player.Facing
+facing_from_input = |dir, fallback| {
+	if dir.y < 0 and dir.x == 0 {
+		North
+	} else if dir.y < 0 and dir.x > 0 {
+		NorthEast
+	} else if dir.x > 0 and dir.y == 0 {
+		East
+	} else if dir.x > 0 and dir.y > 0 {
+		SouthEast
+	} else if dir.y > 0 and dir.x == 0 {
+		South
+	} else if dir.x < 0 and dir.y > 0 {
+		SouthWest
+	} else if dir.x < 0 and dir.y == 0 {
+		West
+	} else if dir.x < 0 and dir.y < 0 {
+		NorthWest
+	} else {
+		fallback
+	}
+}
+
+## Converts an eight-way facing into a movement vector.
+facing_to_vec : Player.Facing -> Math.Vec2
+facing_to_vec = |facing|
+	match facing {
+		North => { x: 0, y: -1 }
+		NorthEast => { x: 0.7, y: -0.7 }
+		East => { x: 1, y: 0 }
+		SouthEast => { x: 0.7, y: 0.7 }
+		South => { x: 0, y: 1 }
+		SouthWest => { x: -0.7, y: 0.7 }
+		West => { x: -1, y: 0 }
+		NorthWest => { x: -0.7, y: -0.7 }
+	}
+
+## Converts an eight-way facing into sprite degrees.
+facing_to_rotation : Player.Facing -> F32
+facing_to_rotation = |facing|
+	match facing {
+		North => -90
+		NorthEast => -45
+		East => 0
+		SouthEast => 45
+		South => 90
+		SouthWest => 135
+		West => 180
+		NorthWest => 225
+	}
+
+## Resets a stopped player's animation to its first frame.
+idle_animation : Sprite.Animation -> Sprite.Animation
+idle_animation = |animation| { frame: 0, frame_count: animation.frame_count, fps: animation.fps, elapsed: 0 }
+
+## Counts a positive timer down without crossing below zero.
+tick_timer : F32, F32 -> F32
+tick_timer = |timer, dt| if timer <= dt 0 else timer - dt

--- a/examples/top_down/Render.roc
+++ b/examples/top_down/Render.roc
@@ -1,0 +1,358 @@
+## Spark Run rendering derived only from loaded assets, level data, and world state.
+import rr.Camera
+import rr.Color
+import rr.Draw
+import rr.Math
+import rr.Sprite
+import rr.Text
+import Game
+import GameAssets
+import Hazard
+import Level
+import Player
+import Spark
+
+Render := [].{
+
+	## Draws one complete Spark Run presentation frame from the resulting world.
+	draw! : Draw.Frame, GameAssets, Level, Game.World => Try({}, [ScopeLimit, ..])
+	draw! = |frame, assets, level, world| {
+		camera = Camera.follow(shaken_target(world), { screen: { x: screen_w, y: screen_h }, zoom: 0.82 })
+		viewport = camera.viewport({ x: screen_w, y: screen_h })
+		frame.clear!(Color.from_hex_rgb(0x071018))
+		frame.with_camera!(
+			camera,
+			|world_frame| {
+				draw_world!(world_frame, level, assets.characters, assets.tiles, world, viewport, assets.font)
+				Ok({})
+			},
+		)?
+		draw_hud!(frame, level, world, assets.font)
+		Ok({})
+	}
+}
+
+screen_w = 800.F32
+
+screen_h = 600.F32
+
+## Wraps a visual animation phase into the unit interval.
+wrap_unit : F32 -> F32
+wrap_unit = |value| if value >= 1 value - 1 else if value < 0 value + 1 else value
+
+## Maps a wrapped visual phase to a back-and-forth amount.
+ping_pong : F32 -> F32
+ping_pong = |phase| if phase < 0.5 phase * 2 else (1 - phase) * 2
+
+## Derives the camera target and deterministic screen shake from the world.
+shaken_target : Game.World -> Math.Vec2
+shaken_target = |world| {
+	amount = world.shake
+	x_phase = ping_pong(wrap_unit(world.phase * 9.7))
+	y_phase = ping_pong(wrap_unit(world.phase * 13.1 + 0.31))
+	{
+		x: world.player.pos.x + (x_phase - 0.5) * amount,
+		y: world.player.pos.y + (y_phase - 0.5) * amount,
+	}
+}
+
+## Draws every camera-space arena layer in back-to-front order.
+draw_world! : Draw.Frame, Level, Draw.Texture, Draw.Texture, Game.World, Math.Rect, Text.Font => {}
+draw_world! = |frame, level, characters, tiles, world, viewport, font| {
+	frame.rectangle_gradient_v!({ x: level.bounds.x, y: level.bounds.y, width: level.bounds.width, height: level.bounds.height, color_top: Color.from_hex_rgb(0x173833), color_bottom: Color.from_hex_rgb(0x132821) })
+	level.tilemap.draw_all_in!(frame, viewport)
+	draw_hazard_lanes!(frame, level, world.phase)
+	draw_props!(frame, level, tiles, viewport)
+	frame.rectangle!({ x: level.bounds.x, y: level.bounds.y, width: level.bounds.width, height: level.bounds.height, style: Draw.outlined(Color.with_alpha(Color.white, 90), 6) })
+
+	draw_spawn!(frame, level, font)
+	draw_exit!(frame, level, world, font)
+	draw_obstacles!(frame, level, tiles, viewport)
+	draw_sparks!(frame, tiles, world.sparks, world.phase, viewport)
+	draw_hazards!(frame, level, characters, world.phase, viewport)
+	draw_burst!(frame, world)
+	draw_player!(frame, characters, world.player)
+}
+
+tile_cols = 27.U64
+
+## Maps a semantic decoration tile to its spritesheet identifier.
+tile_id : Level.Tile -> U64
+tile_id = |tile|
+	match tile {
+		TileFloor => 1
+		TileBlockA => 156
+		TileBlockB => 157
+		TileMarker => 158
+		TileRockA => 181
+		TilePlantA => 183
+		TilePlantB => 184
+		TileFlowerA => 213
+		TileFlowerB => 214
+		TileCrystalA => 237
+		TileCrystalB => 238
+		TileSparkA => 239
+		TileSparkB => 240
+	}
+
+## Returns the source rectangle for one decoration tile.
+tile_source : Level.Tile -> Math.Rect
+tile_source = |tile| {
+	index = tile_id(tile) - 1
+	Sprite.sheet_frame({ frame_size: { x: 64, y: 64 }, row: index // tile_cols, col: index % tile_cols })
+}
+
+## Builds a positioned tile sprite from the shared tile texture.
+tile_sprite : Draw.Texture, Level.Tile, Math.Vec2, F32 -> Sprite.Sprite
+tile_sprite = |tiles, tile, pos, scale|
+	Sprite.from_texture(tiles)
+		.source(
+			tile_source(tile),
+		)
+		.pos(
+			pos,
+		)
+		.scale(
+			scale,
+		)
+
+## Draws one tile sprite from its top-left position.
+draw_tile! : Draw.Frame, Draw.Texture, Level.Tile, Math.Vec2, F32 => {}
+draw_tile! = |frame, tiles, tile, pos, scale| tile_sprite(tiles, tile, pos, scale).draw!(frame)
+
+## Draws one centered and rotated tile sprite.
+draw_tile_centered! : Draw.Frame, Draw.Texture, Level.Tile, Math.Vec2, F32, F32 => {}
+draw_tile_centered! = |frame, tiles, tile, pos, scale, rotation| tile_sprite(tiles, tile, pos, scale).centered().rotation(rotation).draw!(frame)
+
+## Draws the marked player spawn point.
+draw_spawn! : Draw.Frame, Level, Text.Font => {}
+draw_spawn! = |frame, level, font| {
+	frame.circle_gradient!({ center: level.spawn, radius: 72, color_inner: Color.with_alpha(Color.from_hex_rgb(0x2a9d8f), 120), color_outer: Color.with_alpha(Color.from_hex_rgb(0x2a9d8f), 0) })
+	frame.circle!({ center: level.spawn, radius: 42, style: Draw.filled_and_outlined(Color.from_hex_rgb(0x2a9d8f), Color.white, 4) })
+	Text.from("START", font)
+		.size(18)
+		.draw!(frame, { pos: { x: level.spawn.x, y: level.spawn.y + 63 }, color: Color.with_alpha(Color.white, 190), align: (Top, Center) })
+}
+
+## Draws the locked or open exit and its label.
+draw_exit! : Draw.Frame, Level, Game.World, Text.Font => {}
+draw_exit! = |frame, level, world, font| {
+	is_open = world.gate.is_open()
+	color = if is_open Color.from_hex_rgb(0xf9c74f) else Color.from_hex_rgb(0x576066)
+	halo = if is_open Color.with_alpha(color, 95) else Color.with_alpha(Color.black, 70)
+	frame.circle_gradient!({ center: level.exit_center, radius: 82 + world.gate_flash * 28, color_inner: halo, color_outer: Color.with_alpha(color, 0) })
+	frame.circle!({ center: level.exit_center, radius: level.exit_radius, style: Draw.filled_and_outlined(Color.with_alpha(color, 190), Color.white, 4) })
+	Text.from(if is_open "EXIT OPEN" else "LOCKED EXIT", font)
+		.size(19)
+		.draw!(frame, { pos: { x: level.exit_center.x, y: level.exit_center.y + 74 }, color: Color.white, align: (Top, Center) })
+}
+
+## Draws one solid obstacle and its decorative tile.
+draw_obstacle! : Draw.Frame, Draw.Texture, Level.Obstacle => {}
+draw_obstacle! = |frame, tiles, obstacle| {
+	rect = obstacle.rect
+	frame.rounded_rectangle!({ x: rect.x, y: rect.y, width: rect.width, height: rect.height, radius: 14, segments: 8, style: Draw.filled_and_outlined(Color.with_alpha(Color.from_hex_rgb(0x23342d), 235), Color.from_hex_rgb(0xa3b18a), 4) })
+	draw_tile_centered!(frame, tiles, obstacle.tile, obstacle.center(), 1.25, obstacle.rotation)
+}
+
+## Draws visible solid obstacles inside the camera viewport.
+draw_obstacles! : Draw.Frame, Level, Draw.Texture, Math.Rect => {}
+draw_obstacles! = |frame, level, tiles, viewport| {
+	for obstacle in level.obstacles {
+		rect = obstacle.rect
+		visual_bounds = Math.rect(rect.x - 48, rect.y - 48, rect.width + 96, rect.height + 96)
+		if Math.overlaps(visual_bounds, viewport) {
+			draw_obstacle!(frame, tiles, obstacle)
+		}
+	}
+}
+
+## Draws visible non-solid level decorations.
+draw_props! : Draw.Frame, Level, Draw.Texture, Math.Rect => {}
+draw_props! = |frame, level, tiles, viewport| {
+	for decoration in level.decorations {
+		if Math.circle_rect({ center: decoration.pos, radius: 48 * decoration.scale }, viewport) {
+			draw_tile_centered!(frame, tiles, decoration.tile, decoration.pos, decoration.scale, decoration.rotation)
+		}
+	}
+}
+
+## Draws one rotating collectible spark and its glow.
+draw_spark! : Draw.Frame, Draw.Texture, Spark, F32 => {}
+draw_spark! = |frame, tiles, spark, phase| {
+	tile = if spark.id % 2 == 0 TileSparkA else TileSparkB
+	rotation = phase * 160 + U64.to_f32(spark.id) * 19
+	pulse = 1 + ping_pong(wrap_unit(phase * 2 + U64.to_f32(spark.id) * 0.09)) * 0.1
+	frame.circle_gradient!({ center: spark.pos, radius: Spark.radius * 2 * pulse, color_inner: Color.with_alpha(Color.from_hex_rgb(0xf9c74f), 55), color_outer: Color.with_alpha(Color.from_hex_rgb(0xf9c74f), 0) })
+	frame.circle!({ center: spark.pos, radius: Spark.radius + 4 * pulse, style: Draw.outlined(Color.with_alpha(Color.white, 110), 3) })
+	draw_tile_centered!(frame, tiles, tile, spark.pos, 0.72 * pulse, rotation)
+}
+
+## Draws the collectible sparks visible in the camera viewport.
+draw_sparks! : Draw.Frame, Draw.Texture, List(Spark), F32, Math.Rect => {}
+draw_sparks! = |frame, tiles, sparks, phase, viewport| {
+	for spark in sparks {
+		if Math.circle_rect({ center: spark.pos, radius: Spark.radius * 2.2 }, viewport) {
+			draw_spark!(frame, tiles, spark, phase)
+		}
+	}
+}
+
+## Draws each hazard route and its moving glow.
+draw_hazard_lanes! : Draw.Frame, Level, F32 => {}
+draw_hazard_lanes! = |frame, level, phase| {
+	for hazard in level.hazards {
+		pos = hazard.pos(phase)
+		frame.line!({ start: hazard.lane_start(), end: hazard.lane_end(), stroke: Draw.stroke(Color.with_alpha(hazard.color, 48), 10) })
+		frame.circle_gradient!({ center: pos, radius: hazard.radius * 1.9, color_inner: Color.with_alpha(hazard.color, 54), color_outer: Color.with_alpha(hazard.color, 0) })
+	}
+}
+
+robot_source : Math.Rect
+robot_source = Math.rect(458, 88, 33, 43)
+
+## Draws one moving hazard robot and collision outline.
+draw_hazard! : Draw.Frame, Draw.Texture, Hazard, F32 => {}
+draw_hazard! = |frame, characters, hazard, phase| {
+	pos = hazard.pos(phase)
+	sprite = Sprite.from_texture(characters)
+		.source(
+			robot_source,
+		)
+		.pos(
+			pos,
+		)
+		.scale(
+			1.38,
+		)
+		.centered()
+
+	sprite.draw!(frame)
+	frame.circle!({ center: pos, radius: hazard.radius, style: Draw.outlined(Color.with_alpha(Color.white, 170), 3) })
+}
+
+## Draws moving hazards visible in the camera viewport.
+draw_hazards! : Draw.Frame, Level, Draw.Texture, F32, Math.Rect => {}
+draw_hazards! = |frame, level, characters, phase, viewport| {
+	for hazard in level.hazards {
+		pos = hazard.pos(phase)
+		if Math.circle_rect({ center: pos, radius: F32.max(hazard.radius + 3, 34) }, viewport) {
+			draw_hazard!(frame, characters, hazard, phase)
+		}
+	}
+}
+
+## Returns one of eight radial collection-burst directions.
+burst_dir : U64 -> Math.Vec2
+burst_dir = |index|
+	match index % 8 {
+		0 => { x: 1, y: 0 }
+		1 => { x: 0.7, y: 0.7 }
+		2 => { x: 0, y: 1 }
+		3 => { x: -0.7, y: 0.7 }
+		4 => { x: -1, y: 0 }
+		5 => { x: -0.7, y: -0.7 }
+		6 => { x: 0, y: -1 }
+		_ => { x: 0.7, y: -0.7 }
+	}
+
+## Draws the current collection-burst particle recursively.
+draw_burst_particle! : Draw.Frame, Game.World, U64 => {}
+draw_burst_particle! = |frame, world, index| {
+	if index >= 6 or world.burst_timer <= 0 {
+		{}
+	} else {
+		progress = 1 - world.burst_timer / Game.burst_duration
+		dir = burst_dir(index)
+		pos = Math.add(world.burst_pos, Math.scale(dir, 18 + progress * 58))
+		size = 6 + ping_pong(wrap_unit(world.phase * 5 + U64.to_f32(index) * 0.11)) * 3
+		frame.circle!({ center: pos, radius: size, style: Draw.filled(Color.with_alpha(Color.from_hex_rgb(0xf9c74f), if world.burst_timer > 0.18 135 else 70)) })
+		draw_burst_particle!(frame, world, index + 1)
+	}
+}
+
+## Draws the active spark collection burst.
+draw_burst! : Draw.Frame, Game.World => {}
+draw_burst! = |frame, world| draw_burst_particle!(frame, world, 0)
+
+player_source : Math.Rect
+player_source = Math.rect(0, 0, 52, 43)
+
+## Draws the player sprite, dash glow, and collision outline.
+draw_player! : Draw.Frame, Draw.Texture, Player => {}
+draw_player! = |frame, characters, player| {
+	tint = if player.invuln > 0 Color.with_alpha(Color.white, 150) else Color.white
+	scale = if player.dash_active() 1.3 else 1.22
+	sprite = Sprite.from_texture(characters)
+		.source(
+			player_source,
+		)
+		.pos(
+			player.pos,
+		)
+		.scale(
+			scale,
+		)
+		.centered()
+		.rotation(
+			player.rotation(),
+		)
+		.tint(
+			tint,
+		)
+
+	frame.circle!({ center: { x: player.pos.x + 5, y: player.pos.y + 7 }, radius: Player.radius + 6, style: Draw.filled(Color.with_alpha(Color.black, 85)) })
+	if player.dash_active() {
+		trail_center = Math.add(player.pos, Math.scale(player.facing_dir(), -38))
+		frame.circle_gradient!({ center: trail_center, radius: 44, color_inner: Color.with_alpha(Color.from_hex_rgb(0x43aa8b), 55), color_outer: Color.with_alpha(Color.from_hex_rgb(0x43aa8b), 0) })
+		frame.circle_gradient!({ center: player.pos, radius: 54, color_inner: Color.with_alpha(Color.from_hex_rgb(0x43aa8b), 70), color_outer: Color.with_alpha(Color.from_hex_rgb(0x43aa8b), 0) })
+	} else {
+		{}
+	}
+	sprite.draw!(frame)
+	frame.circle!({ center: player.pos, radius: Player.radius, style: Draw.outlined(Color.with_alpha(Color.white, 180), 2) })
+}
+
+## Draws a normalized rounded HUD progress bar.
+draw_bar! : Draw.Frame, F32, F32, F32, F32, F32, Color.Rgba => {}
+draw_bar! = |frame, x, y, width, height, amount, color| {
+	frame.rounded_rectangle!({ x, y, width, height, radius: 5, segments: 6, style: Draw.filled(Color.with_alpha(Color.black, 130)) })
+	frame.rounded_rectangle!({ x, y, width: width * Math.clamp(amount, 0, 1), height, radius: 5, segments: 6, style: Draw.filled(color) })
+}
+
+## Draws score, lives, dash charge, damage flash, and end state.
+draw_hud! : Draw.Frame, Level, Game.World, Text.Font => {}
+draw_hud! = |frame, level, world, font| {
+	is_open = world.gate.is_open()
+
+	frame.rectangle_gradient_v!({ x: 0, y: 0, width: screen_w, height: 76, color_top: Color.with_alpha(Color.black, 220), color_bottom: Color.with_alpha(Color.black, 125) })
+	frame.text!({ pos: { x: 22, y: 16 }, text: "Spark Run", size: 27, spacing: Draw.default_spacing, color: Color.white, font: font })
+	frame.text!({ pos: { x: 195, y: 18 }, text: Str.concat("Sparks ", Str.concat(U64.to_str(world.score), Str.concat("/", U64.to_str(level.spark_total)))), size: 20, spacing: Draw.default_spacing, color: Color.from_hex_rgb(0xf9c74f), font: font })
+	frame.text!({ pos: { x: 382, y: 18 }, text: Str.concat("Lives ", U64.to_str(world.lives)), size: 20, spacing: Draw.default_spacing, color: Color.light_gray, font: font })
+	frame.text!({ pos: { x: 510, y: 18 }, text: if is_open "Gate open" else "Collect all sparks", size: 20, spacing: Draw.default_spacing, color: if is_open Color.from_hex_rgb(0x90be6d) else Color.light_gray, font: font })
+	frame.fps!({ pos: { x: 735, y: 20 }, size: 18, color: Color.gray })
+	draw_bar!(frame, 196, 48, 170, 9, U64.to_f32(world.score) / U64.to_f32(level.spark_total), Color.from_hex_rgb(0xf9c74f))
+	draw_bar!(frame, 510, 48, 120, 9, world.player.dash_charge(), Color.from_hex_rgb(0x43aa8b))
+	frame.text!({ pos: { x: 640, y: 43 }, text: if world.player.dash_ready() "SPACE dash" else "charging", size: 16, spacing: Draw.default_spacing, color: Color.light_gray, font: font })
+
+	if world.flash > 0 {
+		frame.rectangle!({ x: 0, y: 0, width: screen_w, height: screen_h, style: Draw.filled(Color.with_alpha(Color.red, if world.flash > 0.45 120 else 70)) })
+	} else {
+		{}
+	}
+
+	match world.state {
+		Playing => {}
+		Won => draw_modal!(frame, font, "All sparks recovered", "Press SPACE to run again", Color.from_hex_rgb(0x43aa8b))
+		GameOver => draw_modal!(frame, font, "Spark Run ended", "Press SPACE to restart", Color.from_hex_rgb(0xf94144))
+	}
+}
+
+## Draws a centered win or game-over modal.
+draw_modal! : Draw.Frame, Text.Font, Str, Str, Color.Rgba => {}
+draw_modal! = |frame, font, title, subtitle, accent| {
+	frame.rectangle!({ x: 0, y: 0, width: screen_w, height: screen_h, style: Draw.filled(Color.with_alpha(Color.black, 120)) })
+	frame.rounded_rectangle!({ x: 185, y: 226, width: 430, height: 152, radius: 8, segments: 8, style: Draw.filled_and_outlined(Color.with_alpha(Color.black, 230), accent, 4) })
+	Text.from(title, font).size(30).draw!(frame, { pos: { x: screen_w * 0.5, y: 276 }, color: Color.white, align: (Middle, Center) })
+	Text.from(subtitle, font).size(21).draw!(frame, { pos: { x: screen_w * 0.5, y: 326 }, color: Color.light_gray, align: (Middle, Center) })
+}

--- a/examples/top_down/Spark.roc
+++ b/examples/top_down/Spark.roc
@@ -1,0 +1,15 @@
+## Collectible sparks and their circular collision rule.
+import rr.Math
+
+Spark := { id : U64, pos : Math.Vec2 }.{
+	is_eq : _
+	radius = 24.F32
+
+	## Reports whether another circle touches this spark.
+	hit_by : Spark, Math.Circle -> Bool
+	hit_by = |spark, other| Math.circle_overlaps(other, spark_circle(spark))
+}
+
+## Returns the private circular collection body for a spark.
+spark_circle : Spark -> Math.Circle
+spark_circle = |spark| Math.circle(spark.pos, Spark.radius)

--- a/examples/top_down/main.roc
+++ b/examples/top_down/main.roc
@@ -1,370 +1,45 @@
-## Explore a top-down arena with WASD or the arrow keys, dash with Space,
-## collect every spark, and reach the open gate. Escape quits. Run with
-## `--record-demo` to save a repeatable gallery recording.
+## Spark Run: collect every spark, avoid moving hazards, and reach the gate.
 ##
-## This larger example combines a Tiled map, animated sprites, collision rules,
-## a following camera, screen shake, music, and sound cues chosen by pure game
-## calculations before `update!` plays them.
+## Use WASD or Arrow keys to move, Space to dash or restart, and Escape to quit.
+## File structure:
+##
+## - State (`Game.roc`): player, remaining sparks, score, lives, gate, and feedback
+## - Controls (`main.roc`): movement, dash, restart, quit, and repeatable demo route
+## - Assets (`GameAssets.roc`): character and tile textures, font, sounds, and music
+## - Level (`Level.roc`): Tiled map, spawn, exit, obstacles, hazards, and decorations
+## - Gameplay (`Player.roc`, `Spark.roc`, `Hazard.roc`): movement, dash, collection, and damage bodies
+## - Rendering (`Render.roc`): camera, arena layers, sprites, effects, HUD, and end states
+## - Tests (`main.roc`): facing, collisions, collection, damage, escape, and dash events
 app [Model, program] {
 	rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst",
 	roc: "nightly-2026-08-23-fb208ba",
 }
 
 import rr.App
-import rr.Time
-import rr.Assets
-import rr.Audio
-import rr.Camera
-import rr.Color
 import rr.Capture
-import rr.Draw
-import rr.Text
+import rr.Color
 import rr.Devices
-import rr.Keys
+import rr.Draw
 import rr.Math
-import rr.Sprite
 import rr.Tilemap
+import Game
+import GameAssets
+import Hazard
+import Level
+import Player
+import Render
+import Spark
 
-Facing := [North, NorthEast, East, SouthEast, South, SouthWest, West, NorthWest].{
-	is_eq : _
-}
+Model : { assets : GameAssets, level : Level, world : Game.World, demo : Bool, demo_frame : U64 }
 
-GateState := [GateLocked, GateOpen].{
-	is_eq : _
-}
-
-Lane := [Horizontal, Vertical]
-
-Tile := [
-	TileFloor,
-	TileBlockA,
-	TileBlockB,
-	TileMarker,
-	TileRockA,
-	TilePlantA,
-	TilePlantB,
-	TileFlowerA,
-	TileFlowerB,
-	TileCrystalA,
-	TileCrystalB,
-	TileSparkA,
-	TileSparkB,
-]
-
-Decoration : {
-	pos : Math.Vec2,
-	tile : Tile,
-	scale : F32,
-	rotation : F32,
-}
-
-Level : {
-	tilemap : Tilemap,
-	spawn : Math.Vec2,
-	exit_center : Math.Vec2,
-	exit_radius : F32,
-	sparks : List(World.Spark),
-	spark_total : U64,
-	obstacles : List(World.Obstacle),
-	hazards : List(World.Hazard),
-	decorations : List(Decoration),
-	bounds : Math.Rect,
-}
-
-GameState := [Playing, Won, GameOver].{
-	is_eq : _
-}
-
-World := {
-	player : World.Player,
-	sparks : List(World.Spark),
-	score : U64,
-	lives : U64,
-	phase : F32,
-	shake : F32,
-	flash : F32,
-	burst_pos : Math.Vec2,
-	burst_timer : F32,
-	gate : GateState,
-	gate_flash : F32,
-	state : GameState,
-}.{
-	PlayerStep : {
-		pos : Math.Vec2,
-		raw_dir : Math.Vec2,
-		move_dir : Math.Vec2,
-		dash_started : Bool,
-		dash_active : Bool,
-		dt : F32,
-	}
-
-	Player := {
-		pos : Math.Vec2,
-		invuln : F32,
-		dash_cooldown : F32,
-		dash_timer : F32,
-		animation : Sprite.Animation,
-		facing : Facing,
-	}.{
-		new : Math.Vec2 -> Player
-		new = |pos| {
-			pos,
-			invuln: 0,
-			dash_cooldown: 0,
-			dash_timer: 0,
-			animation: Sprite.animation({ frame_count: 4, fps: 10 }),
-			facing: East,
-		}
-
-		circle : Player -> Math.Circle
-		circle = |player| Math.circle(player.pos, player_radius)
-
-		facing_dir : Player -> Math.Vec2
-		facing_dir = |player| facing_to_vec(player.facing)
-
-		rotation : Player -> F32
-		rotation = |player| facing_to_rotation(player.facing)
-
-		dash_ready : Player -> Bool
-		dash_ready = |player| player.dash_cooldown <= 0
-
-		dash_active : Player -> Bool
-		dash_active = |player| player.dash_timer > 0
-
-		dash_charge : Player -> F32
-		dash_charge = |player| if player.dash_ready() 1 else 1 - player.dash_cooldown / dash_cooldown_time
-
-		step : Player, PlayerStep -> Player
-		step = |player, frame| {
-			raw_moving = is_moving(frame.raw_dir)
-			move_moving = is_moving(frame.move_dir)
-
-			{
-				..player,
-				pos: frame.pos,
-				invuln: tick_timer(player.invuln, frame.dt),
-				dash_cooldown: if frame.dash_started dash_cooldown_time else tick_timer(player.dash_cooldown, frame.dt),
-				dash_timer: if frame.dash_started dash_duration else tick_timer(player.dash_timer, frame.dt),
-				animation: if move_moving Sprite.step(player.animation, frame.dt) else idle_animation(player.animation),
-				facing: if frame.dash_active and !(raw_moving) player.facing else facing_from_input(frame.raw_dir, player.facing),
-			}
-		}
-
-		damage_respawn : Player, Math.Vec2 -> Player
-		damage_respawn = |player, respawn_pos| {
-			..player,
-			pos: respawn_pos,
-			invuln: 1.2,
-			dash_timer: 0,
-			facing: East,
-		}
-	}
-
-	Spark := {
-		id : U64,
-		pos : Math.Vec2,
-	}.{
-		is_eq : _
-
-		new : U64, F32, F32 -> Spark
-		new = |id, x, y| { id, pos: { x, y } }
-
-		circle : Spark -> Math.Circle
-		circle = |spark| Math.circle(spark.pos, spark_radius)
-
-		hit_by : Spark, Math.Circle -> Bool
-		hit_by = |spark, other| Math.circle_overlaps(other, spark.circle())
-	}
-
-	Obstacle := {
-		rect : Math.Rect,
-		tile : Tile,
-		rotation : F32,
-	}.{
-		new : F32, F32, F32, F32, Tile, F32 -> Obstacle
-		new = |x, y, width, height, tile, rotation| {
-			rect: Math.rect(x, y, width, height),
-			tile,
-			rotation,
-		}
-
-		center : Obstacle -> Math.Vec2
-		center = |obstacle| Math.center(obstacle.rect)
-
-		hit_by : Obstacle, Math.Circle -> Bool
-		hit_by = |obstacle, circle| Math.circle_rect(circle, obstacle.rect)
-	}
-
-	Hazard := {
-		center : Math.Vec2,
-		span : F32,
-		lane : Lane,
-		offset : F32,
-		radius : F32,
-		color : Color.Rgba,
-	}.{
-		pos : Hazard, F32 -> Math.Vec2
-		pos = |hazard, phase| {
-			amount = ping_pong(wrap_unit(phase + hazard.offset))
-			match hazard.lane {
-				Vertical => { x: hazard.center.x, y: hazard.center.y - hazard.span * 0.5 + hazard.span * amount }
-				Horizontal => { x: hazard.center.x - hazard.span * 0.5 + hazard.span * amount, y: hazard.center.y }
-			}
-		}
-
-		circle : Hazard, F32 -> Math.Circle
-		circle = |hazard, phase| Math.circle(hazard.pos(phase), hazard.radius)
-
-		lane_start : Hazard -> Math.Vec2
-		lane_start = |hazard|
-			match hazard.lane {
-				Vertical => { x: hazard.center.x, y: hazard.center.y - hazard.span * 0.5 }
-				Horizontal => { x: hazard.center.x - hazard.span * 0.5, y: hazard.center.y }
-			}
-
-		lane_end : Hazard -> Math.Vec2
-		lane_end = |hazard|
-			match hazard.lane {
-				Vertical => { x: hazard.center.x, y: hazard.center.y + hazard.span * 0.5 }
-				Horizontal => { x: hazard.center.x + hazard.span * 0.5, y: hazard.center.y }
-			}
-
-		hit_by : Hazard, Math.Circle, F32 -> Bool
-		hit_by = |hazard, other, phase| Math.circle_overlaps(other, hazard.circle(phase))
-	}
-
-	StepInput : {
-		raw_dir : Math.Vec2,
-		dash_pressed : Bool,
-		dt : F32,
-	}
-
-	StepEvent := [DashStarted(Math.Vec2), SparkCollected(Spark), GateOpened, Escaped, Damaged(GameState)].{
-		is_eq : _
-	}
-
-	StepResult : {
-		world : World,
-		events : List(StepEvent),
-	}
-
-	CollectResult : {
-		world : World,
-		collected : Try(Spark, [NoSpark]),
-		gate_opened : Bool,
-	}
-
-	EscapeResult : {
-		world : World,
-		escaped : Bool,
-	}
-
-	DamageResult : {
-		world : World,
-		damaged : Bool,
-	}
-
-	new : Level -> World
-	new = |level| {
-		player: Player.new(level.spawn),
-		sparks: level.sparks,
-		score: 0,
-		lives: 3,
-		phase: 0,
-		shake: 0,
-		flash: 0,
-		burst_pos: level.spawn,
-		burst_timer: 0,
-		gate: GateLocked,
-		gate_flash: 0,
-		state: Playing,
-	}
-}
-
-Sounds : {
-	collect : Audio.Sound,
-	hurt : Audio.Sound,
-	win : Audio.Sound,
-	lose : Audio.Sound,
-	gate : Audio.Sound,
-	dash : Audio.Sound,
-	sparkle : Audio.Sound,
-	music : Audio.Music,
-}
-
-## State retained between updates: loaded fonts, textures and audio, the parsed
-## level, the changing game world, and progress through the repeatable demo.
-## Keeping resources beside the world lets `update!` advance the game and
-## `render!` draw the result without loading anything again.
-Model : {
-	font : Text.Font,
-	characters : Draw.Texture,
-	tiles : Draw.Texture,
-	level : Level,
-	sounds : Sounds,
-	world : World,
-	demo : Bool,
-	demo_frame : U64,
-}
+Controls : Game.Controls
 
 program = { init!, update!, render! }
 
-screen_w = 800.F32
+demo_frames = 150.U64
 
-screen_h = 600.F32
+record_demo_flag = "--record-demo"
 
-world_left = -720.F32
-
-world_top = -520.F32
-
-world_right = 1456.F32
-
-world_bottom = 1144.F32
-
-player_radius = 22.F32
-
-player_speed = 330.F32
-
-dash_speed = 760.F32
-
-dash_duration = 0.18.F32
-
-dash_cooldown_time = 0.62.F32
-
-spark_radius = 24.F32
-
-spark_total = 10.U64
-
-top_down_map_path : Str
-top_down_map_path = "examples/top_down/assets/top_down.tmx"
-
-collect_path : Str
-collect_path = "examples/top_down/assets/kenney-audio/sfx/collect.ogg"
-
-hurt_path : Str
-hurt_path = "examples/top_down/assets/kenney-audio/sfx/hurt.ogg"
-
-win_path : Str
-win_path = "examples/top_down/assets/kenney-audio/sfx/win.ogg"
-
-lose_path : Str
-lose_path = "examples/top_down/assets/kenney-audio/sfx/lose.ogg"
-
-gate_path : Str
-gate_path = "examples/top_down/assets/kenney-audio/sfx/gate.ogg"
-
-dash_path : Str
-dash_path = "examples/top_down/assets/kenney-audio/sfx/dash.ogg"
-
-music_path : Str
-music_path = "examples/top_down/assets/kenney-audio/music/spark_loop.wav"
-
-## How loud each effect is mixed.
-##
-## A `Playback` states volume, pitch, and pan together and defaults volume to 1,
-## so every play has to name its sound's level -- a `Sound` has no volume of
-## its own to set in `init!` and inherit. These constants are the one place the
-## levels live, so no single play can drift away from what the mix intends.
 collect_volume = 0.58.F32
 
 hurt_volume = 0.55.F32
@@ -379,33 +54,14 @@ dash_volume = 0.3.F32
 
 sparkle_volume = 0.16.F32
 
-## The music stream is different: `SetMusicVolume` is a real mutation that
-## sticks, so this is the level `init!` starts at and a restart returns to.
 music_volume = 0.13.F32
 
-## Where the music is ducked to once the exit is reached, so the win sting sits
-## on top of it.
 music_won_volume = 0.08.F32
 
-fallback_spawn : Math.Vec2
-fallback_spawn = { x: -560, y: -360 }
-
-fallback_exit_center : Math.Vec2
-fallback_exit_center = { x: 1185, y: 920 }
-
-fallback_exit_radius = 58.F32
-
-burst_duration = 0.36.F32
-
-demo_frames = 150.U64
-
-record_demo_flag : Str
-record_demo_flag = "--record-demo"
-
+## Configures the interactive window or the repeatable hidden gallery recording.
 top_down_config : List(Str) -> App.Config
 top_down_config = |args| {
 	base = App.default.with_title("RocRay Spark Run").with_frame_pacing(Capped(120))
-
 	if List.contains(args, record_demo_flag) {
 		base
 			.with_visible(Bool.False)
@@ -424,1120 +80,169 @@ top_down_config = |args| {
 	}
 }
 
+## Loads resources and level data before starting music and the first world.
 init! : App.Init(Model, _)
 init! = App.init_for_args(
 	top_down_config,
 	|startup| {
-		assets = Assets.Store.open!(Assets.working_directory("examples/top_down/assets"))?
-		characters = Assets.load_texture!(assets, "kenney-topdown/characters.png")?
-		tiles = Assets.load_texture!(assets, "kenney-topdown/tiles.png")?
-		raw_map = Tilemap.load_tmx!(top_down_map_path)?
-
-		tilemap = Tilemap.from_raw(raw_map)
-			.with_origin(
-				{ x: world_left, y: world_top },
-			)
-			.with_tileset_texture(
-				1,
-				tiles,
-			)
-			.layer_role(
-				"Ground",
-				Drawn,
-			)
-			.layer_role(
-				"Decor",
-				Drawn,
-			)
-			.layer_role(
-				"Walls",
-				Solid,
-			)
-			.object_role(
-				"spawn",
-				Spawn,
-			)
-			.object_role(
-				"spark",
-				Collectible,
-			)
-			.object_role(
-				"hazard",
-				Hazard,
-			)
-			.object_role(
-				"exit",
-				Exit,
-			)
-			.build()?
-		level = level_from_tilemap(tilemap)
-		sounds = make_sounds!()?
-		sounds.music.play!()
-		model = new_game(Draw.default_font!(), characters, tiles, level, sounds)
-		Ok({
-			..model,
-			demo: List.contains(App.args!(startup), record_demo_flag),
-			demo_frame: 0,
-		})
+		assets = GameAssets.load!()?
+		level = Level.load!(assets.tiles)?
+		assets.sounds.music.play!()
+		Ok({ assets, level, world: Game.new(level), demo: List.contains(App.args!(startup), record_demo_flag), demo_frame: 0 })
 	},
 )
 
-make_sound! : Audio.Waveform, F32, F32, I32, F32 => Try(Audio.Sound, [ResourceLimit, SoundGenerationFailed, ..])
-make_sound! = |waveform, from, to, ms, volume|
-	Audio.gen_sound!({
-		waveform,
-		freq_start: from,
-		freq_end: to,
-		ms,
-		attack_ms: 2,
-		decay_ms: 24,
-		sustain: 0.45,
-		release_ms: 45,
-		volume,
-	})
-
-load_sound_or! : Str, Audio.Sound => Audio.Sound
-load_sound_or! = |path, fallback|
-	match Audio.load_sound!(path) {
-		Ok(sound) => sound
-		Err(_) => fallback
-	}
-
-make_sounds! : () => Try(Sounds, [MusicLoadFailed, ResourceLimit, SoundGenerationFailed, ..])
-make_sounds! = || {
-	collect = load_sound_or!(collect_path, make_sound!(Sine, 880, 1160, 110, 0.55)?)
-	hurt = load_sound_or!(hurt_path, make_sound!(Noise, 180, 70, 220, 0.7)?)
-	win = load_sound_or!(win_path, make_sound!(Square, 640, 1280, 520, 0.45)?)
-	lose = load_sound_or!(lose_path, make_sound!(Saw, 120, 45, 520, 0.5)?)
-	gate = load_sound_or!(gate_path, make_sound!(Square, 220, 390, 240, 0.45)?)
-	dash = load_sound_or!(dash_path, make_sound!(Noise, 520, 120, 130, 0.38)?)
-	sparkle = make_sound!(Sine, 980, 1620, 140, 0.36)?
-	music = Audio.load_music!(music_path)?
-
-	# Only the music sets a volume here. Every effect is played through a
-	# `Playback` that states its own, so a volume set here would be a second
-	# source of truth that the next play overwrites anyway.
-	music.set_volume!(music_volume)
-	music.set_looping!(Bool.True)
-
-	Ok({ collect, hurt, win, lose, gate, dash, sparkle, music })
-}
-
-new_game : Text.Font, Draw.Texture, Draw.Texture, Level, Sounds -> Model
-new_game = |font, characters, tiles, level, sounds| {
-	font,
-	characters,
-	tiles,
-	level,
-	sounds,
-	world: World.new(level),
-	demo: Bool.False,
-	demo_frame: 0,
-}
-
-fallback_sparks : List(World.Spark)
-fallback_sparks = [
-	World.Spark.new(0, -430, -150),
-	World.Spark.new(1, -55, -350),
-	World.Spark.new(2, 315, -295),
-	World.Spark.new(3, 760, -405),
-	World.Spark.new(4, 1110, -65),
-	World.Spark.new(5, 910, 350),
-	World.Spark.new(6, 560, 820),
-	World.Spark.new(7, 105, 640),
-	World.Spark.new(8, -280, 895),
-	World.Spark.new(9, -540, 410),
-]
-
-fallback_obstacles : List(World.Obstacle)
-fallback_obstacles = [
-	World.Obstacle.new(-305, -300, 150, 440, TileBlockA, 0),
-	World.Obstacle.new(85, -430, 150, 295, TileBlockB, 11),
-	World.Obstacle.new(210, -45, 510, 120, TileBlockA, 22),
-	World.Obstacle.new(705, 150, 140, 425, TileBlockB, 33),
-	World.Obstacle.new(5, 505, 480, 115, TileBlockA, 44),
-	World.Obstacle.new(-535, 515, 340, 105, TileBlockB, 55),
-	World.Obstacle.new(965, -300, 145, 450, TileBlockA, 66),
-]
-
-fallback_hazards : List(World.Hazard)
-fallback_hazards = [
-	{ center: { x: -445, y: 165 }, span: 520, lane: Horizontal, offset: 0, radius: 30, color: Color.from_hex_rgb(0xf94144) },
-	{ center: { x: 25, y: 320 }, span: 650, lane: Vertical, offset: 0.22, radius: 34, color: Color.from_hex_rgb(0xf3722c) },
-	{ center: { x: 600, y: -255 }, span: 650, lane: Horizontal, offset: 0.48, radius: 32, color: Color.from_hex_rgb(0xf8961e) },
-	{ center: { x: 1035, y: 455 }, span: 700, lane: Vertical, offset: 0.72, radius: 36, color: Color.from_hex_rgb(0xf94144) },
-]
-
-fallback_decorations : List(Decoration)
-fallback_decorations = [
-	{ pos: { x: -640, y: 80 }, tile: TileCrystalA, scale: 1.35, rotation: 0 },
-	{ pos: { x: -575, y: 585 }, tile: TileCrystalB, scale: 1.2, rotation: 0 },
-	{ pos: { x: -85, y: -455 }, tile: TilePlantA, scale: 1.35, rotation: 0 },
-	{ pos: { x: 190, y: 185 }, tile: TileMarker, scale: 1.15, rotation: 0 },
-	{ pos: { x: 780, y: -210 }, tile: TileBlockA, scale: 1.1, rotation: 12 },
-	{ pos: { x: 1110, y: 190 }, tile: TileRockA, scale: 1.45, rotation: 0 },
-	{ pos: { x: 1035, y: 785 }, tile: TileBlockB, scale: 1.2, rotation: -14 },
-	{ pos: { x: 315, y: 975 }, tile: TileFlowerA, scale: 1.05, rotation: 0 },
-	{ pos: { x: -395, y: 960 }, tile: TileFlowerB, scale: 0.9, rotation: 0 },
-	{ pos: { x: 1185, y: 735 }, tile: TileSparkA, scale: 0.7, rotation: 20 },
-	{ pos: { x: 1280, y: -395 }, tile: TileSparkB, scale: 0.72, rotation: -18 },
-	{ pos: { x: -615, y: -405 }, tile: TilePlantB, scale: 1.1, rotation: 0 },
-]
-
-fallback_level : Level
-fallback_level = {
-	tilemap: Tilemap.empty,
-	spawn: fallback_spawn,
-	exit_center: fallback_exit_center,
-	exit_radius: fallback_exit_radius,
-	sparks: fallback_sparks,
-	spark_total,
-	obstacles: fallback_obstacles,
-	hazards: fallback_hazards,
-	decorations: fallback_decorations,
-	bounds: Math.rect(world_left, world_top, world_right - world_left, world_bottom - world_top),
-}
-
-level_from_tilemap : Tilemap -> Level
-level_from_tilemap = |tilemap| {
-	raw = tilemap.raw_map()
-	spawn_object = first_typed_object(tilemap, "spawn")
-	exit_object = first_typed_object(tilemap, "exit")
-	sparks = sparks_from_tilemap(tilemap)
-
-	{
-		tilemap,
-		spawn: object_center_or(tilemap, spawn_object, fallback_spawn),
-		exit_center: object_center_or(tilemap, exit_object, fallback_exit_center),
-		exit_radius: object_radius_or(exit_object, fallback_exit_radius),
-		sparks,
-		spark_total: List.len(sparks),
-		obstacles: obstacles_from_tilemap(raw, tilemap),
-		hazards: hazards_from_tilemap(raw, tilemap),
-		decorations: decorations_from_tilemap(raw, tilemap),
-		bounds: Math.rect(world_left, world_top, world_right - world_left, world_bottom - world_top),
-	}
-}
-
-first_typed_object : Tilemap, Str -> Try(Tilemap.RawObject, [NotFound])
-first_typed_object = |tilemap, type_name|
-	match List.first(tilemap.objects_typed(type_name)) {
-		Ok(object) => Ok(object)
-		Err(_) => Err(NotFound)
-	}
-
-object_center_or : Tilemap, Try(Tilemap.RawObject, [NotFound]), Math.Vec2 -> Math.Vec2
-object_center_or = |tilemap, object_result, fallback|
-	match object_result {
-		Ok(object) => tilemap.object_world_center(object)
-		Err(_) => fallback
-	}
-
-object_radius_or : Try(Tilemap.RawObject, [NotFound]), F32 -> F32
-object_radius_or = |object_result, fallback|
-	match object_result {
-		Ok(object) => if object.width == 0 and object.height == 0 fallback else F32.max(object.width, object.height) * 0.5
-		Err(_) => fallback
-	}
-
-sparks_from_tilemap : Tilemap -> List(World.Spark)
-sparks_from_tilemap = |tilemap| {
-	var $sparks = []
-	for object in tilemap.objects_typed("spark") {
-		pos = tilemap.object_world_center(object)
-		$sparks = List.append($sparks, World.Spark.new(object.id, pos.x, pos.y))
-	}
-	if List.len($sparks) == 0 fallback_sparks else $sparks
-}
-
-obstacles_from_tilemap : Tilemap.RawMap, Tilemap -> List(World.Obstacle)
-obstacles_from_tilemap = |raw, tilemap| {
-	var $items = []
-	for object in tilemap.objects_typed("obstacle") {
-		rect = tilemap.object_world_rect(object)
-		tile = tile_from_name(Tilemap.property_str(raw, object, "tile", "TileBlockA"))
-		rotation = Tilemap.property_f32(raw, object, "rotation", object.rotation)
-		$items = List.append($items, World.Obstacle.new(rect.x, rect.y, rect.width, rect.height, tile, rotation))
-	}
-	if List.len($items) == 0 fallback_obstacles else $items
-}
-
-hazards_from_tilemap : Tilemap.RawMap, Tilemap -> List(World.Hazard)
-hazards_from_tilemap = |raw, tilemap| {
-	var $items = []
-	for object in tilemap.objects_typed("hazard") {
-		center = tilemap.object_world_center(object)
-		lane = lane_from_name(Tilemap.property_str(raw, object, "lane", "Horizontal"))
-		span = Tilemap.property_f32(raw, object, "span", 520)
-		offset = Tilemap.property_f32(raw, object, "offset", 0)
-		radius = Tilemap.property_f32(raw, object, "radius", 30)
-		$items = List.append($items, { center, span, lane, offset, radius, color: hazard_color(object.id) })
-	}
-	if List.len($items) == 0 fallback_hazards else $items
-}
-
-decorations_from_tilemap : Tilemap.RawMap, Tilemap -> List(Decoration)
-decorations_from_tilemap = |raw, tilemap| {
-	var $items = []
-	for object in tilemap.objects_typed("decoration") {
-		$items = List.append(
-			$items,
-			{
-				pos: tilemap.object_world_center(object),
-				tile: tile_from_name(Tilemap.property_str(raw, object, "tile", "TilePlantA")),
-				scale: Tilemap.property_f32(raw, object, "scale", 1),
-				rotation: Tilemap.property_f32(raw, object, "rotation", object.rotation),
-			},
-		)
-	}
-	if List.len($items) == 0 fallback_decorations else $items
-}
-
-tile_from_name : Str -> Tile
-tile_from_name = |name|
-	if name == "TileBlockB" {
-		TileBlockB
-	} else if name == "TileMarker" {
-		TileMarker
-	} else if name == "TileRockA" {
-		TileRockA
-	} else if name == "TilePlantA" {
-		TilePlantA
-	} else if name == "TilePlantB" {
-		TilePlantB
-	} else if name == "TileFlowerA" {
-		TileFlowerA
-	} else if name == "TileFlowerB" {
-		TileFlowerB
-	} else if name == "TileCrystalA" {
-		TileCrystalA
-	} else if name == "TileCrystalB" {
-		TileCrystalB
-	} else if name == "TileSparkA" {
-		TileSparkA
-	} else if name == "TileSparkB" {
-		TileSparkB
-	} else {
-		TileBlockA
-	}
-
-lane_from_name : Str -> Lane
-lane_from_name = |name| if name == "Vertical" Vertical else Horizontal
-
-hazard_color : U64 -> Color.Rgba
-hazard_color = |id|
-	match id % 4 {
-		0 => Color.from_hex_rgb(0xf94144)
-		1 => Color.from_hex_rgb(0xf3722c)
-		2 => Color.from_hex_rgb(0xf8961e)
-		_ => Color.from_hex_rgb(0xf94144)
-	}
-
+## Converts two opposing keys into one signed movement axis.
 axis : Bool, Bool -> F32
 axis = |negative, positive| if negative -1 else if positive 1 else 0
 
-input_axis : Devices.Snapshot -> Math.Vec2
-input_axis = |input| {
+## Translates keyboard bindings into semantic Spark Run controls.
+read_controls : Devices.Snapshot -> Controls
+read_controls = |input| {
 	left = input.key_down(KeyLeft) or input.key_down(KeyA)
 	right = input.key_down(KeyRight) or input.key_down(KeyD)
 	up = input.key_down(KeyUp) or input.key_down(KeyW)
 	down = input.key_down(KeyDown) or input.key_down(KeyS)
-
-	{ x: axis(left, right), y: axis(up, down) }
+	{
+		move: { x: axis(left, right), y: axis(up, down) },
+		dash_pressed: input.key_pressed(KeySpace),
+		restart_pressed: input.key_pressed(KeySpace),
+		quit_pressed: input.key_pressed(KeyEscape),
+	}
 }
 
-## A short route through the arena, expressed as the same device snapshots the
-## interactive game consumes. It collects a spark, then dashes through the map
-## to show movement, animation, camera tracking, and screen shake.
-demo_input : U64 -> Devices.Snapshot
-demo_input = |frame| {
-	base =
+## Produces the semantic controls for one frame of the gallery route.
+demo_controls : U64 -> Controls
+demo_controls = |frame| {
+	move =
 		if frame < 19 {
-			Devices.none.with_key_down(KeyD).with_key_down(KeyS)
+			{ x: 1, y: 1 }
 		} else if frame < 38 {
-			Devices.none.with_key_down(KeyW)
+			{ x: 0, y: -1 }
 		} else if frame < 76 {
-			Devices.none.with_key_down(KeyD)
+			{ x: 1, y: 0 }
 		} else if frame < 108 {
-			Devices.none.with_key_down(KeyS).with_key_down(KeyD)
+			{ x: 1, y: 1 }
 		} else {
-			Devices.none.with_key_down(KeyA)
+			{ x: -1, y: 0 }
 		}
-
-	if frame == 20 or frame == 43 or frame == 82 or frame == 116 {
-		base.with_key_pressed(KeySpace)
-	} else {
-		base
-	}
+	pressed = frame == 20 or frame == 43 or frame == 82 or frame == 116
+	{ move, dash_pressed: pressed, restart_pressed: pressed, quit_pressed: Bool.False }
 }
 
-facing_from_input : Math.Vec2, Facing -> Facing
-facing_from_input = |dir, fallback| {
-	if dir.y < 0 and dir.x == 0 {
-		North
-	} else if dir.y < 0 and dir.x > 0 {
-		NorthEast
-	} else if dir.x > 0 and dir.y == 0 {
-		East
-	} else if dir.x > 0 and dir.y > 0 {
-		SouthEast
-	} else if dir.y > 0 and dir.x == 0 {
-		South
-	} else if dir.x < 0 and dir.y > 0 {
-		SouthWest
-	} else if dir.x < 0 and dir.y == 0 {
-		West
-	} else if dir.x < 0 and dir.y < 0 {
-		NorthWest
-	} else {
-		fallback
-	}
-}
+## Converts a world x-coordinate into stereo pan across the level bounds.
+pan_for_world_x : Level, F32 -> F32
+pan_for_world_x = |level, x| Math.clamp((x - Math.left(level.bounds)) / level.bounds.width * 2 - 1, -1, 1)
 
-clamp_to_world : Level, Math.Vec2 -> Math.Vec2
-clamp_to_world = |level, pos| {
-	x: Math.clamp(pos.x, Math.left(level.bounds) + player_radius, Math.right(level.bounds) - player_radius),
-	y: Math.clamp(pos.y, Math.top(level.bounds) + player_radius, Math.bottom(level.bounds) - player_radius),
-}
-
-any_obstacle_hit : Level, Math.Circle -> Bool
-any_obstacle_hit = |level, circle| {
-	var $hit = Bool.False
-	for obstacle in level.obstacles {
-		if obstacle.hit_by(circle) {
-			$hit = Bool.True
-		}
-	}
-	if level.tilemap.circle_touches_solid(circle) {
-		$hit = Bool.True
-	}
-	$hit
-}
-
-move_player_speed : Level, Math.Vec2, Math.Vec2, F32, F32 -> Math.Vec2
-move_player_speed = |level, player, raw_dir, dt, speed| {
-	dir = Math.normalize(raw_dir)
-	candidate = clamp_to_world(level, Math.add(player, Math.scale(dir, speed * dt)))
-
-	if any_obstacle_hit(level, Math.circle(candidate, player_radius)) player else candidate
-}
-
-wrap_unit : F32 -> F32
-wrap_unit = |value| if value >= 1 value - 1 else if value < 0 value + 1 else value
-
-ping_pong : F32 -> F32
-ping_pong = |phase| if phase < 0.5 phase * 2 else (1 - phase) * 2
-
-tick_timer : F32, F32 -> F32
-tick_timer = |timer, dt| if timer <= dt 0 else timer - dt
-
-find_hit_spark : List(World.Spark), Math.Circle, U64 -> Try(World.Spark, [NoSpark])
-find_hit_spark = |sparks, player_circle, index|
-	match List.get(sparks, index) {
-		Ok(spark) =>
-			if spark.hit_by(player_circle) {
-				Ok(spark)
+## Performs the audio or music effect requested by one pure gameplay event.
+play_event! : GameAssets, Level, Game.World, Game.World, Game.Event => {}
+play_event! = |assets, level, previous_world, world, event| {
+	sounds = assets.sounds
+	match event {
+		DashStarted(pos) =>
+			sounds.dash.playback().with_volume(dash_volume).with_pan(pan_for_world_x(level, pos.x)).with_pitch(0.95 + U64.to_f32(previous_world.score) * 0.015).play!()
+		SparkCollected(spark) => {
+			sounds.collect.playback().with_volume(collect_volume).with_pan(pan_for_world_x(level, spark.pos.x)).play!()
+			if world.score % 3 == 0 {
+				sounds.sparkle.playback().with_volume(sparkle_volume).with_pitch(0.92 + U64.to_f32(world.score) * 0.045).play!()
 			} else {
-				find_hit_spark(sparks, player_circle, index + 1)
-			}
-		Err(_) => Err(NoSpark)
-	}
-
-pan_for_world_x : F32 -> F32
-pan_for_world_x = |x| Math.clamp((x - world_left) / (world_right - world_left) * 2 - 1, -1, 1)
-
-gate_is_open : GateState -> Bool
-gate_is_open = |gate|
-	match gate {
-		GateLocked => Bool.False
-		GateOpen => Bool.True
-	}
-
-gate_after_collect : List(World.Spark) -> GateState
-gate_after_collect = |remaining| if List.len(remaining) == 0 GateOpen else GateLocked
-
-collect_spark : World -> World.CollectResult
-collect_spark = |world|
-	match find_hit_spark(world.sparks, world.player.circle(), 0) {
-		Ok(spark) => {
-			remaining = List.keep_if(world.sparks, |item| item.id != spark.id)
-			next_score = world.score + 1
-			next_gate = gate_after_collect(remaining)
-			gate_opened = next_gate == GateOpen and !(gate_is_open(world.gate))
-
-			{
-				world: {
-					..world,
-					sparks: remaining,
-					score: next_score,
-					shake: 0,
-					flash: 0,
-					burst_pos: spark.pos,
-					burst_timer: burst_duration,
-					gate: next_gate,
-					gate_flash: if gate_opened 1 else world.gate_flash,
-					state: Playing,
-				},
-				collected: Ok(spark),
-				gate_opened,
+				{}
 			}
 		}
-		Err(_) => { world, collected: Err(NoSpark), gate_opened: Bool.False }
-	}
-
-any_hazard_hit : Level, Math.Circle, F32 -> Bool
-any_hazard_hit = |level, circle, phase| {
-	var $hit = Bool.False
-	for hazard in level.hazards {
-		if hazard.hit_by(circle, phase) {
-			$hit = Bool.True
+		GateOpened => sounds.gate.playback().with_volume(gate_volume).play!()
+		Escaped => {
+			sounds.music.set_volume!(music_won_volume)
+			sounds.win.playback().with_volume(win_volume).play!()
 		}
-	}
-	$hit
-}
-
-damage_if_needed : Level, World -> World.DamageResult
-damage_if_needed = |level, world| {
-	if world.player.invuln <= 0 and any_hazard_hit(level, world.player.circle(), world.phase) {
-		next_lives = if world.lives > 0 world.lives - 1 else 0
-		next_state = if world.lives <= 1 GameOver else Playing
-		{
-			world: {
-				..world,
-				player: world.player.damage_respawn(level.spawn),
-				lives: next_lives,
-				shake: 10,
-				flash: 0.28,
-				burst_pos: world.player.pos,
-				burst_timer: burst_duration,
-				state: next_state,
-			},
-			damaged: Bool.True,
-		}
-	} else {
-		{ world, damaged: Bool.False }
+		Damaged(state) =>
+			if state == GameOver {
+				sounds.lose.playback().with_volume(lose_volume).play!()
+			} else {
+				sounds.hurt.playback().with_volume(hurt_volume).play!()
+			}
+		GameStarted => sounds.music.set_volume!(music_volume)
 	}
 }
 
-escape_if_needed : Level, World -> World.EscapeResult
-escape_if_needed = |level, world| {
-	if gate_is_open(world.gate) and Math.circle_overlaps(world.player.circle(), Math.circle(level.exit_center, level.exit_radius)) {
-		{
-			world: {
-				..world,
-				shake: 10,
-				flash: 0,
-				burst_pos: level.exit_center,
-				burst_timer: burst_duration,
-				gate_flash: 1,
-				state: Won,
-			},
-			escaped: Bool.True,
-		}
-	} else {
-		{ world, escaped: Bool.False }
-	}
-}
-
-is_moving : Math.Vec2 -> Bool
-is_moving = |dir| dir.x != 0 or dir.y != 0
-
-facing_to_vec : Facing -> Math.Vec2
-facing_to_vec = |facing|
-	match facing {
-		North => { x: 0, y: -1 }
-		NorthEast => { x: 0.7, y: -0.7 }
-		East => { x: 1, y: 0 }
-		SouthEast => { x: 0.7, y: 0.7 }
-		South => { x: 0, y: 1 }
-		SouthWest => { x: -0.7, y: 0.7 }
-		West => { x: -1, y: 0 }
-		NorthWest => { x: -0.7, y: -0.7 }
-	}
-
-facing_to_rotation : Facing -> F32
-facing_to_rotation = |facing|
-	match facing {
-		North => -90
-		NorthEast => -45
-		East => 0
-		SouthEast => 45
-		South => 90
-		SouthWest => 135
-		West => 180
-		NorthWest => 225
-	}
-
-idle_animation : Sprite.Animation -> Sprite.Animation
-idle_animation = |animation| {
-	frame: 0,
-	frame_count: animation.frame_count,
-	fps: animation.fps,
-	elapsed: 0,
-}
-
-event_when : Bool, World.StepEvent -> List(World.StepEvent)
-event_when = |condition, event| if condition [event] else []
-
-spark_collected_events : Try(World.Spark, [NoSpark]) -> List(World.StepEvent)
-spark_collected_events = |collected|
-	match collected {
-		Ok(spark) => [SparkCollected(spark)]
-		Err(_) => []
-	}
-
-step_events : Bool, Try(World.Spark, [NoSpark]), Bool, Bool, Bool, GameState, Math.Vec2 -> List(World.StepEvent)
-step_events = |dash_started, collected, gate_opened, escaped, damaged, damage_state, dash_pos|
-	List.concat(
-		event_when(dash_started, DashStarted(dash_pos)),
-		List.concat(
-			spark_collected_events(collected),
-			List.concat(
-				event_when(gate_opened, GateOpened),
-				List.concat(
-					event_when(escaped, Escaped),
-					event_when(damaged, Damaged(damage_state)),
-				),
-			),
-		),
-	)
-
-advance_world : Level, World, World.StepInput -> World.StepResult
-advance_world = |level, world, input| {
-	moving = is_moving(input.raw_dir)
-	dash_started = input.dash_pressed and world.player.dash_ready()
-	dash_active = dash_started or world.player.dash_active()
-	move_dir = if dash_active and !(moving) world.player.facing_dir() else input.raw_dir
-	speed = if dash_active dash_speed else player_speed
-	player_pos = move_player_speed(level, world.player.pos, move_dir, input.dt, speed)
-	player = world.player.step({ pos: player_pos, raw_dir: input.raw_dir, move_dir, dash_started, dash_active, dt: input.dt })
-	hazard_speed = 0.15 + U64.to_f32(world.score) * 0.012
-	phase = wrap_unit(world.phase + input.dt * hazard_speed)
-
-	moved = {
-		..world,
-		player,
-		phase,
-		shake: Math.clamp(world.shake - input.dt * 36, 0, 99),
-		flash: tick_timer(world.flash, input.dt * 1.8),
-		burst_timer: tick_timer(world.burst_timer, input.dt),
-		gate_flash: tick_timer(world.gate_flash, input.dt * 1.15),
-		state: Playing,
-	}
-	collect_result = collect_spark(moved)
-	escape_result = escape_if_needed(level, collect_result.world)
-	damage_result = if escape_result.world.state == Won { world: escape_result.world, damaged: Bool.False } else damage_if_needed(level, escape_result.world)
-
-	{
-		world: damage_result.world,
-		events: step_events(
-			dash_started,
-			collect_result.collected,
-			collect_result.gate_opened,
-			escape_result.escaped,
-			damage_result.damaged,
-			damage_result.world.state,
-			world.player.pos,
-		),
-	}
-}
-
-## What a cycle of play asks the audio host for, as data. The pure step names
-## each cue; `update!` performs them in order.
-Cue : [Play(Audio.Playback), MusicVolume(F32)]
-
-perform_cue! : Model, Cue => {}
-perform_cue! = |model, cue|
-	match cue {
-		Play(playback) => playback.play!()
-		MusicVolume(volume) => model.sounds.music.set_volume!(volume)
-	}
-
-## Turn a cycle's world events into the sound cues they ask for.
-##
-## Pure: nothing is played here, each event just names the playback it wants.
-## Pan and pitch are that playback's own parameters rather than settings written
-## onto the shared `Sound`, so a parameter cannot be left behind on the wrong
-## sound -- note that a collected spark pans `collect` but pitches `sparkle`.
-play_step_events : Model, World.StepResult -> List(Cue)
-play_step_events = |model, result| {
-	sounds = model.sounds
-
-	var $cues = []
-	for event in result.events {
-		event_cues =
-			match event {
-				DashStarted(pos) => [
-					Play(
-						sounds.dash
-							.playback()
-							.with_volume(dash_volume)
-							.with_pan(pan_for_world_x(pos.x))
-							.with_pitch(0.95 + U64.to_f32(model.world.score) * 0.015),
-					),
-				]
-				SparkCollected(spark) => {
-					collect = Play(sounds.collect.playback().with_volume(collect_volume).with_pan(pan_for_world_x(spark.pos.x)))
-					sparkle = Play(sounds.sparkle.playback().with_volume(sparkle_volume).with_pitch(0.92 + U64.to_f32(result.world.score) * 0.045))
-					if result.world.score % 3 == 0 [collect, sparkle] else [collect]
-				}
-				GateOpened => [Play(sounds.gate.playback().with_volume(gate_volume))]
-				Escaped => [MusicVolume(music_won_volume), Play(sounds.win.playback().with_volume(win_volume))]
-				Damaged(state) =>
-					if state == GameOver {
-						[Play(sounds.lose.playback().with_volume(lose_volume))]
-					} else {
-						[Play(sounds.hurt.playback().with_volume(hurt_volume))]
-					}
-				}
-
-		$cues = List.concat($cues, event_cues)
-	}
-	$cues
-}
-
-## One cycle of play: the next model together with the cues it wants performed.
-##
-## The cues travel back with the model rather than being fired here, and the
-## caller performs them as it unwinds.
-##
-## The seconds to advance by are a plain parameter rather than a whole
-## `Time.Cycle`: only the elapsed time is used, so the caller stays free to pass
-## a fixed step instead of whatever the last frame happened to take.
-advance_playing : Model, Devices.Snapshot, F32 -> { model : Model, cues : List(Cue) }
-advance_playing = |model, input, dt| {
-	result = advance_world(
-		model.level,
-		model.world,
-		{
-			raw_dir: input_axis(input),
-			dash_pressed: input.key_pressed(KeySpace),
-			dt,
-		},
-	)
-
-	{
-		model: { ..model, world: result.world },
-		cues: play_step_events(model, result),
-	}
-}
-
-## Space restarts from either end state, restoring the music to the level
-## `Escaped` ducked it away from.
-restart_on_space : Model, Devices.Snapshot -> { model : Model, cues : List(Cue) }
-restart_on_space = |model, input|
-	if input.key_pressed(KeySpace) {
-		fresh = new_game(model.font, model.characters, model.tiles, model.level, model.sounds)
-		{
-			model: { ..fresh, demo: model.demo, demo_frame: model.demo_frame },
-			cues: [MusicVolume(music_volume)],
-		}
-	} else {
-		{ model, cues: [] }
-	}
-
-## Nothing here waits, so there is no task to spawn and no message to fold in.
-## The step is pure and returns the cues it wants; `update!` performs them in
-## order and decides whether Escape ends the app.
 Msg : []
 
+## Advances pure gameplay, performs its events, and handles capture or quit.
 update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
 update! = |model, program_input| {
-	input = if model.demo demo_input(model.demo_frame) else program_input.devices
-
-	next = match model.world.state {
-		Playing => advance_playing(model, input, program_input.time.elapsed_seconds)
-		Won => restart_on_space(model, input)
-		GameOver => restart_on_space(model, input)
+	controls = if model.demo demo_controls(model.demo_frame) else read_controls(program_input.devices)
+	dt = program_input.time.elapsed_seconds
+	(world, events) = Game.update(model.level, model.world, controls, dt)
+	for event in events {
+		play_event!(model.assets, model.level, model.world, world, event)
 	}
-
-	for cue in next.cues {
-		perform_cue!(model, cue)
-	}
-
-	exit =
-		if model.demo {
-			match program_input.capture {
-				Finished(_) => Err(Exit(0))
-				Failed(_) => Err(Exit(1))
-				_ => Ok({})
-			}
-		} else if input.key_pressed(KeyEscape) {
-			Err(Exit(0))
-		} else {
-			Ok({})
+	if model.demo {
+		match program_input.capture {
+			Finished(_) => Err(Exit(0))
+			Failed(_) => Err(Exit(1))
+			_ => Ok({ ..model, world, demo_frame: model.demo_frame + 1 })
 		}
-
-	match exit {
-		Err(code) => Err(code)
-		Ok({}) => Ok({ ..next.model, demo_frame: model.demo_frame + 1 })
+	} else if controls.quit_pressed {
+		Err(Exit(0))
+	} else {
+		Ok({ ..model, world, demo_frame: model.demo_frame + 1 })
 	}
 }
 
-## The camera follows the (shaken) player position, so it is a pure function of
-## the model and is derived here rather than stored.
+## Delegates the complete presentation frame to the rendering module.
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ScopeLimit, ..])
-render! = |model, frame| {
-	camera = Camera.follow(shaken_target(model.world), { screen: { x: screen_w, y: screen_h }, zoom: 0.82 })
-	viewport = camera.viewport({ x: screen_w, y: screen_h })
+render! = |model, frame| Render.draw!(frame, model.assets, model.level, model.world)
 
-	frame.clear!(Color.from_hex_rgb(0x071018))
-	frame.with_camera!(
-		camera,
-		|world_frame| {
-			draw_world!(world_frame, model.level, model.characters, model.tiles, model.world, viewport, model.font)
-			Ok({})
-		},
-	)?
-	draw_hud!(frame, model.level, model.world, model.font)
+no_controls : Controls
+no_controls = { move: { x: 0, y: 0 }, dash_pressed: Bool.False, restart_pressed: Bool.False, quit_pressed: Bool.False }
 
-	Ok({})
+test_level : Level
+test_level = {
+	tilemap: Tilemap.empty,
+	spawn: { x: -560, y: -360 },
+	exit_center: { x: 1185, y: 920 },
+	exit_radius: 58,
+	sparks: [Spark.{ id: 0, pos: { x: -430, y: -150 } }, Spark.{ id: 1, pos: { x: 100, y: 100 } }],
+	spark_total: 2,
+	obstacles: [],
+	hazards: [Hazard.{ center: { x: -445, y: 165 }, span: 520, lane: Horizontal, offset: 0, radius: 30, color: Color.red }],
+	decorations: [],
+	bounds: Math.rect(-720, -520, 2176, 1664),
 }
 
-shaken_target : World -> Math.Vec2
-shaken_target = |world| {
-	amount = world.shake
-	x_phase = ping_pong(wrap_unit(world.phase * 9.7))
-	y_phase = ping_pong(wrap_unit(world.phase * 13.1 + 0.31))
-	{
-		x: world.player.pos.x + (x_phase - 0.5) * amount,
-		y: world.player.pos.y + (y_phase - 0.5) * amount,
+expect Player.new(test_level.spawn).circle().radius == Player.radius
+expect Player.new(test_level.spawn).facing_dir() == { x: 1, y: 0 }
+expect
+	match Player.new(test_level.spawn).facing {
+		East => Bool.True
+		_ => Bool.False
 	}
-}
-
-draw_world! : Draw.Frame, Level, Draw.Texture, Draw.Texture, World, Math.Rect, Text.Font => {}
-draw_world! = |frame, level, characters, tiles, world, viewport, font| {
-	frame.rectangle_gradient_v!({ x: level.bounds.x, y: level.bounds.y, width: level.bounds.width, height: level.bounds.height, color_top: Color.from_hex_rgb(0x173833), color_bottom: Color.from_hex_rgb(0x132821) })
-	level.tilemap.draw_all_in!(frame, viewport)
-	draw_hazard_lanes!(frame, level, world.phase)
-	draw_props!(frame, level, tiles, viewport)
-	frame.rectangle!({ x: level.bounds.x, y: level.bounds.y, width: level.bounds.width, height: level.bounds.height, style: Draw.outlined(Color.with_alpha(Color.white, 90), 6) })
-
-	draw_spawn!(frame, level, font)
-	draw_exit!(frame, level, world, font)
-	draw_obstacles!(frame, level, tiles, viewport)
-	draw_sparks!(frame, tiles, world.sparks, world.phase, viewport)
-	draw_hazards!(frame, level, characters, world.phase, viewport)
-	draw_burst!(frame, world)
-	draw_player!(frame, characters, world.player)
-}
-
-tile_cols = 27.U64
-
-tile_id : Tile -> U64
-tile_id = |tile|
-	match tile {
-		TileFloor => 1
-		TileBlockA => 156
-		TileBlockB => 157
-		TileMarker => 158
-		TileRockA => 181
-		TilePlantA => 183
-		TilePlantB => 184
-		TileFlowerA => 213
-		TileFlowerB => 214
-		TileCrystalA => 237
-		TileCrystalB => 238
-		TileSparkA => 239
-		TileSparkB => 240
-	}
-
-tile_source : Tile -> Math.Rect
-tile_source = |tile| {
-	index = tile_id(tile) - 1
-	Sprite.sheet_frame({ frame_size: { x: 64, y: 64 }, row: index // tile_cols, col: index % tile_cols })
-}
-
-tile_sprite : Draw.Texture, Tile, Math.Vec2, F32 -> Sprite.Sprite
-tile_sprite = |tiles, tile, pos, scale|
-	Sprite.from_texture(tiles)
-		.source(
-			tile_source(tile),
-		)
-		.pos(
-			pos,
-		)
-		.scale(
-			scale,
-		)
-
-draw_tile! : Draw.Frame, Draw.Texture, Tile, Math.Vec2, F32 => {}
-draw_tile! = |frame, tiles, tile, pos, scale| tile_sprite(tiles, tile, pos, scale).draw!(frame)
-
-draw_tile_centered! : Draw.Frame, Draw.Texture, Tile, Math.Vec2, F32, F32 => {}
-draw_tile_centered! = |frame, tiles, tile, pos, scale, rotation| tile_sprite(tiles, tile, pos, scale).centered().rotation(rotation).draw!(frame)
-
-draw_spawn! : Draw.Frame, Level, Text.Font => {}
-draw_spawn! = |frame, level, font| {
-	frame.circle_gradient!({ center: level.spawn, radius: 72, color_inner: Color.with_alpha(Color.from_hex_rgb(0x2a9d8f), 120), color_outer: Color.with_alpha(Color.from_hex_rgb(0x2a9d8f), 0) })
-	frame.circle!({ center: level.spawn, radius: 42, style: Draw.filled_and_outlined(Color.from_hex_rgb(0x2a9d8f), Color.white, 4) })
-	Text.from("START", font)
-		.size(18)
-		.draw!(frame, { pos: { x: level.spawn.x, y: level.spawn.y + 63 }, color: Color.with_alpha(Color.white, 190), align: (Top, Center) })
-}
-
-draw_exit! : Draw.Frame, Level, World, Text.Font => {}
-draw_exit! = |frame, level, world, font| {
-	is_open = gate_is_open(world.gate)
-	color = if is_open Color.from_hex_rgb(0xf9c74f) else Color.from_hex_rgb(0x576066)
-	halo = if is_open Color.with_alpha(color, 95) else Color.with_alpha(Color.black, 70)
-	frame.circle_gradient!({ center: level.exit_center, radius: 82 + world.gate_flash * 28, color_inner: halo, color_outer: Color.with_alpha(color, 0) })
-	frame.circle!({ center: level.exit_center, radius: level.exit_radius, style: Draw.filled_and_outlined(Color.with_alpha(color, 190), Color.white, 4) })
-	Text.from(if is_open "EXIT OPEN" else "LOCKED EXIT", font)
-		.size(19)
-		.draw!(frame, { pos: { x: level.exit_center.x, y: level.exit_center.y + 74 }, color: Color.white, align: (Top, Center) })
-}
-
-draw_obstacle! : Draw.Frame, Draw.Texture, World.Obstacle => {}
-draw_obstacle! = |frame, tiles, obstacle| {
-	rect = obstacle.rect
-	frame.rounded_rectangle!({ x: rect.x, y: rect.y, width: rect.width, height: rect.height, radius: 14, segments: 8, style: Draw.filled_and_outlined(Color.with_alpha(Color.from_hex_rgb(0x23342d), 235), Color.from_hex_rgb(0xa3b18a), 4) })
-	draw_tile_centered!(frame, tiles, obstacle.tile, obstacle.center(), 1.25, obstacle.rotation)
-}
-
-draw_obstacles! : Draw.Frame, Level, Draw.Texture, Math.Rect => {}
-draw_obstacles! = |frame, level, tiles, viewport| {
-	for obstacle in level.obstacles {
-		rect = obstacle.rect
-		visual_bounds = Math.rect(rect.x - 48, rect.y - 48, rect.width + 96, rect.height + 96)
-		if Math.overlaps(visual_bounds, viewport) {
-			draw_obstacle!(frame, tiles, obstacle)
-		}
-	}
-}
-
-draw_props! : Draw.Frame, Level, Draw.Texture, Math.Rect => {}
-draw_props! = |frame, level, tiles, viewport| {
-	for decoration in level.decorations {
-		if Math.circle_rect({ center: decoration.pos, radius: 48 * decoration.scale }, viewport) {
-			draw_tile_centered!(frame, tiles, decoration.tile, decoration.pos, decoration.scale, decoration.rotation)
-		}
-	}
-}
-
-draw_spark! : Draw.Frame, Draw.Texture, World.Spark, F32 => {}
-draw_spark! = |frame, tiles, spark, phase| {
-	tile = if spark.id % 2 == 0 TileSparkA else TileSparkB
-	rotation = phase * 160 + U64.to_f32(spark.id) * 19
-	pulse = 1 + ping_pong(wrap_unit(phase * 2 + U64.to_f32(spark.id) * 0.09)) * 0.1
-	frame.circle_gradient!({ center: spark.pos, radius: spark_radius * 2 * pulse, color_inner: Color.with_alpha(Color.from_hex_rgb(0xf9c74f), 55), color_outer: Color.with_alpha(Color.from_hex_rgb(0xf9c74f), 0) })
-	frame.circle!({ center: spark.pos, radius: spark_radius + 4 * pulse, style: Draw.outlined(Color.with_alpha(Color.white, 110), 3) })
-	draw_tile_centered!(frame, tiles, tile, spark.pos, 0.72 * pulse, rotation)
-}
-
-draw_sparks! : Draw.Frame, Draw.Texture, List(World.Spark), F32, Math.Rect => {}
-draw_sparks! = |frame, tiles, sparks, phase, viewport| {
-	for spark in sparks {
-		if Math.circle_rect({ center: spark.pos, radius: spark_radius * 2.2 }, viewport) {
-			draw_spark!(frame, tiles, spark, phase)
-		}
-	}
-}
-
-draw_hazard_lanes! : Draw.Frame, Level, F32 => {}
-draw_hazard_lanes! = |frame, level, phase| {
-	for hazard in level.hazards {
-		pos = hazard.pos(phase)
-		frame.line!({ start: hazard.lane_start(), end: hazard.lane_end(), stroke: Draw.stroke(Color.with_alpha(hazard.color, 48), 10) })
-		frame.circle_gradient!({ center: pos, radius: hazard.radius * 1.9, color_inner: Color.with_alpha(hazard.color, 54), color_outer: Color.with_alpha(hazard.color, 0) })
-	}
-}
-
-robot_source : Math.Rect
-robot_source = Math.rect(458, 88, 33, 43)
-
-draw_hazard! : Draw.Frame, Draw.Texture, World.Hazard, F32 => {}
-draw_hazard! = |frame, characters, hazard, phase| {
-	pos = hazard.pos(phase)
-	sprite = Sprite.from_texture(characters)
-		.source(
-			robot_source,
-		)
-		.pos(
-			pos,
-		)
-		.scale(
-			1.38,
-		)
-		.centered()
-
-	sprite.draw!(frame)
-	frame.circle!({ center: pos, radius: hazard.radius, style: Draw.outlined(Color.with_alpha(Color.white, 170), 3) })
-}
-
-draw_hazards! : Draw.Frame, Level, Draw.Texture, F32, Math.Rect => {}
-draw_hazards! = |frame, level, characters, phase, viewport| {
-	for hazard in level.hazards {
-		pos = hazard.pos(phase)
-		if Math.circle_rect({ center: pos, radius: F32.max(hazard.radius + 3, 34) }, viewport) {
-			draw_hazard!(frame, characters, hazard, phase)
-		}
-	}
-}
-
-burst_dir : U64 -> Math.Vec2
-burst_dir = |index|
-	match index % 8 {
-		0 => { x: 1, y: 0 }
-		1 => { x: 0.7, y: 0.7 }
-		2 => { x: 0, y: 1 }
-		3 => { x: -0.7, y: 0.7 }
-		4 => { x: -1, y: 0 }
-		5 => { x: -0.7, y: -0.7 }
-		6 => { x: 0, y: -1 }
-		_ => { x: 0.7, y: -0.7 }
-	}
-
-draw_burst_particle! : Draw.Frame, World, U64 => {}
-draw_burst_particle! = |frame, world, index| {
-	if index >= 6 or world.burst_timer <= 0 {
-		{}
-	} else {
-		progress = 1 - world.burst_timer / burst_duration
-		dir = burst_dir(index)
-		pos = Math.add(world.burst_pos, Math.scale(dir, 18 + progress * 58))
-		size = 6 + ping_pong(wrap_unit(world.phase * 5 + U64.to_f32(index) * 0.11)) * 3
-		frame.circle!({ center: pos, radius: size, style: Draw.filled(Color.with_alpha(Color.from_hex_rgb(0xf9c74f), if world.burst_timer > 0.18 135 else 70)) })
-		draw_burst_particle!(frame, world, index + 1)
-	}
-}
-
-draw_burst! : Draw.Frame, World => {}
-draw_burst! = |frame, world| draw_burst_particle!(frame, world, 0)
-
-player_source : Math.Rect
-player_source = Math.rect(0, 0, 52, 43)
-
-draw_player! : Draw.Frame, Draw.Texture, World.Player => {}
-draw_player! = |frame, characters, player| {
-	tint = if player.invuln > 0 Color.with_alpha(Color.white, 150) else Color.white
-	scale = if player.dash_active() 1.3 else 1.22
-	sprite = Sprite.from_texture(characters)
-		.source(
-			player_source,
-		)
-		.pos(
-			player.pos,
-		)
-		.scale(
-			scale,
-		)
-		.centered()
-		.rotation(
-			player.rotation(),
-		)
-		.tint(
-			tint,
-		)
-
-	frame.circle!({ center: { x: player.pos.x + 5, y: player.pos.y + 7 }, radius: player_radius + 6, style: Draw.filled(Color.with_alpha(Color.black, 85)) })
-	if player.dash_active() {
-		trail_center = Math.add(player.pos, Math.scale(player.facing_dir(), -38))
-		frame.circle_gradient!({ center: trail_center, radius: 44, color_inner: Color.with_alpha(Color.from_hex_rgb(0x43aa8b), 55), color_outer: Color.with_alpha(Color.from_hex_rgb(0x43aa8b), 0) })
-		frame.circle_gradient!({ center: player.pos, radius: 54, color_inner: Color.with_alpha(Color.from_hex_rgb(0x43aa8b), 70), color_outer: Color.with_alpha(Color.from_hex_rgb(0x43aa8b), 0) })
-	} else {
-		{}
-	}
-	sprite.draw!(frame)
-	frame.circle!({ center: player.pos, radius: player_radius, style: Draw.outlined(Color.with_alpha(Color.white, 180), 2) })
-}
-
-draw_bar! : Draw.Frame, F32, F32, F32, F32, F32, Color.Rgba => {}
-draw_bar! = |frame, x, y, width, height, amount, color| {
-	frame.rounded_rectangle!({ x, y, width, height, radius: 5, segments: 6, style: Draw.filled(Color.with_alpha(Color.black, 130)) })
-	frame.rounded_rectangle!({ x, y, width: width * Math.clamp(amount, 0, 1), height, radius: 5, segments: 6, style: Draw.filled(color) })
-}
-
-draw_hud! : Draw.Frame, Level, World, Text.Font => {}
-draw_hud! = |frame, level, world, font| {
-	is_open = gate_is_open(world.gate)
-
-	frame.rectangle_gradient_v!({ x: 0, y: 0, width: screen_w, height: 76, color_top: Color.with_alpha(Color.black, 220), color_bottom: Color.with_alpha(Color.black, 125) })
-	frame.text!({ pos: { x: 22, y: 16 }, text: "Spark Run", size: 27, spacing: Draw.default_spacing, color: Color.white, font: font })
-	frame.text!({ pos: { x: 195, y: 18 }, text: Str.concat("Sparks ", Str.concat(U64.to_str(world.score), Str.concat("/", U64.to_str(level.spark_total)))), size: 20, spacing: Draw.default_spacing, color: Color.from_hex_rgb(0xf9c74f), font: font })
-	frame.text!({ pos: { x: 382, y: 18 }, text: Str.concat("Lives ", U64.to_str(world.lives)), size: 20, spacing: Draw.default_spacing, color: Color.light_gray, font: font })
-	frame.text!({ pos: { x: 510, y: 18 }, text: if is_open "Gate open" else "Collect all sparks", size: 20, spacing: Draw.default_spacing, color: if is_open Color.from_hex_rgb(0x90be6d) else Color.light_gray, font: font })
-	frame.fps!({ pos: { x: 735, y: 20 }, size: 18, color: Color.gray })
-	draw_bar!(frame, 196, 48, 170, 9, U64.to_f32(world.score) / U64.to_f32(level.spark_total), Color.from_hex_rgb(0xf9c74f))
-	draw_bar!(frame, 510, 48, 120, 9, world.player.dash_charge(), Color.from_hex_rgb(0x43aa8b))
-	frame.text!({ pos: { x: 640, y: 43 }, text: if world.player.dash_ready() "SPACE dash" else "charging", size: 16, spacing: Draw.default_spacing, color: Color.light_gray, font: font })
-
-	if world.flash > 0 {
-		frame.rectangle!({ x: 0, y: 0, width: screen_w, height: screen_h, style: Draw.filled(Color.with_alpha(Color.red, if world.flash > 0.45 120 else 70)) })
-	} else {
-		{}
-	}
-
-	match world.state {
-		Playing => {}
-		Won => draw_modal!(frame, font, "All sparks recovered", "Press SPACE to run again", Color.from_hex_rgb(0x43aa8b))
-		GameOver => draw_modal!(frame, font, "Spark Run ended", "Press SPACE to restart", Color.from_hex_rgb(0xf94144))
-	}
-}
-
-draw_modal! : Draw.Frame, Text.Font, Str, Str, Color.Rgba => {}
-draw_modal! = |frame, font, title, subtitle, accent| {
-	frame.rectangle!({ x: 0, y: 0, width: screen_w, height: screen_h, style: Draw.filled(Color.with_alpha(Color.black, 120)) })
-	frame.rounded_rectangle!({ x: 185, y: 226, width: 430, height: 152, radius: 8, segments: 8, style: Draw.filled_and_outlined(Color.with_alpha(Color.black, 230), accent, 4) })
-	Text.from(title, font).size(30).draw!(frame, { pos: { x: screen_w * 0.5, y: 276 }, color: Color.white, align: (Middle, Center) })
-	Text.from(subtitle, font).size(21).draw!(frame, { pos: { x: screen_w * 0.5, y: 326 }, color: Color.light_gray, align: (Middle, Center) })
-}
-
-approx : F32, F32 -> Bool
-approx = |a, b| F32.abs(a - b) < 0.0001
-
-approx_vec : Math.Vec2, Math.Vec2 -> Bool
-approx_vec = |a, b| approx(a.x, b.x) and approx(a.y, b.y)
-
-test_hazard : World.Hazard
-test_hazard = { center: { x: 0, y: 0 }, span: 20, lane: Horizontal, offset: 0, radius: 5, color: Color.white }
-
-expect World.Player.new(fallback_spawn).circle().radius == player_radius
-expect World.Player.new(fallback_spawn).facing_dir() == { x: 1, y: 0 }
-expect World.Player.new(fallback_spawn).facing == East
-expect facing_to_rotation(East) == 0
-expect facing_to_vec(NorthWest) == { x: -0.7, y: -0.7 }
-expect gate_is_open(GateOpen)
-expect !(gate_is_open(GateLocked))
-expect tile_id(TileBlockA) == 156
-expect tile_id(TileSparkB) == 240
-expect World.Player.new({ x: 10, y: 20 }).damage_respawn(fallback_spawn).pos == fallback_spawn
-expect World.Obstacle.new(0, 0, 10, 10, TileBlockA, 0).hit_by(Math.circle({ x: 5, y: 5 }, 1))
-expect !(World.Obstacle.new(0, 0, 10, 10, TileBlockA, 0).hit_by(Math.circle({ x: 30, y: 30 }, 1)))
-expect approx_vec(test_hazard.pos(0), { x: -10, y: 0 })
-expect approx_vec(test_hazard.pos(0.25), { x: 0, y: 0 })
+expect Player.new({ x: 10, y: 20 }).damage_respawn(test_level.spawn).pos == test_level.spawn
 
 expect {
-	spark = World.Spark.new(7, 10, 20)
-	find_hit_spark([spark], Math.circle({ x: 10, y: 20 }, 1), 0) == Ok(spark)
+	hazard = Hazard.{ center: { x: 0, y: 0 }, span: 20, lane: Horizontal, offset: 0, radius: 5, color: Color.white }
+	hazard.pos(0) == { x: -10, y: 0 } and hazard.pos(0.25) == { x: 0, y: 0 }
 }
 
 expect {
-	world = { ..World.new(fallback_level), player: World.Player.new({ x: -430, y: -150 }) }
-	result = collect_spark(world)
-	result.world.score == 1 and result.collected == Ok(World.Spark.new(0, -430, -150))
+	world = { ..Game.new(test_level), player: Player.new({ x: -430, y: -150 }) }
+	(next, events) = Game.update(test_level, world, no_controls, 0)
+	next.score == 1 and events == [SparkCollected(Spark.{ id: 0, pos: { x: -430, y: -150 } })]
 }
 
 expect {
-	spark = World.Spark.new(99, 0, 0)
-	world = { ..World.new(fallback_level), player: World.Player.new({ x: 0, y: 0 }), sparks: [spark], score: 9 }
-	result = collect_spark(world)
-	result.gate_opened and result.world.gate == GateOpen and result.world.score == 10
+	world = { ..Game.new(test_level), player: Player.new({ x: -705, y: 165 }) }
+	(next, events) = Game.update(test_level, world, no_controls, 0)
+	next.lives == 2 and events == [Damaged(Playing)]
 }
 
 expect {
-	world = { ..World.new(fallback_level), player: World.Player.new({ x: -705, y: 165 }) }
-	result = damage_if_needed(fallback_level, world)
-	result.damaged and result.world.lives == 2 and result.world.player.pos == fallback_spawn
+	world = { ..Game.new(test_level), gate: GateOpen, player: Player.new(test_level.exit_center) }
+	(next, events) = Game.update(test_level, world, no_controls, 0)
+	next.state == Won and events == [Escaped]
 }
 
 expect {
-	world = { ..World.new(fallback_level), gate: GateOpen, player: World.Player.new(fallback_exit_center) }
-	result = escape_if_needed(fallback_level, world)
-	result.escaped and result.world.state == Won
-}
-
-expect {
-	result = advance_world(fallback_level, World.new(fallback_level), { raw_dir: { x: 1, y: 0 }, dash_pressed: Bool.True, dt: 0.01 })
-	List.first(result.events) == Ok(DashStarted(fallback_spawn)) and result.world.player.dash_timer == dash_duration
+	controls = { ..no_controls, move: { x: 1, y: 0 }, dash_pressed: Bool.True }
+	(next, events) = Game.update(test_level, Game.new(test_level), controls, 0.01)
+	List.first(events) == Ok(DashStarted(test_level.spawn)) and next.player.dash_active()
 }


### PR DESCRIPTION
# Roc-Ray Game Examples Refactor

## Motivation

The larger roc-ray game examples such as Breakout, Top Down, and Cave Climb currently keep most gameplay logic in a single large `main.roc` file.

This is useful for very small examples, but becomes harder to navigate once a game contains several independent gameplay concepts such as:

- player movement
- enemies
- projectiles or abilities
- collision logic
- level data
- camera behavior
- animation
- input handling
- rendering
- game state transitions

The goal of this refactor is not to introduce a full game framework or ECS.

Instead, the examples should demonstrate a simple modular architecture that remains close to roc-ray's current model:

```text
Host
  ↓
Controls
  ↓
Game update
  ↓
World
  ↓
Render
  ↓
Frame
```

The application should continue to own its complete game state explicitly.

The refactor should primarily:

- keep `main.roc` small and easy to understand
- separate independent gameplay concepts into focused modules
- distinguish static level data from dynamic world state
- translate raw platform input into semantic game controls
- keep gameplay update logic as pure as practical
- keep rendering separate from simulation logic
- allow gameplay systems to communicate through explicit events
- avoid introducing generic abstractions before multiple games actually need them

The resulting architecture should provide a more digestible main!.roc entry point and navigation.
