### PR TITLE
Finish the typed host boundary PR #187 started

### DIFF
--- a/platform/App.roc
+++ b/platform/App.roc
@@ -397,10 +397,12 @@ App := [].{
 	## reads the clipboard with `Window.read_clipboard!`, which names the
 	## refusals separately.
 	get_clipboard_text! : Startup => Try(Str, [Unavailable, ..])
-	get_clipboard_text! = |_startup| {
-		result = Host.window_read_clipboard!()
-		if result.err == 0 Ok(result.contents) else Err(Unavailable)
-	}
+	get_clipboard_text! = |_startup|
+		match Host.window_read_clipboard!() {
+			# Startup deliberately collapses every refusal into one outcome.
+			Ok(contents) => Ok(contents)
+			Err(_) => Err(Unavailable)
+		}
 
 	## Replace the system clipboard contents with UTF-8 text.
 	##

--- a/platform/Assets.roc
+++ b/platform/Assets.roc
@@ -38,8 +38,8 @@
 ## Release textures the app no longer needs before loading more.
 import Color
 import Host
-import rrt.Handle
 import rrt.Texture as RrtTexture
+import rrt.Store as RrtStore
 
 Assets := [].{
 
@@ -56,7 +56,7 @@ Assets := [].{
 	## An opened, explicitly located disk asset store. The host retains the
 	## directory handle, not the process working directory; every relative asset
 	## lookup is made through that handle.
-	Store :: Host.Store.{
+	Store :: RrtStore.Store.{
 
 		## Open the store described by a `StoreConfig`, checking its manifest if
 		## one was required.
@@ -118,10 +118,10 @@ Assets := [].{
 		## `expect` build that model. Do not use it to test asset resolution or
 		## resource lifetime.
 		stub : Store
-		stub = Store.(Handle.stub)
+		stub = Store.(RrtStore.stub)
 
 		## Internal bridge for platform operations that also use an asset store.
-		for_host : Store -> Host.Store
+		for_host : Store -> RrtStore.Store
 		for_host = |Store.(store)| store
 	}
 

--- a/platform/Assets.roc
+++ b/platform/Assets.roc
@@ -298,23 +298,34 @@ Assets := [].{
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
 	update_texture! : Texture, List(Color.Rgba) => Try({}, [PixelCountMismatch, ..])
 	update_texture! = |texture, pixels|
-		whole_texture_result(Host.texture_update!({ texture, pixels }))
+	# closed error union to open error union. The public API does not yet
+	# distinguish a handle that is not an app-owned texture from a pixel
+	# count that does not match, so both report the mismatch.
+		match Host.texture_update!({ texture, pixels }) {
+			Ok({}) => Ok({})
+			Err(NotMutable) => Err(PixelCountMismatch)
+			Err(PixelCountMismatch) => Err(PixelCountMismatch)
+		}
 
 	## Replace one rectangle of a texture, paying only for that rectangle.
 	##
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
 	update_texture_region! : Texture, Region => Try({}, [PixelCountMismatch, RegionOutOfBounds, ..])
 	update_texture_region! = |texture, region|
-		region_result(
-			Host.texture_update_region!({
-				texture,
-				x: region.x,
-				y: region.y,
-				width: region.width,
-				height: region.height,
-				pixels: region.pixels,
-			}),
-		)
+	# closed error union to open error union, as `update_texture!` does.
+		match Host.texture_update_region!({
+			texture,
+			x: region.x,
+			y: region.y,
+			width: region.width,
+			height: region.height,
+			pixels: region.pixels,
+		}) {
+			Ok({}) => Ok({})
+			Err(RegionOutOfBounds) => Err(RegionOutOfBounds)
+			Err(NotMutable) => Err(PixelCountMismatch)
+			Err(PixelCountMismatch) => Err(PixelCountMismatch)
+		}
 
 	## Change how this texture is sampled when scaled.
 	##
@@ -390,32 +401,4 @@ wrap_code = |wrap|
 		Clamp => 1
 		MirrorRepeat => 2
 		MirrorClamp => 3
-	}
-
-## Code the host returns when an upload exceeded the frame's budget.
-## Mirrored in `src/host_native.zig`.
-## Code the host returns for a region that hangs over the texture's edge.
-## Mirrored in `src/host_native.zig`.
-upload_err_out_of_bounds : U8
-upload_err_out_of_bounds = 3
-
-## Decode the host's code for a whole-texture upload, which has no region to
-## be out of bounds.
-whole_texture_result : U8 -> Try({}, [PixelCountMismatch, ..])
-whole_texture_result = |code|
-	if code == 0 {
-		Ok({})
-	} else {
-		Err(PixelCountMismatch)
-	}
-
-## Decode the host's code for a region upload.
-region_result : U8 -> Try({}, [PixelCountMismatch, RegionOutOfBounds, ..])
-region_result = |code|
-	if code == 0 {
-		Ok({})
-	} else if code == upload_err_out_of_bounds {
-		Err(RegionOutOfBounds)
-	} else {
-		Err(PixelCountMismatch)
 	}

--- a/platform/Audio.roc
+++ b/platform/Audio.roc
@@ -37,7 +37,8 @@
 ## `Music.is_playing!`, `Music.length!`, and `Music.time_played!` -- are legal
 ## in any callback, `render!` included.
 import Host
-import rrt.Handle
+import rrt.AudioSound as RrtAudioSound
+import rrt.AudioMusic as RrtAudioMusic
 
 Audio := [].{
 
@@ -46,7 +47,7 @@ Audio := [].{
 	## A sound has no volume, pitch, or pan of its own that outlives a play.
 	## raylib's are sticky per resource, and every play sets all three, so there
 	## is nothing to set once and inherit -- see `Playback`.
-	Sound :: { resource : Host.AudioSound }.{
+	Sound :: { resource : RrtAudioSound.AudioSound }.{
 
 		## Play this sound at its default volume, pitch, and pan.
 		##
@@ -95,7 +96,7 @@ Audio := [].{
 		## Put it in a model to reach the app's pure update logic from an
 		## `expect`. Do not use it to test playback or resource lifetime.
 		stub : Sound
-		stub = { resource: Handle.stub }
+		stub = { resource: RrtAudioSound.stub }
 	}
 
 	## A sound together with the settings it should be played at.
@@ -135,7 +136,7 @@ Audio := [].{
 	}
 
 	## Host-owned streamed music. The platform updates active streams each frame.
-	Music :: { resource : Host.AudioMusic }.{
+	Music :: { resource : RrtAudioMusic.AudioMusic }.{
 
 		## Start or restart playback.
 		##
@@ -218,7 +219,7 @@ Audio := [].{
 		## update logic from an `expect`. Do not use it to test playback or
 		## resource lifetime.
 		stub : Music
-		stub = { resource: Handle.stub }
+		stub = { resource: RrtAudioMusic.stub }
 	}
 
 	## Procedural waveform used by `gen_sound!`.
@@ -296,7 +297,7 @@ Audio := [].{
 	expect waveform_code(Noise) == 4
 }
 
-loaded_sound_from_resource : Try(Host.AudioSound, Host.AudioLoadSoundError) -> Try(Audio.Sound, [SoundLoadFailed, ResourceLimit, ..])
+loaded_sound_from_resource : Try(RrtAudioSound.AudioSound, Host.AudioLoadSoundError) -> Try(Audio.Sound, [SoundLoadFailed, ResourceLimit, ..])
 loaded_sound_from_resource = |result|
 	match result {
 		# closed error union to open error union
@@ -311,7 +312,7 @@ loaded_sound_from_resource = |result|
 		Err(ResourceLimit) => Err(ResourceLimit)
 	}
 
-generated_sound_from_resource : Try(Host.AudioSound, Host.AudioGenerateSoundError) -> Try(Audio.Sound, [SoundGenerationFailed, ResourceLimit, ..])
+generated_sound_from_resource : Try(RrtAudioSound.AudioSound, Host.AudioGenerateSoundError) -> Try(Audio.Sound, [SoundGenerationFailed, ResourceLimit, ..])
 generated_sound_from_resource = |result|
 	match result {
 		# closed error union to open error union
@@ -326,7 +327,7 @@ generated_sound_from_resource = |result|
 		Err(ResourceLimit) => Err(ResourceLimit)
 	}
 
-music_from_resource : Try(Host.AudioMusic, Host.AudioLoadMusicError) -> Try(Audio.Music, [MusicLoadFailed, ResourceLimit, ..])
+music_from_resource : Try(RrtAudioMusic.AudioMusic, Host.AudioLoadMusicError) -> Try(Audio.Music, [MusicLoadFailed, ResourceLimit, ..])
 music_from_resource = |result|
 	match result {
 		# closed error union to open error union

--- a/platform/Capture.roc
+++ b/platform/Capture.roc
@@ -274,11 +274,14 @@ Capture := [].{
 	## run under `--host-headless`.
 	pixel_at! : Source, { x : I32, y : I32 } => Try(Color.Rgba, PixelReadError)
 	pixel_at! = |source, point| {
-		result = Host.capture_pixel_at!({ source: pixel_source(source), x: point.x, y: point.y })
-		if result.err == 0 {
-			Ok(Color.rgba(result.r, result.g, result.b, result.a))
-		} else {
-			Err(pixel_read_error(result.err))
+		# closed error union to open error union
+		match Host.capture_pixel_at!({ source: pixel_source(source), x: point.x, y: point.y }) {
+			Ok(pixel) => Ok(Color.rgba(pixel.r, pixel.g, pixel.b, pixel.a))
+			Err(Busy) => Err(Busy)
+			Err(ReadbackFailed) => Err(ReadbackFailed)
+			Err(RegionOutOfBounds) => Err(RegionOutOfBounds)
+			Err(TargetUnavailable) => Err(TargetUnavailable)
+			Err(Unavailable) => Err(Unavailable)
 		}
 	}
 
@@ -314,10 +317,14 @@ Capture := [].{
 			width: region.width,
 			height: region.height,
 		})
-		if result.err == 0 {
-			Ok(result.bytes)
-		} else {
-			Err(pixel_read_error(result.err))
+		# closed error union to open error union
+		match result {
+			Ok(bytes) => Ok(bytes)
+			Err(Busy) => Err(Busy)
+			Err(ReadbackFailed) => Err(ReadbackFailed)
+			Err(RegionOutOfBounds) => Err(RegionOutOfBounds)
+			Err(TargetUnavailable) => Err(TargetUnavailable)
+			Err(Unavailable) => Err(Unavailable)
 		}
 	}
 
@@ -477,31 +484,6 @@ pixel_source = |source|
 		Screen => { target: Draw.RenderTexture.stub.for_host(), screen: Bool.True }
 		Target(target) => { target: target.for_host(), screen: Bool.False }
 	}
-
-## Decode the host's capture-error code for a pixel readback.
-##
-## The same `src/capture.zig` codes the exports use, plus the one that is only
-## a readback's business: a region outside its source. An unnamed code is drift
-## between this module and the host rather than a state an app can act on, so
-## it reports as the driver having refused the read.
-pixel_read_error : U8 -> Capture.PixelReadError
-pixel_read_error = |code|
-	match code {
-		10 => Busy
-		11 => Unavailable
-		12 => ReadbackFailed
-		13 => TargetUnavailable
-		14 => RegionOutOfBounds
-		_ => ReadbackFailed
-	}
-
-expect pixel_read_error(10) == Busy
-expect pixel_read_error(11) == Unavailable
-expect pixel_read_error(12) == ReadbackFailed
-expect pixel_read_error(13) == TargetUnavailable
-expect pixel_read_error(14) == RegionOutOfBounds
-expect pixel_read_error(0) == ReadbackFailed
-expect pixel_read_error(99) == ReadbackFailed
 
 expect capture_format_code(Png) == 0
 expect capture_format_code(Gif) == 1

--- a/platform/Capture.roc
+++ b/platform/Capture.roc
@@ -148,11 +148,15 @@ Capture := [].{
 	## still waiting for its frame is `AlreadyPending`.
 	screenshot! : Str => Try({}, ScreenshotError)
 	screenshot! = |path| {
-		err = Host.capture_screenshot!(path)
-		if err == 0 {
-			Ok({})
-		} else {
-			Err(screenshot_error(err))
+		# closed error union to open error union
+		match Host.capture_screenshot!(path) {
+			Ok({}) => Ok({})
+			Err(AlreadyPending) => Err(AlreadyPending)
+			Err(Busy) => Err(Busy)
+			Err(PathEscapesOutputDir) => Err(PathEscapesOutputDir)
+			Err(PathInvalid) => Err(PathInvalid)
+			Err(Unavailable) => Err(Unavailable)
+			Err(WriteFailed) => Err(WriteFailed)
 		}
 	}
 
@@ -202,11 +206,18 @@ Capture := [].{
 	## ```
 	screenshot_texture! : Draw.RenderTexture, Str => Try({}, TextureExportError)
 	screenshot_texture! = |target, path| {
-		err = Host.capture_screenshot_texture!({ target: target.for_host(), path })
-		if err == 0 {
-			Ok({})
-		} else {
-			Err(texture_export_error(err))
+		# closed error union to open error union
+		match Host.capture_screenshot_texture!({ target: target.for_host(), path }) {
+			Ok({}) => Ok({})
+			Err(BudgetExceeded) => Err(BudgetExceeded)
+			Err(Busy) => Err(Busy)
+			Err(OutOfMemory) => Err(OutOfMemory)
+			Err(PathEscapesOutputDir) => Err(PathEscapesOutputDir)
+			Err(PathInvalid) => Err(PathInvalid)
+			Err(ReadbackFailed) => Err(ReadbackFailed)
+			Err(TargetUnavailable) => Err(TargetUnavailable)
+			Err(Unavailable) => Err(Unavailable)
+			Err(WriteFailed) => Err(WriteFailed)
 		}
 	}
 
@@ -355,6 +366,8 @@ Capture := [].{
 	start! : Recording => {}
 	start! = |recording| {
 		ratio = capture_scale_ratio(recording.scale())
+		# The host latches the refusal for the next `Input` to report, so there
+		# is nothing to answer with here.
 		_refusal = Host.capture_start_recording!({
 			path: recording.path(),
 			format: capture_format_code(recording.format()),
@@ -414,64 +427,6 @@ expect failure_reason(8) == WriteFailed
 expect failure_reason(9) == EncodeFailed
 expect failure_reason(0) == Unknown
 expect failure_reason(200) == Unknown
-
-## Decode the host's capture-error code for a screenshot.
-##
-## These are `src/capture.zig`'s codes, the same ones a recording's
-## `FailureReason` names, so a path that escapes the output directory is still
-## reported as the sandbox refusing it rather than as a failed write.
-screenshot_error : U8 -> Capture.ScreenshotError
-screenshot_error = |code|
-	match code {
-		1 => PathInvalid
-		2 => PathEscapesOutputDir
-		3 => AlreadyPending
-		7 => WriteFailed
-		10 => Busy
-		11 => Unavailable
-		_ => WriteFailed
-	}
-
-expect screenshot_error(1) == PathInvalid
-expect screenshot_error(2) == PathEscapesOutputDir
-expect screenshot_error(3) == AlreadyPending
-expect screenshot_error(7) == WriteFailed
-expect screenshot_error(10) == Busy
-expect screenshot_error(11) == Unavailable
-expect screenshot_error(99) == WriteFailed
-
-## Decode the host's capture-error code for an offscreen export.
-##
-## The same `src/capture.zig` codes again, so a path refused by the sandbox
-## reads the same here as it does for a screenshot or a recording. An unnamed
-## code is drift between this module and the host rather than a state an app can
-## do anything about, so it reports as a failed write.
-texture_export_error : U8 -> Capture.TextureExportError
-texture_export_error = |code|
-	match code {
-		1 => PathInvalid
-		2 => PathEscapesOutputDir
-		6 => BudgetExceeded
-		7 => OutOfMemory
-		8 => WriteFailed
-		10 => Busy
-		11 => Unavailable
-		12 => ReadbackFailed
-		13 => TargetUnavailable
-		_ => WriteFailed
-	}
-
-expect texture_export_error(1) == PathInvalid
-expect texture_export_error(2) == PathEscapesOutputDir
-expect texture_export_error(6) == BudgetExceeded
-expect texture_export_error(7) == OutOfMemory
-expect texture_export_error(8) == WriteFailed
-expect texture_export_error(10) == Busy
-expect texture_export_error(11) == Unavailable
-expect texture_export_error(12) == ReadbackFailed
-expect texture_export_error(13) == TargetUnavailable
-expect texture_export_error(0) == WriteFailed
-expect texture_export_error(99) == WriteFailed
 
 ## Flatten a `Source` onto the pair the host ABI carries.
 ##

--- a/platform/Cmd.roc
+++ b/platform/Cmd.roc
@@ -262,13 +262,17 @@ Cmd := {
 			stderr_limit_bytes: cmd.stderr_limit_bytes,
 		})
 
-		output = { exit_code: result.exit_code, stdout: result.stdout, stderr: result.stderr }
-		if result.err == 0 {
-			Ok(output)
-		} else if result.err == run_err_timed_out {
-			Err(Timeout(output))
-		} else {
-			Err(run_error(result.err))
+		# closed error union to open error union
+		match result {
+			Ok(output) => Ok(output)
+			Err(Timeout(output)) => Err(Timeout(output))
+			Err(Busy) => Err(Busy)
+			Err(CommandNotFound) => Err(CommandNotFound)
+			Err(PermissionDenied) => Err(PermissionDenied)
+			Err(SpawnFailed) => Err(SpawnFailed)
+			Err(StderrLimitExceeded) => Err(StderrLimitExceeded)
+			Err(StdoutLimitExceeded) => Err(StdoutLimitExceeded)
+			Err(Unavailable) => Err(Unavailable)
 		}
 	}
 
@@ -294,50 +298,6 @@ Cmd := {
 			Err(err) => Err(err)
 		}
 }
-
-## The deadline expired and the host killed the child. Mirrored in
-## `src/cmd_effect.zig`.
-run_err_timed_out : U8
-run_err_timed_out = 5
-
-## The host would not start another child. Mirrored in `src/cmd_effect.zig`,
-## and numbered as `Files` numbers its own `Busy`, so a code never means two
-## things across this boundary.
-run_err_busy : U8
-run_err_busy = 3
-
-## Decode the host's run-error code.
-##
-## `Timeout` is absent because it carries a payload only `run!` holds;
-## `run!` names it before asking here. Anything unrecognized is `SpawnFailed`,
-## the code for a child that could not be started for a reason with no better
-## name.
-run_error : U8 -> Cmd.CmdErr
-run_error = |code|
-	if code == 1 {
-		CommandNotFound
-	} else if code == run_err_busy {
-		Busy
-	} else if code == 4 {
-		Unavailable
-	} else if code == 6 {
-		StdoutLimitExceeded
-	} else if code == 7 {
-		StderrLimitExceeded
-	} else if code == 8 {
-		PermissionDenied
-	} else {
-		SpawnFailed
-	}
-
-expect run_error(1) == CommandNotFound
-expect run_error(2) == SpawnFailed
-expect run_error(3) == Busy
-expect run_error(4) == Unavailable
-expect run_error(6) == StdoutLimitExceeded
-expect run_error(7) == StderrLimitExceeded
-expect run_error(8) == PermissionDenied
-expect run_error(99) == SpawnFailed
 
 expect Cmd.new("ls").program == "ls"
 expect Cmd.new("ls").args == []

--- a/platform/Draw.roc
+++ b/platform/Draw.roc
@@ -1177,15 +1177,16 @@ Draw := [].{
 	## Legal in `render!` only.
 	with_render_texture! : Frame, RenderTexture, (Frame => Try(result, [ScopeLimit, ScopeUnavailable, ..errors])) => Try(result, [ScopeLimit, ScopeUnavailable, ..errors])
 	with_render_texture! = |frame, RenderTexture.(target), callback| {
-		status = Host.draw_begin_render_texture!(target)
-		if status == scope_ok {
-			result = callback(frame)
-			Host.draw_end_render_texture!()
-			result
-		} else if status == scope_limit {
-			Err(ScopeLimit)
-		} else {
-			Err(ScopeUnavailable)
+		# closed error union to open error union. The scope is closed on every
+		# path the callback can take, error included.
+		match Host.draw_begin_render_texture!(target) {
+			Ok({}) => {
+				result = callback(frame)
+				Host.draw_end_render_texture!()
+				result
+			}
+			Err(ScopeLimit) => Err(ScopeLimit)
+			Err(ScopeUnavailable) => Err(ScopeUnavailable)
 		}
 	}
 
@@ -1195,15 +1196,16 @@ Draw := [].{
 	## Legal in `render!` only.
 	with_shader! : Frame, Shader, (Frame => Try(result, [ScopeLimit, ScopeUnavailable, ..errors])) => Try(result, [ScopeLimit, ScopeUnavailable, ..errors])
 	with_shader! = |frame, Shader.(shader), callback| {
-		status = Host.draw_begin_shader!(shader)
-		if status == scope_ok {
-			result = callback(frame)
-			Host.draw_end_shader!()
-			result
-		} else if status == scope_limit {
-			Err(ScopeLimit)
-		} else {
-			Err(ScopeUnavailable)
+		# closed error union to open error union. The scope is closed on every
+		# path the callback can take, error included.
+		match Host.draw_begin_shader!(shader) {
+			Ok({}) => {
+				result = callback(frame)
+				Host.draw_end_shader!()
+				result
+			}
+			Err(ScopeLimit) => Err(ScopeLimit)
+			Err(ScopeUnavailable) => Err(ScopeUnavailable)
 		}
 	}
 
@@ -1213,15 +1215,18 @@ Draw := [].{
 	## Legal in `render!` only.
 	with_blend_mode! : Frame, BlendMode, (Frame => Try(result, [ScopeLimit, ..errors])) => Try(result, [ScopeLimit, ..errors])
 	with_blend_mode! = |frame, mode, callback| {
-		status = Host.draw_begin_blend!(blend_mode_code(mode))
-		if status == scope_ok {
-			result = callback(frame)
-			Host.draw_end_blend!()
-			result
-		} else if status == scope_limit {
-			Err(ScopeLimit)
-		} else {
-			crash "blend scope host invariant failed"
+		# closed error union to open error union. The scope is closed on every
+		# path the callback can take, error included. `blend_mode_code` only
+		# ever produces a mode the backend accepts, so `ScopeUnavailable` here
+		# means the platform disagreed with itself.
+		match Host.draw_begin_blend!(blend_mode_code(mode)) {
+			Ok({}) => {
+				result = callback(frame)
+				Host.draw_end_blend!()
+				result
+			}
+			Err(ScopeLimit) => Err(ScopeLimit)
+			Err(ScopeUnavailable) => crash "blend scope host invariant failed"
 		}
 	}
 
@@ -1230,15 +1235,16 @@ Draw := [].{
 	## Legal in `render!` only.
 	with_camera! : Frame, CameraMode, (Frame => Try(result, [ScopeLimit, ..errors])) => Try(result, [ScopeLimit, ..errors])
 	with_camera! = |frame, camera, callback| {
-		status = Host.draw_begin_camera!(camera)
-		if status == scope_ok {
-			result = callback(frame)
-			Host.draw_end_camera!()
-			result
-		} else if status == scope_limit {
-			Err(ScopeLimit)
-		} else {
-			crash "camera scope host invariant failed"
+		# closed error union to open error union. The scope is closed on every
+		# path the callback can take, error included.
+		match Host.draw_begin_camera!(camera) {
+			Ok({}) => {
+				result = callback(frame)
+				Host.draw_end_camera!()
+				result
+			}
+			Err(ScopeLimit) => Err(ScopeLimit)
+			Err(ScopeUnavailable) => crash "camera scope host invariant failed"
 		}
 	}
 
@@ -1262,15 +1268,16 @@ Draw := [].{
 		# extern with Math.Rect's public ability-bearing alias.
 		scissor : Host.DrawScissor
 		scissor = { x: bounds.x, y: bounds.y, width: bounds.width, height: bounds.height }
-		status = Host.draw_begin_scissor!(scissor)
-		if status == scope_ok {
-			result = callback(frame)
-			Host.draw_end_scissor!()
-			result
-		} else if status == scope_limit {
-			Err(ScopeLimit)
-		} else {
-			crash "scissor scope host invariant failed"
+		# closed error union to open error union. The scope is closed on every
+		# path the callback can take, error included.
+		match Host.draw_begin_scissor!(scissor) {
+			Ok({}) => {
+				result = callback(frame)
+				Host.draw_end_scissor!()
+				result
+			}
+			Err(ScopeLimit) => Err(ScopeLimit)
+			Err(ScopeUnavailable) => crash "scissor scope host invariant failed"
 		}
 	}
 
@@ -1343,19 +1350,12 @@ font_format_code = |format|
 		Otf => 1
 	}
 
-scope_ok : U8
-scope_ok = 0
-
-scope_limit : U8
-scope_limit = 2
-
 uniform_host! : RrtShader.Shader, Str => Try(Host.ShaderUniform, [UniformNotFound, ..])
 uniform_host! = |shader, name| {
-	location = Host.shader_location!({ shader, name })
-	if location < 0 {
-		Err(UniformNotFound)
-	} else {
-		Ok({ shader, location })
+	# closed error union to open error union
+	match Host.shader_location!({ shader, name }) {
+		Ok(location) => Ok({ shader, location })
+		Err(UniformNotFound) => Err(UniformNotFound)
 	}
 }
 

--- a/platform/Files.roc
+++ b/platform/Files.roc
@@ -267,7 +267,7 @@ Files := [].{
 	## }
 	## ```
 	write_text! : Str, Str => Try({}, WriteError)
-	write_text! = |path, contents| write_result(Host.files_write_text!(path, contents))
+	write_text! = |path, contents| lifted(Host.files_write_text!(path, contents))
 
 	## Replace a file's contents with ordinary Roc bytes.
 	##
@@ -279,56 +279,21 @@ Files := [].{
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks
 	## the task; refused in `update!` and `render!`.
 	write_bytes! : Str, List(U8) => Try({}, WriteError)
-	write_bytes! = |path, bytes| write_result(Host.files_write_bytes!(path, bytes))
+	write_bytes! = |path, bytes| lifted(Host.files_write_bytes!(path, bytes))
 
 }
 
-## The host refused the write because the path is not the app's to write.
-## Mirrored in `src/host_native.zig`.
-write_err_permission_denied : U8
-write_err_permission_denied = 8
-
-## The filesystem has no room for the file. Mirrored in
-## `src/host_native.zig`.
-write_err_no_space : U8
-write_err_no_space = 9
-
-## Turn a write's error code into its terminal outcome.
-##
-## The codes a write shares with a read -- `NotFound`, `Unavailable`, and the
-## generic failure -- are numbered the same as the read table's, so one code
-## never means two things across the boundary. The two a read cannot produce
-## are numbered past it.
-write_result : U8 -> Try({}, Files.WriteError)
-write_result = |code|
-	if code == 0 {
-		Ok({})
-	} else {
-		Err(write_error(code))
+## Re-lift a write's closed error union onto the open one `Files` exposes.
+lifted : Try({}, Host.FilesWriteError) -> Try({}, Files.WriteError)
+lifted = |result|
+	match result {
+		Ok({}) => Ok({})
+		Err(NoSpace) => Err(NoSpace)
+		Err(NotFound) => Err(NotFound)
+		Err(PermissionDenied) => Err(PermissionDenied)
+		Err(Unavailable) => Err(Unavailable)
+		Err(WriteFailed) => Err(WriteFailed)
 	}
-
-write_error : U8 -> Files.WriteError
-write_error = |code|
-	if code == 1 {
-		NotFound
-	} else if code == 4 {
-		Unavailable
-	} else if code == write_err_permission_denied {
-		PermissionDenied
-	} else if code == write_err_no_space {
-		NoSpace
-	} else {
-		WriteFailed
-	}
-
-expect write_result(0) == Ok({})
-expect write_result(1) == Err(NotFound)
-expect write_error(1) == NotFound
-expect write_error(2) == WriteFailed
-expect write_error(4) == Unavailable
-expect write_error(8) == PermissionDenied
-expect write_error(9) == NoSpace
-expect write_error(99) == WriteFailed
 
 ## Decode a listing's bytes into entries.
 ##

--- a/platform/Files.roc
+++ b/platform/Files.roc
@@ -103,14 +103,17 @@ Files := [].{
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks
 	## the task; refused in `update!` and `render!`.
 	read_text! : Str => Try(Str, ReadTextError)
-	read_text! = |path| {
-		result = Host.files_read_text!(path)
-		if result.err == 0 {
-			Ok(result.contents)
-		} else {
-			Err(read_text_error(result.err))
+	read_text! = |path|
+		match Host.files_read_text!(path) {
+			# closed error union to open error union
+			Ok(contents) => Ok(contents)
+			Err(Busy) => Err(Busy)
+			Err(NotFound) => Err(NotFound)
+			Err(NotUtf8) => Err(NotUtf8)
+			Err(ReadFailed) => Err(ReadFailed)
+			Err(TooLarge) => Err(TooLarge)
+			Err(Unavailable) => Err(Unavailable)
 		}
-	}
 
 	## Read a bounded file as ordinary Roc bytes.
 	##
@@ -128,14 +131,16 @@ Files := [].{
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks
 	## the task; refused in `update!` and `render!`.
 	read_bytes! : Str => Try(List(U8), ReadBytesError)
-	read_bytes! = |path| {
-		result = Host.files_read_bytes!(path)
-		if result.err == 0 {
-			Ok(result.bytes)
-		} else {
-			Err(read_bytes_error(result.err))
+	read_bytes! = |path|
+		match Host.files_read_bytes!(path) {
+			# closed error union to open error union
+			Ok(bytes) => Ok(bytes)
+			Err(Busy) => Err(Busy)
+			Err(NotFound) => Err(NotFound)
+			Err(ReadFailed) => Err(ReadFailed)
+			Err(TooLarge) => Err(TooLarge)
+			Err(Unavailable) => Err(Unavailable)
 		}
-	}
 
 	## List one directory without recursively walking its children.
 	##
@@ -152,14 +157,17 @@ Files := [].{
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks
 	## the task; refused in `update!` and `render!`.
 	list! : Str => Try(List(Entry), ListError)
-	list! = |path| {
-		result = Host.files_list!(path)
-		if result.err == 0 {
-			Ok(decode_listing(result.bytes))
-		} else {
-			Err(list_error(result.err))
+	list! = |path|
+		match Host.files_list!(path) {
+			# closed error union to open error union
+			Ok(bytes) => Ok(decode_listing(bytes))
+			Err(Busy) => Err(Busy)
+			Err(NotADirectory) => Err(NotADirectory)
+			Err(NotFound) => Err(NotFound)
+			Err(ReadFailed) => Err(ReadFailed)
+			Err(TooLarge) => Err(TooLarge)
+			Err(Unavailable) => Err(Unavailable)
 		}
-	}
 
 	## What one path is, how big it is, and when it last changed.
 	##
@@ -208,21 +216,23 @@ Files := [].{
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks
 	## the task; refused in `update!` and `render!`.
 	metadata! : Str => Try(Metadata, MetadataError)
-	metadata! = |path| {
-		result = Host.files_metadata!(path)
-		if result.err == 0 {
+	metadata! = |path|
+		match Host.files_metadata!(path) {
+			# closed error union to open error union
+			Ok(stat) =>
 			# The host normalizes the instant before it crosses, so the only
 			# way this fails is a host that is wrong about its own contract.
 			# Saying so is more use than reporting it as a filesystem error an
 			# app could act on.
-			match Time.Timestamp.from_parts({ seconds: result.modified_seconds, nanosecond: result.modified_nanosecond }) {
-				Ok(modified) => Ok({ kind: entry_kind(result.kind), size_bytes: result.size_bytes, modified: modified })
-				Err(InvalidNanosecond) => crash ("roc-ray: Files.metadata! received a modification time the host had not normalized")
-			}
-		} else {
-			Err(metadata_error(result.err))
+				match Time.Timestamp.from_parts({ seconds: stat.modified_seconds, nanosecond: stat.modified_nanosecond }) {
+					Ok(modified) => Ok({ kind: entry_kind(stat.kind), size_bytes: stat.size_bytes, modified: modified })
+					Err(InvalidNanosecond) => crash ("roc-ray: Files.metadata! received a modification time the host had not normalized")
+				}
+			Err(NotFound) => Err(NotFound)
+			Err(PermissionDenied) => Err(PermissionDenied)
+			Err(ReadFailed) => Err(ReadFailed)
+			Err(Unavailable) => Err(Unavailable)
 		}
-	}
 
 	## Replace a file's contents with a `Str`, creating it if it is not there.
 	##
@@ -272,92 +282,6 @@ Files := [].{
 	write_bytes! = |path, bytes| write_result(Host.files_write_bytes!(path, bytes))
 
 }
-
-## Error code for work the host would not start. Mirrored in
-## `src/host_native.zig`.
-read_err_busy : U8
-read_err_busy = 3
-
-## Error code for content the host declined to copy into a `Str`.
-## Mirrored in `src/host_native.zig`.
-read_err_too_large : U8
-read_err_too_large = 5
-
-## Error code for bytes that cannot become a `Str`. Mirrored in
-## `src/host_native.zig`.
-read_err_not_utf8 : U8
-read_err_not_utf8 = 6
-
-## The host refused to list the path because it is not a directory. Mirrored in
-## `src/host_native.zig`.
-read_err_not_a_directory : U8
-read_err_not_a_directory = 7
-
-## Decode the host's read-error code for a byte-list read. Mirrored in
-## `src/host_native.zig`.
-read_bytes_error : U8 -> Files.ReadBytesError
-read_bytes_error = |code|
-	if code == 1 {
-		NotFound
-	} else if code == read_err_busy {
-		Busy
-	} else if code == 4 {
-		Unavailable
-	} else if code == read_err_too_large {
-		TooLarge
-	} else {
-		ReadFailed
-	}
-
-expect read_bytes_error(1) == NotFound
-expect read_bytes_error(2) == ReadFailed
-expect read_bytes_error(3) == Busy
-expect read_bytes_error(4) == Unavailable
-expect read_bytes_error(5) == TooLarge
-expect read_bytes_error(99) == ReadFailed
-
-## Decode the host's read-error code for a string-delivered read.
-##
-## The same codes plus one, rather than a second table: the two reads fail for
-## the same reasons and only differ in what they were asked to produce.
-read_text_error : U8 -> Files.ReadTextError
-read_text_error = |code|
-	if code == read_err_not_utf8 {
-		NotUtf8
-	} else {
-		match read_bytes_error(code) {
-			NotFound => NotFound
-			Busy => Busy
-			Unavailable => Unavailable
-			TooLarge => TooLarge
-			ReadFailed => ReadFailed
-		}
-	}
-
-expect read_text_error(6) == NotUtf8
-expect read_text_error(1) == NotFound
-expect read_text_error(5) == TooLarge
-
-## Decode the host's listing-error code. Mirrored in `src/host_native.zig`.
-list_error : U8 -> Files.ListError
-list_error = |code|
-	if code == 1 {
-		NotFound
-	} else if code == read_err_busy {
-		Busy
-	} else if code == 4 {
-		Unavailable
-	} else if code == read_err_too_large {
-		TooLarge
-	} else if code == read_err_not_a_directory {
-		NotADirectory
-	} else {
-		ReadFailed
-	}
-
-expect list_error(1) == NotFound
-expect list_error(7) == NotADirectory
-expect list_error(2) == ReadFailed
 
 ## The host refused the write because the path is not the app's to write.
 ## Mirrored in `src/host_native.zig`.
@@ -490,26 +414,3 @@ expect decode_listing([2, 's', 'r', 'c', 0, 1, 'a', '.', 't', 0]) == [
 ## A kind byte with no terminator after it ends the listing rather than being
 ## guessed at, so a truncated buffer still yields the entries that were whole.
 expect decode_listing([1, 'a', 0, 2, 'b']) == [{ name: "a", kind: File }]
-
-## Decode the host's metadata-error code. Mirrored in `src/host_native.zig`.
-##
-## A stat can be refused for a reason a read cannot: a directory on the way to
-## the path may be one this process may not look inside, which is
-## `PermissionDenied` rather than the file being absent.
-metadata_error : U8 -> Files.MetadataError
-metadata_error = |code|
-	if code == 1 {
-		NotFound
-	} else if code == 4 {
-		Unavailable
-	} else if code == write_err_permission_denied {
-		PermissionDenied
-	} else {
-		ReadFailed
-	}
-
-expect metadata_error(1) == NotFound
-expect metadata_error(2) == ReadFailed
-expect metadata_error(4) == Unavailable
-expect metadata_error(8) == PermissionDenied
-expect metadata_error(99) == ReadFailed

--- a/platform/Host.roc
+++ b/platform/Host.roc
@@ -127,13 +127,23 @@ Host := [].{
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
 	texture_generate_checked! : TextureGenerateChecked => Try(Texture, TextureGenerateError)
 
+	## Failures while replacing a texture's pixels.
+	##
+	## `NotMutable` is a handle that is not an app-owned texture at all -- a
+	## released one, a stub, or a render target, which the host writes only
+	## through `render!`.
+	TextureUpdateError : [NotMutable, PixelCountMismatch]
+
+	## Failures while replacing pixels inside a texture rectangle.
+	TextureUpdateRegionError : [NotMutable, PixelCountMismatch, RegionOutOfBounds]
+
 	## Replace all texture pixels.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	texture_update! : TextureUpdate => U8
+	texture_update! : TextureUpdate => Try({}, TextureUpdateError)
 
 	## Replace pixels within a texture rectangle.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	texture_update_region! : TextureUpdateRegion => U8
+	texture_update_region! : TextureUpdateRegion => Try({}, TextureUpdateRegionError)
 
 	## Set the texture scaling filter.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
@@ -244,9 +254,12 @@ Host := [].{
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
 	shader_load_store! : ShaderLoadStore => Try(Shader, ShaderLoadStoreError)
 
+	## Failures while looking up a shader uniform.
+	ShaderLocationError : [UniformNotFound]
+
 	## Get a shader uniform location.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	shader_location! : ShaderLocation => I32
+	shader_location! : ShaderLocation => Try(I32, ShaderLocationError)
 
 	## Set a floating-point shader uniform.
 	## Legal in `render!` only.
@@ -522,13 +535,19 @@ Host := [].{
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
 	files_list! : Str => Try(List(U8), FilesListError)
 
-	## Replace a file with UTF-8; return `0` or a `Files` write-error code.
-	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	files_write_text! : Str, Str => U8
+	## Failures while replacing a whole file.
+	##
+	## A write fails for reasons a read cannot, so it has a union of its own
+	## rather than sharing one with `files_read_bytes!`.
+	FilesWriteError : [NoSpace, NotFound, PermissionDenied, Unavailable, WriteFailed]
 
-	## Replace a file with bytes; use the same result codes as text writes.
+	## Replace a file with UTF-8.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	files_write_bytes! : Str, List(U8) => U8
+	files_write_text! : Str, Str => Try({}, FilesWriteError)
+
+	## Replace a file with bytes; the same failures as a text write.
+	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
+	files_write_bytes! : Str, List(U8) => Try({}, FilesWriteError)
 
 	## Http interface
 	## One ordered HTTP header.
@@ -623,19 +642,25 @@ Host := [].{
 	cmd_run! : CmdRunArgs => Try(CmdOutput, CmdRunError)
 
 	## Stdio interface
-	## Queue UTF-8 atomically; return `0` or a stdio result code.
+	## Failures while queueing one atomic write.
+	##
+	## `TooLarge` is a payload past the whole ring and can never be queued;
+	## `BufferFull` is one that does not fit right now.
+	StdioWriteError : [BufferFull, TooLarge, Unavailable]
+
+	## Queue UTF-8 atomically.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	stdio_write_text! : U8, Str => U8
+	stdio_write_text! : U8, Str => Try({}, StdioWriteError)
 
 	## Queue UTF-8 and a newline as one reservation.
 	##
 	## Host-side appending avoids a copy and prevents interleaved writes.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	stdio_write_line! : U8, Str => U8
+	stdio_write_line! : U8, Str => Try({}, StdioWriteError)
 
-	## Queue bytes atomically; use the text-write result codes.
+	## Queue bytes atomically; the same failures as a text write.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	stdio_write_bytes! : U8, List(U8) => U8
+	stdio_write_bytes! : U8, List(U8) => Try({}, StdioWriteError)
 
 	## Udp interface
 	## Bind a dotted-quad IPv4 literal; port `0` requests an assigned port.
@@ -690,9 +715,15 @@ Host := [].{
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
 	udp_bind! : UdpBindArgs => Try(UdpBound, UdpBindError)
 
-	## Send one datagram; return `0` or a `Udp` error code.
+	## Failures while handing one datagram to the kernel.
+	## `NoRoute` is what `Udp` exposes as `Unreachable`; it is spelled
+	## differently here because `roc glue` lowers a tag to a Zig enum member
+	## and `unreachable` is a Zig keyword.
+	UdpSendError : [InvalidAddress, NoRoute, PermissionDenied, SendFailed, TooLarge, Unavailable, WouldBlock]
+
+	## Send one datagram.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	udp_send! : UdpSendArgs => U8
+	udp_send! : UdpSendArgs => Try({}, UdpSendError)
 
 	## Wait for at least one datagram, then drain what is already buffered.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
@@ -1056,9 +1087,17 @@ Host := [].{
 	## Arbitrary textured-quad parameters.
 	DrawTextureQuad : { texture : Texture, source : Math.Rect, top_left : Math.Vec2, bottom_left : Math.Vec2, bottom_right : Math.Vec2, top_right : Math.Vec2, q_top_left : F32, q_bottom_left : F32, q_bottom_right : F32, q_top_right : F32, tint : Color.Rgba }
 
+	## Failures while opening one drawing scope.
+	##
+	## `ScopeLimit` is the scope stack already at its bound. `ScopeUnavailable`
+	## is a handle that no longer resolves, or a flattened argument outside
+	## what the backend accepts; the scopes that take neither cannot produce
+	## it, and say so where they are used.
+	DrawScopeError : [ScopeLimit, ScopeUnavailable]
+
 	## Begin 2D drawing with a camera.
 	## Legal in `render!` only.
-	draw_begin_camera! : Camera.Camera2D => U8
+	draw_begin_camera! : Camera.Camera2D => Try({}, DrawScopeError)
 
 	## End 2D camera drawing.
 	## Legal in `render!` only.
@@ -1066,7 +1105,7 @@ Host := [].{
 
 	## Begin the flattened blend mode.
 	## Legal in `render!` only.
-	draw_begin_blend! : U8 => U8
+	draw_begin_blend! : U8 => Try({}, DrawScopeError)
 
 	## Restore alpha blending.
 	## Legal in `render!` only.
@@ -1074,7 +1113,7 @@ Host := [].{
 
 	## Begin drawing to a render target.
 	## Legal in `render!` only.
-	draw_begin_render_texture! : TextureRenderTarget => U8
+	draw_begin_render_texture! : TextureRenderTarget => Try({}, DrawScopeError)
 
 	## End render-target drawing.
 	## Legal in `render!` only.
@@ -1082,7 +1121,7 @@ Host := [].{
 
 	## Begin clipping to a screen rectangle.
 	## Legal in `render!` only.
-	draw_begin_scissor! : DrawScissor => U8
+	draw_begin_scissor! : DrawScissor => Try({}, DrawScopeError)
 
 	## End scissor clipping.
 	## Legal in `render!` only.
@@ -1090,7 +1129,7 @@ Host := [].{
 
 	## Begin custom-shader drawing.
 	## Legal in `render!` only.
-	draw_begin_shader! : Shader => U8
+	draw_begin_shader! : Shader => Try({}, DrawScopeError)
 
 	## Restore the default shader.
 	## Legal in `render!` only.
@@ -1237,17 +1276,23 @@ Host := [].{
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
 	capture_set_virtual_text! : List(U32) => {}
 
+	## Failures while arming a recording.
+	CaptureStartError : [AlreadyRecording, Busy, PathEscapesOutputDir, PathInvalid, Unavailable, UnsupportedFormat, WriteFailed]
+
 	## Arm recording and latch its result for the next `Input`.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	capture_start_recording! : CaptureStartRecording => U8
+	capture_start_recording! : CaptureStartRecording => Try({}, CaptureStartError)
 
 	## Finalize the running recording and write its file.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
 	capture_stop_recording! : () => Try(CaptureStopped, CaptureStopError)
 
+	## Failures while writing one framebuffer as PNG.
+	CaptureScreenshotError : [AlreadyPending, Busy, PathEscapesOutputDir, PathInvalid, Unavailable, WriteFailed]
+
 	## Write the next framebuffer as PNG, parking until complete.
 	## Legal only in a task, where it parks the task; refused in `init!`, `update!`, and `render!`.
-	capture_screenshot! : Str => U8
+	capture_screenshot! : Str => Try({}, CaptureScreenshotError)
 
 	## A render target and output path.
 	CaptureTextureShot : {
@@ -1255,9 +1300,12 @@ Host := [].{
 		path : Str,
 	}
 
+	## Failures while exporting one render target as PNG.
+	CaptureTextureShotError : [BudgetExceeded, Busy, OutOfMemory, PathEscapesOutputDir, PathInvalid, ReadbackFailed, TargetUnavailable, Unavailable, WriteFailed]
+
 	## Read back a target, then park while encoding and writing its PNG.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	capture_screenshot_texture! : CaptureTextureShot => U8
+	capture_screenshot_texture! : CaptureTextureShot => Try({}, CaptureTextureShotError)
 
 	## Flattened screen-or-target source.
 	##

--- a/platform/Host.roc
+++ b/platform/Host.roc
@@ -47,9 +47,9 @@
 ## > `Udp`: bound sockets and bounded datagram send/receive batches.
 ## > `Sqlite`: connection and statement handles plus flattened query results.
 ##
-## Opaque `Handle(resource)` values erase to `Box(U64)` resource
-## tokens resolved and lifetime-checked by the host, never exposing native
-## addresses.
+## Resource values from the `roc-ray-types` package carry an opaque
+## `Handle(resource)` that erases to a `Box(U64)` token resolved and
+## lifetime-checked by the host, never exposing native addresses.
 ## Native pointers, backend objects, public unions, and application policy do
 ## not belong here.
 import rrt.Camera
@@ -59,6 +59,13 @@ import rrt.Math
 import rrt.Handle
 import rrt.Shader
 import rrt.Texture
+import rrt.Store
+import rrt.TextPrepared
+import rrt.AudioSound
+import rrt.AudioMusic
+import rrt.UdpSocket
+import rrt.SqliteDb
+import rrt.SqliteStmt
 
 Host := [].{
 
@@ -152,13 +159,8 @@ Host := [].{
 	## Text resource interface
 	FontResource : [FontResource]
 
-	PreparedTextResource := {}
-
-	## Opaque ARC-owned prepared text.
-	TextPrepared : Handle(PreparedTextResource)
-
 	## Text-preparation parameters.
-	TextPrepare : { text : Str, size : F32, spacing : F32, font : Handle(FontResource) }
+	TextPrepare : { text : Str, size : F32, spacing : F32, font : Font.FontHandle }
 
 	## Failures while preparing text.
 	TextPrepareError : [ResourceLimit, InvalidResource]
@@ -271,10 +273,6 @@ Host := [].{
 	shader_set_texture! : ShaderTexture => {}
 
 	## Store resource interface
-	StoreResource := {}
-
-	## Opaque ARC-owned directory store; copies keep it open.
-	Store : Handle(StoreResource)
 
 	## Parameters for opening a confined asset store.
 	StoreOpen : {
@@ -364,14 +362,6 @@ Host := [].{
 	}
 
 	## Audio interface
-	SoundResource := {}
-	MusicResource := {}
-
-	## Opaque ARC-owned sound.
-	AudioSound : Handle(SoundResource)
-
-	## Opaque ARC-owned music stream.
-	AudioMusic : Handle(MusicResource)
 
 	## Failures while generating a sound.
 	AudioGenerateSoundError : [ResourceLimit, SoundGenerationFailed]
@@ -496,46 +486,41 @@ Host := [].{
 	audio_set_master_volume! : F32 => {}
 
 	## Files interface
-	## Text contents when `err` is `0`; otherwise empty.
-	FilesTextResult : {
-		err : U8,
-		contents : Str,
-	}
+	## Failures while reading a file as validated UTF-8.
+	FilesReadTextError : [Busy, NotFound, NotUtf8, ReadFailed, TooLarge, Unavailable]
 
-	## Read bytes or an encoded directory listing; empty on error.
-	##
-	## The host allocation transfers into Roc list ARC without copying.
-	FilesBytesResult : {
-		err : U8,
-		bytes : List(U8),
-	}
+	## Failures while reading a file as bytes.
+	FilesReadBytesError : [Busy, NotFound, ReadFailed, TooLarge, Unavailable]
 
-	## One `stat`; all payload fields are zero on error.
-	##
-	## Modification time uses the normalized `Time.Timestamp` parts.
-	FilesMetadataResult : {
-		err : U8,
+	## Failures while listing one directory.
+	FilesListError : [Busy, NotADirectory, NotFound, ReadFailed, TooLarge, Unavailable]
+
+	## One `stat`. Modification time uses the normalized `Time.Timestamp` parts.
+	FilesMetadata : {
 		kind : U8,
 		size_bytes : U64,
 		modified_seconds : I64,
 		modified_nanosecond : U32,
 	}
 
+	## Failures while stating one path.
+	FilesMetadataError : [NotFound, PermissionDenied, ReadFailed, Unavailable]
+
 	## Read bounded, validated UTF-8.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	files_read_text! : Str => FilesTextResult
+	files_read_text! : Str => Try(Str, FilesReadTextError)
 
 	## Stat one path, following symbolic links.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	files_metadata! : Str => FilesMetadataResult
+	files_metadata! : Str => Try(FilesMetadata, FilesMetadataError)
 
 	## Read bounded bytes without copying the payload.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	files_read_bytes! : Str => FilesBytesResult
+	files_read_bytes! : Str => Try(List(U8), FilesReadBytesError)
 
 	## List one directory into the encoded form `Files` decodes.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	files_list! : Str => FilesBytesResult
+	files_list! : Str => Try(List(U8), FilesListError)
 
 	## Replace a file with UTF-8; return `0` or a `Files` write-error code.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
@@ -569,18 +554,22 @@ Host := [].{
 		max_response_bytes : U64,
 	}
 
-	## A response when `err == 0`; otherwise only `err_message` is populated.
+	## A complete response. A non-2xx `status` is a reply, not a failure.
 	HttpResponseFromHost : {
-		err : U8,
-		err_message : Str,
 		status : U16,
 		headers : List(HttpHeaderPair),
 		body : List(U8),
 	}
 
+	## Failures while running one HTTP exchange.
+	##
+	## `Other` carries the host's own description, so a host that learns to
+	## distinguish a new failure still reports something an app can print.
+	HttpSendError : [MalformedResponse, NetworkError, Other(Str), Timeout]
+
 	## Send one request and wait for the whole response.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	http_send! : HttpRequestToHost => HttpResponseFromHost
+	http_send! : HttpRequestToHost => Try(HttpResponseFromHost, HttpSendError)
 
 	## Cmd interface
 	## One child-process environment variable.
@@ -606,20 +595,32 @@ Host := [].{
 		stderr_limit_bytes : U64,
 	}
 
-	## A finished child or launch failure.
-	##
-	## `err == 0` includes nonzero child exits. A timeout preserves captured
-	## output and sets `exit_code` to `-1`; other errors leave payloads empty.
-	CmdRunResult : {
-		err : U8,
+	## A finished child. A nonzero `exit_code` is a finished child, not a
+	## failure to run one.
+	CmdOutput : {
 		exit_code : I64,
 		stdout : List(U8),
 		stderr : List(U8),
 	}
 
+	## Failures while starting or waiting on a child process.
+	##
+	## `Timeout` carries the output captured before the deadline expired, which
+	## is why it is the one variant with a payload.
+	CmdRunError : [
+		Busy,
+		CommandNotFound,
+		PermissionDenied,
+		SpawnFailed,
+		StderrLimitExceeded,
+		StdoutLimitExceeded,
+		Timeout(CmdOutput),
+		Unavailable,
+	]
+
 	## Start one child process and wait for it to finish.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	cmd_run! : CmdRunArgs => CmdRunResult
+	cmd_run! : CmdRunArgs => Try(CmdOutput, CmdRunError)
 
 	## Stdio interface
 	## Queue UTF-8 atomically; return `0` or a stdio result code.
@@ -637,28 +638,25 @@ Host := [].{
 	stdio_write_bytes! : U8, List(U8) => U8
 
 	## Udp interface
-	UdpSocketResource := {}
-
-	## Opaque ARC-owned bound socket.
-	UdpHandle : Handle(UdpSocketResource)
-
 	## Bind a dotted-quad IPv4 literal; port `0` requests an assigned port.
 	UdpBindArgs : {
 		ip : Str,
 		port : U16,
 	}
 
-	## A bound socket and its assigned address, or an error.
-	UdpBindResult : {
-		handle : UdpHandle,
+	## A bound socket and the address the kernel assigned it.
+	UdpBound : {
+		handle : UdpSocket,
 		ip : U32,
 		port : U16,
-		err : U8,
 	}
+
+	## Failures while opening and binding a socket.
+	UdpBindError : [AddressInUse, AddressUnavailable, InvalidAddress, PermissionDenied, ResourceLimit, Unavailable]
 
 	## One outgoing datagram. `ip` is a dotted-quad IPv4 literal.
 	UdpSendArgs : {
-		socket : UdpHandle,
+		socket : UdpSocket,
 		ip : Str,
 		port : U16,
 		bytes : List(U8),
@@ -666,7 +664,7 @@ Host := [].{
 
 	## Receive request; zero timeout means none, and the host caps the batch.
 	UdpReceiveArgs : {
-		socket : UdpHandle,
+		socket : UdpSocket,
 		timeout_ms : U64,
 		max_datagrams : U32,
 	}
@@ -679,16 +677,18 @@ Host := [].{
 		len : U64,
 	}
 
-	## A received batch when `err == 0`; otherwise both lists are empty.
-	UdpReceiveResult : {
-		err : U8,
+	## One received batch: the datagram ranges and the payload they index into.
+	UdpBatch : {
 		slices : List(UdpDatagramSlice),
 		payload : List(U8),
 	}
 
+	## Failures while waiting for datagrams.
+	UdpReceiveError : [AlreadyReceiving, ReceiveFailed, Timeout, Unavailable]
+
 	## Open and bind one IPv4 UDP socket.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	udp_bind! : UdpBindArgs => UdpBindResult
+	udp_bind! : UdpBindArgs => Try(UdpBound, UdpBindError)
 
 	## Send one datagram; return `0` or a `Udp` error code.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
@@ -696,7 +696,7 @@ Host := [].{
 
 	## Wait for at least one datagram, then drain what is already buffered.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	udp_receive! : UdpReceiveArgs => UdpReceiveResult
+	udp_receive! : UdpReceiveArgs => Try(UdpBatch, UdpReceiveError)
 
 	## App interface
 	## Zero-sized startup authority minted by the adapter.
@@ -735,15 +735,12 @@ Host := [].{
 	keys_set_exit_key! : I32 => {}
 
 	## Window interface
-	## Clipboard text when `err == 0`; otherwise empty.
-	WindowClipboardResult : {
-		err : U8,
-		contents : Str,
-	}
+	## Failures while reading the system clipboard as text.
+	WindowClipboardError : [Busy, TooLarge, Unavailable]
 
 	## Get clipboard text.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	window_read_clipboard! : () => WindowClipboardResult
+	window_read_clipboard! : () => Try(Str, WindowClipboardError)
 
 	## Replace the clipboard with UTF-8 text.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
@@ -904,14 +901,6 @@ Host := [].{
 	tilemap_draw! : TilemapRenderRequest => {}
 
 	## Sqlite interface
-	SqliteDbResource := {}
-	SqliteStmtResource := {}
-
-	## Opaque ARC-owned database connection.
-	SqliteDb : Handle(SqliteDbResource)
-
-	## Opaque statement that retains its connection.
-	SqliteStmt : Handle(SqliteStmtResource)
 
 	## One row-major query cell.
 	##
@@ -935,14 +924,23 @@ Host := [].{
 		blob : List(U8),
 	}
 
-	## A connection when `err == 0`; otherwise an invalid handle.
-	SqliteOpenResult : { err : I64, message : Str, db : SqliteDb }
+	## One failure SQLite itself reported: its own result code and message.
+	##
+	## The code stays numeric on the wire because it is SQLite's, not this
+	## host's; `Sqlite` names it in the app's vocabulary.
+	SqliteFailure : { code : I64, message : Str }
 
-	## A prepared statement or its failure.
-	SqlitePrepareResult : { err : I64, message : Str, stmt : SqliteStmt }
+	## Failures while opening a connection.
+	SqliteOpenError : [SqliteErr(SqliteFailure), TooManyConnections]
 
-	## An outcome without a payload.
-	SqliteStatusResult : { err : I64, message : Str }
+	## Failures with nothing to report but the failure itself.
+	SqliteStatusError : [SqliteErr(SqliteFailure)]
+
+	## Failures while compiling one statement.
+	SqlitePrepareError : [MultipleStatements, SqliteErr(SqliteFailure), TooManyStatements]
+
+	## Failures while running one statement to completion.
+	SqliteQueryError : [MultipleStatements, ResultTooLarge, SqliteErr(SqliteFailure)]
 
 	## One completed query.
 	##
@@ -950,9 +948,7 @@ Host := [].{
 	## is their shared byte buffer.
 	##
 	## `changes` and `last_insert_rowid` describe this statement.
-	SqliteQueryResult : {
-		err : I64,
-		message : Str,
+	SqliteRows : {
 		names : List(U8),
 		ncols : U64,
 		row_count : U64,
@@ -965,27 +961,27 @@ Host := [].{
 	## Open or create a database. `mode` is `0` read/write/create, `1`
 	## read/write, `2` read-only.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	sqlite_open! : Str, U8, U64, U64 => SqliteOpenResult
+	sqlite_open! : Str, U8, U64, U64 => Try(SqliteDb, SqliteOpenError)
 
 	## Close early; final handle release remains the fallback.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	sqlite_close! : SqliteDb => SqliteStatusResult
+	sqlite_close! : SqliteDb => Try({}, SqliteStatusError)
 
 	## Compile one statement for reuse.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	sqlite_prepare! : SqliteDb, Str => SqlitePrepareResult
+	sqlite_prepare! : SqliteDb, Str => Try(SqliteStmt, SqlitePrepareError)
 
 	## Bind and run a prepared statement to completion, then reset it.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	sqlite_run_stmt! : SqliteStmt, List(SqliteBindingWire) => SqliteQueryResult
+	sqlite_run_stmt! : SqliteStmt, List(SqliteBindingWire) => Try(SqliteRows, SqliteQueryError)
 
 	## Prepare, bind, run, and finalize without retaining a statement.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	sqlite_run_once! : SqliteDb, Str, List(SqliteBindingWire) => SqliteQueryResult
+	sqlite_run_once! : SqliteDb, Str, List(SqliteBindingWire) => Try(SqliteRows, SqliteQueryError)
 
 	## Run a script without bindings or returned rows.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	sqlite_exec_script! : SqliteDb, Str => SqliteStatusResult
+	sqlite_exec_script! : SqliteDb, Str => Try({}, SqliteStatusError)
 
 	## Draw interface
 	## Zero-sized frame authority minted by the adapter.
@@ -1040,7 +1036,7 @@ Host := [].{
 	DrawFps : { pos : Math.Vec2, size : F32, color : Color.Rgba }
 
 	## Text-drawing parameters.
-	DrawText : { pos : Math.Vec2, text : Str, size : F32, spacing : F32, color : Color.Rgba, font : Handle(FontResource) }
+	DrawText : { pos : Math.Vec2, text : Str, size : F32, spacing : F32, color : Color.Rgba, font : Font.FontHandle }
 
 	## Prepared-text drawing parameters.
 	DrawPreparedTextDraw : { prepared : TextPrepared, pos : Math.Vec2, color : Color.Rgba }
@@ -1203,12 +1199,14 @@ Host := [].{
 		quality : U8,
 	}
 
-	## Finalized recording when `err == 0`.
-	CaptureStopResult : {
-		err : U8,
+	## A finalized recording: the frames it holds and the file's size.
+	CaptureStopped : {
 		frames : U64,
 		bytes : U64,
 	}
+
+	## Failures while finalizing a running recording.
+	CaptureStopError : [BudgetExceeded, Busy, NotRecording, ReadbackFailed, TargetUnavailable, Unavailable]
 
 	## Scripted pointer state; inactive returns control to hardware.
 	CaptureVirtualMouse : {
@@ -1245,7 +1243,7 @@ Host := [].{
 
 	## Finalize the running recording and write its file.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	capture_stop_recording! : () => CaptureStopResult
+	capture_stop_recording! : () => Try(CaptureStopped, CaptureStopError)
 
 	## Write the next framebuffer as PNG, parking until complete.
 	## Legal only in a task, where it parks the task; refused in `init!`, `update!`, and `render!`.
@@ -1269,14 +1267,16 @@ Host := [].{
 		screen : Bool,
 	}
 
-	## One RGBA pixel when `err == 0`; otherwise zeroed channels.
-	CapturePixelResult : {
-		err : U8,
+	## One RGBA pixel.
+	CapturePixel : {
 		r : U8,
 		g : U8,
 		b : U8,
 		a : U8,
 	}
+
+	## Failures while reading pixels back from a source.
+	CapturePixelError : [Busy, ReadbackFailed, RegionOutOfBounds, TargetUnavailable, Unavailable]
 
 	## A source-relative pixel coordinate.
 	CapturePixelProbe : {
@@ -1287,7 +1287,7 @@ Host := [].{
 
 	## Read one pixel synchronously.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	capture_pixel_at! : CapturePixelProbe => CapturePixelResult
+	capture_pixel_at! : CapturePixelProbe => Try(CapturePixel, CapturePixelError)
 
 	## A source-relative pixel rectangle.
 	CaptureRegionProbe : {
@@ -1298,14 +1298,8 @@ Host := [].{
 		height : I32,
 	}
 
-	## Packed RGBA8 bytes transferred into Roc list ARC; empty on error.
-	CaptureRegionResult : {
-		err : U8,
-		bytes : List(U8),
-	}
-
 	## Read a rectangle of a source as row-major, top-down RGBA8 bytes.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	capture_read_region! : CaptureRegionProbe => CaptureRegionResult
+	capture_read_region! : CaptureRegionProbe => Try(List(U8), CapturePixelError)
 
 }

--- a/platform/Http.roc
+++ b/platform/Http.roc
@@ -161,11 +161,13 @@ Http := [].{
 		check_method(Request.method(request)) ? HttpErr
 		url = Url.parse(Request.uri(request)) ? InvalidUrl
 		canonical = Url.without_fragment(url)
-		raw = Host.http_send!(to_host_request(config, request, Url.to_str(canonical)))
-		if raw.err == 0 {
-			Ok(from_host_response(raw))
-		} else {
-			Err(HttpErr(to_transport_err(raw)))
+		# closed error union to open error union
+		match Host.http_send!(to_host_request(config, request, Url.to_str(canonical))) {
+			Ok(raw) => Ok(from_host_response(raw))
+			Err(MalformedResponse) => Err(HttpErr(MalformedResponse))
+			Err(NetworkError) => Err(HttpErr(NetworkError))
+			Err(Other(message)) => Err(HttpErr(Other(Str.to_utf8(message))))
+			Err(Timeout) => Err(HttpErr(Timeout))
 		}
 	}
 
@@ -315,22 +317,6 @@ from_host_response = |raw|
 		.with_headers(raw.headers.map(|{ name, value }| { name, value }))
 		.with_body(raw.body)
 
-## Rebuild the transport error the host reported.
-##
-## Unknown codes become `Other` rather than crashing, so a host that learns to
-## distinguish a new failure still reports something an app can print.
-to_transport_err : Host.HttpResponseFromHost -> Http.TransportErr
-to_transport_err = |raw|
-	if raw.err == 1 {
-		Timeout
-	} else if raw.err == 2 {
-		NetworkError
-	} else if raw.err == 3 {
-		MalformedResponse
-	} else {
-		Other(Str.to_utf8(raw.err_message))
-	}
-
 ## basic-cli's numeric method codes, so the two hosts agree on the wire.
 ##
 ## `send_with!` refuses `QUERY` and `Unknown(_)` before this runs, so their
@@ -382,10 +368,3 @@ expect to_host_method_ext(GET) == ""
 # ordinary `Request.from_method(GET)` is never sent without one.
 expect to_host_timeout(NoTimeout, 30_000) == 30_000
 expect to_host_timeout(TimeoutMilliseconds(250), 30_000) == 250
-
-expect to_transport_err({ err: 1, err_message: "", status: 0, headers: [], body: [] }) == Timeout
-expect to_transport_err({ err: 2, err_message: "", status: 0, headers: [], body: [] }) == NetworkError
-expect to_transport_err({ err: 3, err_message: "", status: 0, headers: [], body: [] }) == MalformedResponse
-
-# An unrecognised code still reports the host's message rather than crashing.
-expect to_transport_err({ err: 99, err_message: "boom", status: 0, headers: [], body: [] }) == Other(Str.to_utf8("boom"))

--- a/platform/Sqlite.roc
+++ b/platform/Sqlite.roc
@@ -17,7 +17,8 @@
 ## refuse results above one million cells or `Config.max_result_bytes` rather
 ## than truncating them. The default byte limit is sixteen megabytes.
 import Host
-import rrt.Handle
+import rrt.SqliteDb as RrtSqliteDb
+import rrt.SqliteStmt as RrtSqliteStmt
 
 Sqlite := [].{
 
@@ -173,7 +174,7 @@ Sqlite := [].{
 	## The host owns the connection; this is a reference-counted handle to it.
 	## Keep it in the model, copy it freely, and let the last reference close
 	## it.
-	Db :: Host.SqliteDb.{
+	Db :: RrtSqliteDb.SqliteDb.{
 
 		## Open or create a database under `default_config`.
 		##
@@ -201,12 +202,11 @@ Sqlite := [].{
 				config.busy_timeout_ms,
 				config.max_result_bytes,
 			)
-			if result.err == 0 {
-				Ok(Db.(result.db))
-			} else if result.err == err_too_many_connections {
-				Err(TooManyConnections)
-			} else {
-				Err(sqlite_err(result.err, result.message))
+			# closed error union to open error union
+			match result {
+				Ok(db) => Ok(Db.(db))
+				Err(TooManyConnections) => Err(TooManyConnections)
+				Err(SqliteErr(failure)) => Err(sqlite_err(failure))
 			}
 		}
 
@@ -225,14 +225,12 @@ Sqlite := [].{
 		## Legal in `init!`, where it blocks startup, and in tasks, where it
 		## parks the task; refused in `update!` and `render!`.
 		close! : Db => Try({}, [SqliteErr(ErrCode, Str)])
-		close! = |Db.(db)| {
-			result = Host.sqlite_close!(db)
-			if result.err == 0 {
-				Ok({})
-			} else {
-				Err(sqlite_err(result.err, result.message))
+		close! = |Db.(db)|
+		# closed error union to open error union
+			match Host.sqlite_close!(db) {
+				Ok({}) => Ok({})
+				Err(SqliteErr(failure)) => Err(sqlite_err(failure))
 			}
-		}
 
 		## Resource-free connection value for pure tests.
 		##
@@ -242,7 +240,7 @@ Sqlite := [].{
 		## model, to let a pure `expect` build that model. Do not use it to
 		## test queries or resource lifetime.
 		stub : Db
-		stub = Db.(Handle.stub)
+		stub = Db.(RrtSqliteDb.stub)
 	}
 
 	## One row of a result, with its column names.
@@ -391,7 +389,7 @@ Sqlite := [].{
 	## what a per-frame or per-record write wants. The host owns the compiled
 	## statement; the last handle released finalizes it, and the connection it
 	## came from stays open at least that long.
-	Stmt :: Host.SqliteStmt.{
+	Stmt :: RrtSqliteStmt.SqliteStmt.{
 
 		## Run this statement, which must not return rows.
 		##
@@ -419,7 +417,7 @@ Sqlite := [].{
 
 		## Resource-free statement value for pure tests. See `Db.stub`.
 		stub : Stmt
-		stub = Stmt.(Handle.stub)
+		stub = Stmt.(RrtSqliteStmt.stub)
 	}
 
 	## Compile one statement for repeated use.
@@ -431,15 +429,12 @@ Sqlite := [].{
 	## the task; refused in `update!` and `render!`.
 	prepare! : Db, Str => Try(Stmt, PrepareErr)
 	prepare! = |Db.(db), query| {
-		result = Host.sqlite_prepare!(db, query)
-		if result.err == 0 {
-			Ok(Stmt.(result.stmt))
-		} else if result.err == err_too_many_statements {
-			Err(TooManyStatements)
-		} else if result.err == err_multiple_statements {
-			Err(MultipleStatements)
-		} else {
-			Err(sqlite_err(result.err, result.message))
+		# closed error union to open error union
+		match Host.sqlite_prepare!(db, query) {
+			Ok(stmt) => Ok(Stmt.(stmt))
+			Err(TooManyStatements) => Err(TooManyStatements)
+			Err(MultipleStatements) => Err(MultipleStatements)
+			Err(SqliteErr(failure)) => Err(sqlite_err(failure))
 		}
 	}
 
@@ -480,14 +475,12 @@ Sqlite := [].{
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks
 	## the task; refused in `update!` and `render!`.
 	exec_script! : Db, Str => Try({}, [SqliteErr(ErrCode, Str)])
-	exec_script! = |Db.(db), script| {
-		result = Host.sqlite_exec_script!(db, script)
-		if result.err == 0 {
-			Ok({})
-		} else {
-			Err(sqlite_err(result.err, result.message))
+	exec_script! = |Db.(db), script|
+	# closed error union to open error union
+		match Host.sqlite_exec_script!(db, script) {
+			Ok({}) => Ok({})
+			Err(SqliteErr(failure)) => Err(sqlite_err(failure))
 		}
-	}
 
 	## Describe an error code, for a log line or an error screen.
 	errcode_to_str : ErrCode -> Str
@@ -539,20 +532,6 @@ mode_code = |mode|
 expect mode_code(ReadWriteCreate) == 0
 expect mode_code(ReadOnly) == 2
 
-## Host refusals. Negative because SQLite's own result codes never are, so one
-## number never means two things. Mirrored in `src/sqlite_effect.zig`.
-err_too_many_connections : I64
-err_too_many_connections = -1
-
-err_too_many_statements : I64
-err_too_many_statements = -2
-
-err_result_too_large : I64
-err_result_too_large = -3
-
-err_multiple_statements : I64
-err_multiple_statements = -4
-
 ## Column type codes, as SQLite numbers them. Mirrored in
 ## `src/sqlite_effect.zig`.
 cell_integer : U8
@@ -601,8 +580,8 @@ expect in_bounds(I64.to_u8_try(-1)) == Err(IntOutOfBounds)
 ## `Constraint` and the detail stays in the message. Without this an app
 ## matching on `Constraint` would miss every constraint SQLite bothered to be
 ## specific about.
-sqlite_err : I64, Str -> [SqliteErr(Sqlite.ErrCode, Str), ..]
-sqlite_err = |code, message| SqliteErr(errcode_from_i64(code % 256), message)
+sqlite_err : Host.SqliteFailure -> [SqliteErr(Sqlite.ErrCode, Str), ..]
+sqlite_err = |{ code, message }| SqliteErr(errcode_from_i64(code % 256), message)
 
 errcode_from_i64 : I64 -> Sqlite.ErrCode
 errcode_from_i64 = |code|
@@ -648,8 +627,8 @@ expect errcode_from_i64(101) == Done
 expect errcode_from_i64(77) == Unknown(77)
 
 ## 2067 is SQLITE_CONSTRAINT_UNIQUE: primary code 19 with detail 8 above it.
-expect sqlite_err(2067, "unique") == SqliteErr(Constraint, "unique")
-expect sqlite_err(5, "busy") == SqliteErr(Busy, "busy")
+expect sqlite_err({ code: 2067, message: "unique" }) == SqliteErr(Constraint, "unique")
+expect sqlite_err({ code: 5, message: "busy" }) == SqliteErr(Busy, "busy")
 
 ## Flatten one binding for the host. Only the field `kind` names is read, so
 ## the others carry whatever is cheapest to write down.
@@ -669,16 +648,14 @@ expect binding_wire({ name: ":a", value: Null }).kind == cell_null
 expect binding_wire({ name: ":a", value: String("hi") }).text == "hi"
 
 ## Turn a finished query into rows, or into the reason there are none.
-queried : Host.SqliteQueryResult -> Try(List(Sqlite.Row), Sqlite.QueryErr)
+queried : Try(Host.SqliteRows, Host.SqliteQueryError) -> Try(List(Sqlite.Row), Sqlite.QueryErr)
 queried = |result|
-	if result.err == 0 {
-		Ok(decode_rows(result))
-	} else if result.err == err_result_too_large {
-		Err(ResultTooLarge)
-	} else if result.err == err_multiple_statements {
-		Err(MultipleStatements)
-	} else {
-		Err(sqlite_err(result.err, result.message))
+# closed error union to open error union
+	match result {
+		Ok(rows) => Ok(decode_rows(rows))
+		Err(ResultTooLarge) => Err(ResultTooLarge)
+		Err(MultipleStatements) => Err(MultipleStatements)
+		Err(SqliteErr(failure)) => Err(sqlite_err(failure))
 	}
 
 ## Turn a finished statement into what it changed.
@@ -686,42 +663,40 @@ queried = |result|
 ## A statement that produced rows is refused rather than reported as a
 ## successful write: `execute!` has nowhere to put them, and silently dropping
 ## a `SELECT`'s output would hide the mistake.
-executed : Host.SqliteQueryResult -> Try(Sqlite.Outcome, Sqlite.ExecuteErr)
+executed : Try(Host.SqliteRows, Host.SqliteQueryError) -> Try(Sqlite.Outcome, Sqlite.ExecuteErr)
 executed = |result|
-	if result.err == 0 {
-		if result.row_count > 0 {
-			Err(RowsReturnedUseQueryInstead)
-		} else {
-			Ok({ changes: result.changes, last_insert_rowid: result.last_insert_rowid })
-		}
-	} else if result.err == err_result_too_large {
-		Err(ResultTooLarge)
-	} else if result.err == err_multiple_statements {
-		Err(MultipleStatements)
-	} else {
-		Err(sqlite_err(result.err, result.message))
+# closed error union to open error union
+	match result {
+		Ok(rows) =>
+			if rows.row_count > 0 {
+				Err(RowsReturnedUseQueryInstead)
+			} else {
+				Ok({ changes: rows.changes, last_insert_rowid: rows.last_insert_rowid })
+			}
+		Err(ResultTooLarge) => Err(ResultTooLarge)
+		Err(MultipleStatements) => Err(MultipleStatements)
+		Err(SqliteErr(failure)) => Err(sqlite_err(failure))
 	}
 
 ## Turn a finished query into its single row.
-exactly_one : Host.SqliteQueryResult -> Try(Sqlite.Row, Sqlite.ExactlyOneErr)
+exactly_one : Try(Host.SqliteRows, Host.SqliteQueryError) -> Try(Sqlite.Row, Sqlite.ExactlyOneErr)
 exactly_one = |result|
-	if result.err == 0 {
-		if result.row_count == 0 {
-			Err(NoRowsReturned)
-		} else if result.row_count > 1 {
-			Err(TooManyRowsReturned)
-		} else {
-			match List.first(decode_rows(result)) {
-				Ok(row) => Ok(row)
-				Err(_) => Err(NoRowsReturned)
+# closed error union to open error union
+	match result {
+		Ok(rows) =>
+			if rows.row_count == 0 {
+				Err(NoRowsReturned)
+			} else if rows.row_count > 1 {
+				Err(TooManyRowsReturned)
+			} else {
+				match List.first(decode_rows(rows)) {
+					Ok(row) => Ok(row)
+					Err(_) => Err(NoRowsReturned)
+				}
 			}
-		}
-	} else if result.err == err_result_too_large {
-		Err(ResultTooLarge)
-	} else if result.err == err_multiple_statements {
-		Err(MultipleStatements)
-	} else {
-		Err(sqlite_err(result.err, result.message))
+		Err(ResultTooLarge) => Err(ResultTooLarge)
+		Err(MultipleStatements) => Err(MultipleStatements)
+		Err(SqliteErr(failure)) => Err(sqlite_err(failure))
 	}
 
 ## Decode a whole result into rows.
@@ -731,13 +706,13 @@ exactly_one = |result|
 ## that names, text and blobs all point into. Nothing here can fail: a cell the
 ## host did not write is not reachable, and a short buffer ends the decode
 ## rather than being guessed at.
-decode_rows : Host.SqliteQueryResult -> List(Sqlite.Row)
+decode_rows : Host.SqliteRows -> List(Sqlite.Row)
 decode_rows = |result| {
 	names = decode_names(result.names, 0, [])
 	decode_row_at(result, names, 0, [])
 }
 
-decode_row_at : Host.SqliteQueryResult, List(Str), U64, List(Sqlite.Row) -> List(Sqlite.Row)
+decode_row_at : Host.SqliteRows, List(Str), U64, List(Sqlite.Row) -> List(Sqlite.Row)
 decode_row_at = |result, names, row, found|
 	if row >= result.row_count {
 		found
@@ -750,7 +725,7 @@ decode_row_at = |result, names, row, found|
 		)
 	}
 
-decode_cells : Host.SqliteQueryResult, U64, U64, List(Sqlite.Value) -> List(Sqlite.Value)
+decode_cells : Host.SqliteRows, U64, U64, List(Sqlite.Value) -> List(Sqlite.Value)
 decode_cells = |result, at, remaining, found|
 	if remaining == 0 {
 		found

--- a/platform/Stderr.roc
+++ b/platform/Stderr.roc
@@ -34,13 +34,13 @@ Stderr := [].{
 	## most 256 kibibytes cross per call, counting the string's UTF-8 bytes and
 	## the newline; a longer string is `TooLarge` and nothing is queued.
 	line! : Str => Try({}, WriteError)
-	line! = |text| write_result(Host.stdio_write_line!(2, text))
+	line! = |text| lifted(Host.stdio_write_line!(2, text))
 
 	## Write a string with no newline after it. Bounded exactly as `line!` is.
 	##
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
 	write! : Str => Try({}, WriteError)
-	write! = |text| write_result(Host.stdio_write_text!(2, text))
+	write! = |text| lifted(Host.stdio_write_text!(2, text))
 
 	## Write bytes that are not necessarily text.
 	##
@@ -50,8 +50,16 @@ Stderr := [].{
 	## newline, no translation. Bounded exactly as `line!` is, counting the length
 	## of the list.
 	write_bytes! : List(U8) => Try({}, WriteError)
-	write_bytes! = |bytes| write_result(Host.stdio_write_bytes!(2, bytes))
+	write_bytes! = |bytes| lifted(Host.stdio_write_bytes!(2, bytes))
 }
 
-write_result = |code|
-	if code == 0 Ok({}) else if code == 5 Err(TooLarge) else if code == 11 Err(BufferFull) else Err(Unavailable)
+## Re-lift a queued write's closed error union onto the open one this module
+## exposes.
+lifted : Try({}, Host.StdioWriteError) -> Try({}, WriteError)
+lifted = |result|
+	match result {
+		Ok({}) => Ok({})
+		Err(BufferFull) => Err(BufferFull)
+		Err(TooLarge) => Err(TooLarge)
+		Err(Unavailable) => Err(Unavailable)
+	}

--- a/platform/Stdout.roc
+++ b/platform/Stdout.roc
@@ -33,13 +33,13 @@ Stdout := [].{
 	## most 256 kibibytes cross per call, counting the string's UTF-8 bytes and
 	## the newline; a longer string is `TooLarge` and nothing is queued.
 	line! : Str => Try({}, WriteError)
-	line! = |text| write_result(Host.stdio_write_line!(1, text))
+	line! = |text| lifted(Host.stdio_write_line!(1, text))
 
 	## Write a string with no newline after it. Bounded exactly as `line!` is.
 	##
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
 	write! : Str => Try({}, WriteError)
-	write! = |text| write_result(Host.stdio_write_text!(1, text))
+	write! = |text| lifted(Host.stdio_write_text!(1, text))
 
 	## Write bytes that are not necessarily text.
 	##
@@ -49,8 +49,16 @@ Stdout := [].{
 	## newline, no translation. Bounded exactly as `line!` is, counting the length
 	## of the list.
 	write_bytes! : List(U8) => Try({}, WriteError)
-	write_bytes! = |bytes| write_result(Host.stdio_write_bytes!(1, bytes))
+	write_bytes! = |bytes| lifted(Host.stdio_write_bytes!(1, bytes))
 }
 
-write_result = |code|
-	if code == 0 Ok({}) else if code == 5 Err(TooLarge) else if code == 11 Err(BufferFull) else Err(Unavailable)
+## Re-lift a queued write's closed error union onto the open one this module
+## exposes.
+lifted : Try({}, Host.StdioWriteError) -> Try({}, WriteError)
+lifted = |result|
+	match result {
+		Ok({}) => Ok({})
+		Err(BufferFull) => Err(BufferFull)
+		Err(TooLarge) => Err(TooLarge)
+		Err(Unavailable) => Err(Unavailable)
+	}

--- a/platform/Text.roc
+++ b/platform/Text.roc
@@ -24,7 +24,7 @@ import Draw
 import Host
 import Math
 import rrt.Font as RrtFont
-import rrt.Handle
+import rrt.TextPrepared as RrtTextPrepared
 
 Text := [].{
 
@@ -124,7 +124,7 @@ Text := [].{
 	## Host-owned immutable text. Its ARC handle retains any loaded font and its
 	## cached native NUL-terminated bytes are reused by every draw.
 	Prepared :: {
-		resource : Host.TextPrepared,
+		resource : RrtTextPrepared.TextPrepared,
 		measured : Size,
 	}.{
 
@@ -171,7 +171,7 @@ Text := [].{
 		stub : Prepared
 		stub = Prepared.(
 			{
-				resource: Handle.stub,
+				resource: RrtTextPrepared.stub,
 				measured: { width: 0, height: 0 },
 			},
 		)

--- a/platform/Udp.roc
+++ b/platform/Udp.roc
@@ -173,16 +173,22 @@ Udp := [].{
 		## Legal in `init!`, `update!`, and tasks; refused in `render!`.
 		send! : Socket, Address, List(U8) => Try({}, SendError)
 		send! = |Socket.(socket), to, bytes| {
-			err = Host.udp_send!({
+			result = Host.udp_send!({
 				socket: socket.handle,
 				ip: to.ip,
 				port: to.port,
 				bytes,
 			})
-			if err == 0 {
-				Ok({})
-			} else {
-				Err(send_error(err))
+			# closed error union to open error union
+			match result {
+				Ok({}) => Ok({})
+				Err(InvalidAddress) => Err(InvalidAddress)
+				Err(PermissionDenied) => Err(PermissionDenied)
+				Err(SendFailed) => Err(SendFailed)
+				Err(TooLarge) => Err(TooLarge)
+				Err(Unavailable) => Err(Unavailable)
+				Err(NoRoute) => Err(Unreachable)
+				Err(WouldBlock) => Err(WouldBlock)
 			}
 		}
 
@@ -246,28 +252,11 @@ format_ip = |ip| {
 	"${octet(24)}.${octet(16)}.${octet(8)}.${octet(0)}"
 }
 
-## Name a failed send. Mirrors the `ERR_*` codes in `src/udp_effect.zig`.
-send_error : U8 -> Udp.SendError
-send_error = |code|
-	match code {
-		1 => Unavailable
-		2 => InvalidAddress
-		10 => PermissionDenied
-		11 => TooLarge
-		12 => WouldBlock
-		13 => Unreachable
-		_ => SendFailed
-	}
-
 expect format_ip(0x7f000001) == "127.0.0.1"
 expect format_ip(0) == "0.0.0.0"
 expect format_ip(0xffffffff) == "255.255.255.255"
 expect format_ip(0xc0a80101) == "192.168.1.1"
 expect format_ip(0x08080808) == "8.8.8.8"
-
-expect send_error(12) == WouldBlock
-expect send_error(11) == TooLarge
-expect send_error(3) == SendFailed
 
 ## Each datagram in a batch keeps its own bytes and its own sender: a decode
 ## that shared one slice, or lost the address, would make every reply go to the

--- a/platform/Udp.roc
+++ b/platform/Udp.roc
@@ -50,7 +50,7 @@
 ## privileges, and report `PermissionDenied` when they are missing. Broadcast
 ## and multicast are not enabled.
 import Host
-import rrt.Handle
+import rrt.UdpSocket as RrtUdpSocket
 
 Udp := [].{
 
@@ -135,11 +135,15 @@ Udp := [].{
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
 	bind! : Address => Try(Socket, BindError)
 	bind! = |address| {
-		result = Host.udp_bind!({ ip: address.ip, port: address.port })
-		if result.err == 0 {
-			Ok(Socket.({ handle: result.handle, local: { ip: format_ip(result.ip), port: result.port } }))
-		} else {
-			Err(bind_error(result.err))
+		# closed error union to open error union
+		match Host.udp_bind!({ ip: address.ip, port: address.port }) {
+			Ok(bound) => Ok(Socket.({ handle: bound.handle, local: { ip: format_ip(bound.ip), port: bound.port } }))
+			Err(AddressInUse) => Err(AddressInUse)
+			Err(AddressUnavailable) => Err(AddressUnavailable)
+			Err(InvalidAddress) => Err(InvalidAddress)
+			Err(PermissionDenied) => Err(PermissionDenied)
+			Err(ResourceLimit) => Err(ResourceLimit)
+			Err(Unavailable) => Err(Unavailable)
 		}
 	}
 
@@ -148,7 +152,7 @@ Udp := [].{
 	## The handle is reference counted: copy it freely, and when the last copy
 	## goes -- out of the model, out of a task's captures, or at shutdown --
 	## the socket is closed. There is nothing to remember to close.
-	Socket := { handle : Host.UdpHandle, local : Address }.{
+	Socket := { handle : RrtUdpSocket.UdpSocket, local : Address }.{
 
 		## The address this socket is actually bound to, including the port the
 		## operating system chose when `bind!` was given `0`.
@@ -201,10 +205,13 @@ Udp := [].{
 				timeout_ms: config.timeout_ms,
 				max_datagrams: config.max_datagrams,
 			})
-			if result.err == 0 {
-				Ok(decode_batch(result.slices, result.payload))
-			} else {
-				Err(receive_error(result.err))
+			# closed error union to open error union
+			match result {
+				Ok(batch) => Ok(decode_batch(batch.slices, batch.payload))
+				Err(AlreadyReceiving) => Err(AlreadyReceiving)
+				Err(ReceiveFailed) => Err(ReceiveFailed)
+				Err(Timeout) => Err(Timeout)
+				Err(Unavailable) => Err(Unavailable)
 			}
 		}
 
@@ -217,7 +224,7 @@ Udp := [].{
 		## a pure `expect` build that model. Do not use it to test delivery or
 		## resource lifetime.
 		stub : Socket
-		stub = Socket.({ handle: Handle.stub, local: { ip: "0.0.0.0", port: 0 } })
+		stub = Socket.({ handle: RrtUdpSocket.stub, local: { ip: "0.0.0.0", port: 0 } })
 	}
 }
 
@@ -239,18 +246,6 @@ format_ip = |ip| {
 	"${octet(24)}.${octet(16)}.${octet(8)}.${octet(0)}"
 }
 
-## Name a failed bind. Mirrors the `ERR_*` codes in `src/udp_effect.zig`.
-bind_error : U8 -> Udp.BindError
-bind_error = |code|
-	match code {
-		2 => InvalidAddress
-		4 => ResourceLimit
-		8 => AddressInUse
-		9 => AddressUnavailable
-		10 => PermissionDenied
-		_ => Unavailable
-	}
-
 ## Name a failed send. Mirrors the `ERR_*` codes in `src/udp_effect.zig`.
 send_error : U8 -> Udp.SendError
 send_error = |code|
@@ -264,31 +259,15 @@ send_error = |code|
 		_ => SendFailed
 	}
 
-## Name a failed receive. Mirrors the `ERR_*` codes in `src/udp_effect.zig`.
-receive_error : U8 -> Udp.ReceiveError
-receive_error = |code|
-	match code {
-		1 => Unavailable
-		14 => Timeout
-		15 => AlreadyReceiving
-		_ => ReceiveFailed
-	}
-
 expect format_ip(0x7f000001) == "127.0.0.1"
 expect format_ip(0) == "0.0.0.0"
 expect format_ip(0xffffffff) == "255.255.255.255"
 expect format_ip(0xc0a80101) == "192.168.1.1"
 expect format_ip(0x08080808) == "8.8.8.8"
 
-expect bind_error(2) == InvalidAddress
-expect bind_error(8) == AddressInUse
-expect bind_error(1) == Unavailable
 expect send_error(12) == WouldBlock
 expect send_error(11) == TooLarge
 expect send_error(3) == SendFailed
-expect receive_error(14) == Timeout
-expect receive_error(15) == AlreadyReceiving
-expect receive_error(3) == ReceiveFailed
 
 ## Each datagram in a batch keeps its own bytes and its own sender: a decode
 ## that shared one slice, or lost the address, would make every reply go to the

--- a/platform/Window.roc
+++ b/platform/Window.roc
@@ -74,14 +74,14 @@ Window := [].{
 	## Content that is not text, or is larger than the host will copy into a
 	## `Str`, is refused rather than truncated.
 	read_clipboard! : () => Try(Str, ClipboardReadError)
-	read_clipboard! = || {
-		result = Host.window_read_clipboard!()
-		if result.err == 0 {
-			Ok(result.contents)
-		} else {
-			Err(clipboard_error(result.err))
+	read_clipboard! = ||
+		match Host.window_read_clipboard!() {
+			# closed error union to open error union
+			Ok(contents) => Ok(contents)
+			Err(Busy) => Err(Busy)
+			Err(TooLarge) => Err(TooLarge)
+			Err(Unavailable) => Err(Unavailable)
 		}
-	}
 
 	## Set raylib's CPU-side frame-rate cap.
 	##
@@ -175,19 +175,3 @@ expect {
 	monitor = monitor_from_host({ index: 1, name: "HDMI-1", width: 2560, height: 1440, x: 1920, y: 0, refresh_hz: 144 })
 	monitor.size == { width: 2560, height: 1440 } and monitor.position == { x: 1920, y: 0 }
 }
-
-## Decode the host's clipboard-error code. Mirrored in `src/host_native.zig`.
-clipboard_error : U8 -> Window.ClipboardReadError
-clipboard_error = |code|
-	if code == 5 {
-		TooLarge
-	} else if code == 3 {
-		Busy
-	} else {
-		Unavailable
-	}
-
-expect clipboard_error(5) == TooLarge
-expect clipboard_error(3) == Busy
-expect clipboard_error(4) == Unavailable
-expect clipboard_error(0) == Unavailable

--- a/src/host_native.zig
+++ b/src/host_native.zig
@@ -1002,7 +1002,20 @@ fn readFileWaiting(allocator: std.mem.Allocator, path: []const u8, limit: usize,
 /// file. A file that is not valid UTF-8 is reported rather than delivered,
 /// because `RocStr.fromSlice` only copies and every later string operation on
 /// an invalid one would be undefined.
-fn hostedFilesReadText(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c) abi.HostFiles_read_textRetRecord {
+/// Name a read code in `Files.read_text!`'s vocabulary.
+fn filesReadTextError(code: u8) abi.HostFiles_read_textErr {
+    return switch (code) {
+        READ_ERR_NOT_FOUND => .not_found,
+        READ_ERR_BUSY => .busy,
+        READ_ERR_UNAVAILABLE => .unavailable,
+        READ_ERR_TOO_LARGE => .too_large,
+        READ_ERR_NOT_UTF8 => .not_utf8,
+        else => .read_failed,
+    };
+}
+
+fn hostedFilesReadText(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c) abi.HostFiles_read_textResult {
+    const Result = abi.HostFiles_read_textResult;
     enforcePhase("Files.read_text!", during_wait);
     var effect = EffectScope.begin("Files.read_text!", path_arg.asSlice().len);
     defer effect.end();
@@ -1014,7 +1027,7 @@ fn hostedFilesReadText(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c) ab
     const bytes = readFileWaiting(allocator, path_arg.asSlice(), MAX_INLINE_READ_BYTES + 1, &err) orelse {
         effect.setExternalElapsed(external_started);
         effect.setOutcome(if (err == READ_ERR_BUSY or err == READ_ERR_UNAVAILABLE) .refused else .runtime_error);
-        return .{ .err = err, .contents = abi.RocStr.empty() };
+        return abiTryErr(Result, filesReadTextError(err));
     };
     effect.setExternalElapsed(external_started);
     defer allocator.free(bytes);
@@ -1023,17 +1036,17 @@ fn hostedFilesReadText(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c) ab
     if (!std.unicode.utf8ValidateSlice(bytes)) {
         effect.setValidationElapsed(validation_started);
         effect.setOutcome(.runtime_error);
-        return .{ .err = READ_ERR_NOT_UTF8, .contents = abi.RocStr.empty() };
+        return abiTryErr(Result, filesReadTextError(READ_ERR_NOT_UTF8));
     }
     effect.setValidationElapsed(validation_started);
     effect.addCopiedBytes(bytes.len);
     const conversion_started = observatoryDetailMeasurementStart();
     const contents = abi.RocStr.fromSlice(bytes, roc_host);
     effect.setConversionElapsed(conversion_started);
-    return .{ .err = 0, .contents = contents };
+    return abiTryOk(Result, contents);
 }
 
-fn exportedFilesReadText(path_arg: abi.RocStr) callconv(.c) abi.HostFiles_read_textRetRecord {
+fn exportedFilesReadText(path_arg: abi.RocStr) callconv(.c) abi.HostFiles_read_textResult {
     return hostedFilesReadText(activeHost(), path_arg);
 }
 
@@ -1044,7 +1057,19 @@ fn exportedFilesReadText(path_arg: abi.RocStr) callconv(.c) abi.HostFiles_read_t
 /// file costs one allocation and no copy. A delivery slot is reserved before
 /// any I/O starts, so a full heap answers `Busy` rather than reading a file and
 /// discarding it.
-fn hostedFilesReadBytes(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c) abi.HostFiles_read_bytesRetRecord {
+/// Name a read code in `Files.read_bytes!`'s vocabulary.
+fn filesReadBytesError(code: u8) abi.HostFiles_read_bytesErr {
+    return switch (code) {
+        READ_ERR_NOT_FOUND => .not_found,
+        READ_ERR_BUSY => .busy,
+        READ_ERR_UNAVAILABLE => .unavailable,
+        READ_ERR_TOO_LARGE => .too_large,
+        else => .read_failed,
+    };
+}
+
+fn hostedFilesReadBytes(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c) abi.HostFiles_read_bytesResult {
+    const Result = abi.HostFiles_read_bytesResult;
     enforcePhase("Files.read_bytes!", during_wait);
     var effect = EffectScope.begin("Files.read_bytes!", path_arg.asSlice().len);
     defer effect.end();
@@ -1052,31 +1077,48 @@ fn hostedFilesReadBytes(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c) a
     const result = readByteListWaiting(roc_host, path_arg.asSlice(), .read);
     if (result.err != 0) {
         effect.setOutcome(if (result.err == READ_ERR_BUSY or result.err == READ_ERR_UNAVAILABLE) .refused else .runtime_error);
-    } else {
-        effect.addOwnershipTransferBytes(result.bytes.items().len);
+        return abiTryErr(Result, filesReadBytesError(result.err));
     }
-    return result;
+    effect.addOwnershipTransferBytes(result.bytes.items().len);
+    return abiTryOk(Result, result.bytes);
 }
 
-fn exportedFilesReadBytes(path_arg: abi.RocStr) callconv(.c) abi.HostFiles_read_bytesRetRecord {
+fn exportedFilesReadBytes(path_arg: abi.RocStr) callconv(.c) abi.HostFiles_read_bytesResult {
     return hostedFilesReadBytes(activeHost(), path_arg);
 }
 
 /// `Files.list!`: one directory's entries, encoded into the same byte list a
 /// read delivers and decoded by `Files`.
-fn hostedFilesList(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c) abi.HostFiles_listRetRecord {
+/// Name a read code in `Files.list!`'s vocabulary.
+///
+/// A listing is the only one of the three that can be refused for not being a
+/// directory, which is why it does not share `Files.read_bytes!`'s union.
+fn filesListError(code: u8) abi.HostFiles_listErr {
+    return switch (code) {
+        READ_ERR_NOT_FOUND => .not_found,
+        READ_ERR_BUSY => .busy,
+        READ_ERR_UNAVAILABLE => .unavailable,
+        READ_ERR_TOO_LARGE => .too_large,
+        READ_ERR_NOT_A_DIRECTORY => .not_adirectory,
+        else => .read_failed,
+    };
+}
+
+fn hostedFilesList(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c) abi.HostFiles_listResult {
+    const Result = abi.HostFiles_listResult;
     enforcePhase("Files.list!", during_wait);
     var effect = EffectScope.begin("Files.list!", path_arg.asSlice().len);
     defer effect.end();
     defer path_arg.decref(roc_host);
-    // Structurally the same record as a byte read's, but a distinct generated
-    // type, so copy it across field by field rather than casting.
     const result = readByteListWaiting(roc_host, path_arg.asSlice(), .list);
-    if (result.err != 0) effect.setOutcome(if (result.err == READ_ERR_BUSY or result.err == READ_ERR_UNAVAILABLE) .refused else .runtime_error);
-    return .{ .err = result.err, .bytes = result.bytes };
+    if (result.err != 0) {
+        effect.setOutcome(if (result.err == READ_ERR_BUSY or result.err == READ_ERR_UNAVAILABLE) .refused else .runtime_error);
+        return abiTryErr(Result, filesListError(result.err));
+    }
+    return abiTryOk(Result, result.bytes);
 }
 
-fn exportedFilesList(path_arg: abi.RocStr) callconv(.c) abi.HostFiles_listRetRecord {
+fn exportedFilesList(path_arg: abi.RocStr) callconv(.c) abi.HostFiles_listResult {
     return hostedFilesList(activeHost(), path_arg);
 }
 
@@ -1112,21 +1154,41 @@ fn statEntryKind(kind: std.Io.File.Kind) u8 {
 /// the same, and the difference is only that the answer is five numbers rather
 /// than a payload, so there is no delivery slot to reserve and nothing to
 /// bound but the wait itself.
-fn statPathIn(base: std.Io.Dir, io: std.Io, path: []const u8) abi.HostFiles_metadataRetRecord {
+fn statPathIn(base: std.Io.Dir, io: std.Io, path: []const u8) StatOutcome {
     const stat = base.statFile(io, path, .{ .follow_symlinks = true }) catch |err|
-        return .{ .err = statErrorCode(err), .kind = 0, .size_bytes = 0, .modified_seconds = 0, .modified_nanosecond = 0 };
+        return .{ .err = statErrorCode(err), .found = std.mem.zeroes(abi.HostFiles_metadataOk) };
     const modified = timestampFromNanos(stat.mtime.nanoseconds);
     return .{
         .err = 0,
-        .kind = statEntryKind(stat.kind),
-        .size_bytes = stat.size,
-        .modified_seconds = modified.seconds,
-        .modified_nanosecond = modified.nanosecond,
+        .found = .{
+            .kind = statEntryKind(stat.kind),
+            .size_bytes = stat.size,
+            .modified_seconds = modified.seconds,
+            .modified_nanosecond = modified.nanosecond,
+        },
+    };
+}
+
+/// A finished stat, before it is named in the app's vocabulary. `found` is
+/// meaningful only when `err` is zero.
+const StatOutcome = struct {
+    err: u8,
+    found: abi.HostFiles_metadataOk,
+};
+
+/// Name a stat code in `Files.metadata!`'s vocabulary.
+fn filesMetadataError(code: u8) abi.HostFiles_metadataErr {
+    return switch (code) {
+        READ_ERR_NOT_FOUND => .not_found,
+        READ_ERR_UNAVAILABLE => .unavailable,
+        WRITE_ERR_PERMISSION_DENIED => .permission_denied,
+        else => .read_failed,
     };
 }
 
 /// `Files.metadata!`: what one path is, how big it is, and when it changed.
-fn hostedFilesMetadata(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c) abi.HostFiles_metadataRetRecord {
+fn hostedFilesMetadata(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c) abi.HostFiles_metadataResult {
+    const Result = abi.HostFiles_metadataResult;
     enforcePhase("Files.metadata!", during_wait);
     var effect = EffectScope.begin("Files.metadata!", path_arg.asSlice().len);
     defer effect.end();
@@ -1136,11 +1198,14 @@ fn hostedFilesMetadata(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c) ab
     const park = AppTasks.observePark("stat", 0);
     defer AppTasks.observeResume(park, "stat");
     const result = statPathIn(std.Io.Dir.cwd(), waitingIo(), path_arg.asSlice());
-    if (result.err != 0) effect.setOutcome(if (result.err == READ_ERR_UNAVAILABLE) .refused else .runtime_error);
-    return result;
+    if (result.err != 0) {
+        effect.setOutcome(if (result.err == READ_ERR_UNAVAILABLE) .refused else .runtime_error);
+        return abiTryErr(Result, filesMetadataError(result.err));
+    }
+    return abiTryOk(Result, result.found);
 }
 
-fn exportedFilesMetadata(path_arg: abi.RocStr) callconv(.c) abi.HostFiles_metadataRetRecord {
+fn exportedFilesMetadata(path_arg: abi.RocStr) callconv(.c) abi.HostFiles_metadataResult {
     return hostedFilesMetadata(activeHost(), path_arg);
 }
 
@@ -1705,8 +1770,26 @@ fn resolveReadbackSource(source: abi.HostCapture_pixel_atArg0Source, err: *u8) ?
     };
 }
 
-fn pixelReadFailure(err: u8) abi.HostCapture_pixel_atRetRecord {
-    return .{ .err = err, .r = 0, .g = 0, .b = 0, .a = 0 };
+/// Name a readback code in `Capture`'s pixel vocabulary.
+///
+/// `pixel_at!` and `read_region!` fail for the same reasons and share one
+/// union; only the payload of a success differs.
+fn capturePixelError(code: u8) abi.HostCapture_pixel_atErr {
+    return switch (code) {
+        capture.err_busy => .busy,
+        capture.err_unavailable => .unavailable,
+        capture.err_target_unavailable => .target_unavailable,
+        capture.err_region_out_of_bounds => .region_out_of_bounds,
+        else => .readback_failed,
+    };
+}
+
+fn pixelReadFailure(err: u8) abi.HostCapture_pixel_atResult {
+    return abiTryErr(abi.HostCapture_pixel_atResult, capturePixelError(err));
+}
+
+fn regionReadFailure(err: u8) abi.HostCapture_read_regionResult {
+    return abiTryErr(abi.HostCapture_read_regionResult, capturePixelError(err));
 }
 
 /// `Capture.pixel_at!`: one pixel's colour, with nothing allocated to carry it.
@@ -1714,7 +1797,7 @@ fn pixelReadFailure(err: u8) abi.HostCapture_pixel_atRetRecord {
 /// Synchronous rather than waiting. The screen comes from a snapshot the host
 /// already holds and a render target is read through the graphics context this
 /// thread owns, so there is nothing here to park on.
-fn hostedCapturePixelAt(roc_host: *RocHost, args: abi.HostCapture_pixel_atArgs) abi.HostCapture_pixel_atRetRecord {
+fn hostedCapturePixelAt(roc_host: *RocHost, args: abi.HostCapture_pixel_atArgs) abi.HostCapture_pixel_atResult {
     enforcePhase("Capture.pixel_at!", during_update);
     var effect = EffectScope.begin("Capture.pixel_at!", 0);
     defer effect.end();
@@ -1729,10 +1812,10 @@ fn hostedCapturePixelAt(roc_host: *RocHost, args: abi.HostCapture_pixel_atArgs) 
 
     const channels = capture.pixelAt(pixels.bytes, pixels.width, args.x, args.y);
     effect.setDrawMetrics(1, 4);
-    return .{ .err = capture.err_none, .r = channels[0], .g = channels[1], .b = channels[2], .a = channels[3] };
+    return abiTryOk(abi.HostCapture_pixel_atResult, abi.HostCapture_pixel_atOk{ .r = channels[0], .g = channels[1], .b = channels[2], .a = channels[3] });
 }
 
-fn exportedCapturePixelAt(args: abi.HostCapture_pixel_atArgs) callconv(.c) abi.HostCapture_pixel_atRetRecord {
+fn exportedCapturePixelAt(args: abi.HostCapture_pixel_atArgs) callconv(.c) abi.HostCapture_pixel_atResult {
     return hostedCapturePixelAt(activeHost(), args);
 }
 
@@ -1744,46 +1827,45 @@ fn exportedCapturePixelAt(args: abi.HostCapture_pixel_atArgs) callconv(.c) abi.H
 /// readback, so the expensive part never runs for a read that has nowhere to
 /// put its answer -- the same admission `Files.read_bytes!` does before it
 /// opens a path, and for the same reason.
-fn hostedCaptureReadRegion(roc_host: *RocHost, args: abi.HostCapture_read_regionArgs) abi.HostCapture_read_regionRetRecord {
+fn hostedCaptureReadRegion(roc_host: *RocHost, args: abi.HostCapture_read_regionArgs) abi.HostCapture_read_regionResult {
     enforcePhase("Capture.read_region!", during_update);
     var effect = EffectScope.begin("Capture.read_region!", 0);
     defer effect.end();
     defer releaseResourceBox(roc_host, args.source.target.handle);
 
-    const empty = abi.RocListWith(u8, false).empty();
     const region = capture.Region{ .x = args.x, .y = args.y, .width = args.width, .height = args.height };
 
     const bytes = capture.regionBytes(region) orelse
-        return .{ .err = capture.err_region_out_of_bounds, .bytes = empty };
+        return regionReadFailure(capture.err_region_out_of_bounds);
     if (bytes > capture.max_readback_bytes)
-        return .{ .err = capture.err_region_out_of_bounds, .bytes = empty };
+        return regionReadFailure(capture.err_region_out_of_bounds);
 
-    if (!file_bytes_delivery_reservations.reserve()) return .{ .err = capture.err_busy, .bytes = empty };
+    if (!file_bytes_delivery_reservations.reserve()) return regionReadFailure(capture.err_busy);
     defer file_bytes_delivery_reservations.release();
 
     var err: u8 = capture.err_readback_failed;
-    const pixels = resolveReadbackSource(args.source, &err) orelse return .{ .err = err, .bytes = empty };
+    const pixels = resolveReadbackSource(args.source, &err) orelse return regionReadFailure(err);
     defer pixels.deinit();
 
     const bounds = capture.validateRegion(region, pixels.width, pixels.height);
-    if (bounds != capture.err_none) return .{ .err = bounds, .bytes = empty };
+    if (bounds != capture.err_none) return regionReadFailure(bounds);
 
     const allocator = allocatorFromHost(roc_host);
     const copy = allocator.alloc(u8, @intCast(bytes)) catch
-        return .{ .err = capture.err_busy, .bytes = empty };
+        return regionReadFailure(capture.err_busy);
     capture.copyRegion(copy, pixels.bytes, pixels.width, region);
 
     // The transfer itself, shared with every other handed-over byte list. Its
     // only refusal is a full heap, which is the same "no slot" this call
     // already reserved against and reports as `Busy`.
     const installed = installReadBytes(allocator, copy);
-    if (installed.err != 0) return .{ .err = capture.err_busy, .bytes = empty };
+    if (installed.err != 0) return regionReadFailure(capture.err_busy);
     effect.addOwnershipTransferBytes(@intCast(bytes));
     effect.setDrawMetrics(@as(u64, @intCast(args.width)) *| @as(u64, @intCast(args.height)), bytes);
-    return .{ .err = capture.err_none, .bytes = installed.bytes };
+    return abiTryOk(abi.HostCapture_read_regionResult, installed.bytes);
 }
 
-fn exportedCaptureReadRegion(args: abi.HostCapture_read_regionArgs) callconv(.c) abi.HostCapture_read_regionRetRecord {
+fn exportedCaptureReadRegion(args: abi.HostCapture_read_regionArgs) callconv(.c) abi.HostCapture_read_regionResult {
     return hostedCaptureReadRegion(activeHost(), args);
 }
 
@@ -1792,7 +1874,17 @@ fn exportedCaptureReadRegion(args: abi.HostCapture_read_regionArgs) callconv(.c)
 /// same list on the way out.
 const ByteListWait = enum { read, list };
 
-fn readByteListWaiting(roc_host: *RocHost, path: []const u8, kind: ByteListWait) abi.HostFiles_read_bytesRetRecord {
+/// A finished byte-list wait, before it is named in the app's vocabulary.
+///
+/// The host keeps one internal code table for reads, listings, and stats
+/// because they share the same failures; each hosted function translates it
+/// into that effect's own closed error union on the way out.
+const ByteListOutcome = struct {
+    err: u8,
+    bytes: abi.RocListWith(u8, false),
+};
+
+fn readByteListWaiting(roc_host: *RocHost, path: []const u8, kind: ByteListWait) ByteListOutcome {
     const empty = abi.RocListWith(u8, false).empty();
     // Reserve before any filesystem work starts. A terminal `Busy` here means
     // precisely that nothing was read.
@@ -1838,7 +1930,7 @@ fn readByteListWaiting(roc_host: *RocHost, path: []const u8, kind: ByteListWait)
 /// An empty read becomes the canonical empty list rather than occupying a slot,
 /// and a full heap frees the buffer and reports `Busy` -- the read happened,
 /// but there is nowhere to hand it over.
-fn installReadBytes(allocator: std.mem.Allocator, bytes: []u8) abi.HostFiles_read_bytesRetRecord {
+fn installReadBytes(allocator: std.mem.Allocator, bytes: []u8) ByteListOutcome {
     const empty = abi.RocListWith(u8, false).empty();
     if (bytes.len == 0) {
         allocator.free(bytes);
@@ -1856,7 +1948,9 @@ fn installReadBytes(allocator: std.mem.Allocator, bytes: []u8) abi.HostFiles_rea
 /// The phase handling mirrors `hostedTaskSleep`: the request parks this
 /// coroutine, the frame loop runs in between and sets phases of its own, and
 /// the task must see `.task` again when the response arrives.
-fn hostedHttpSend(request: http_effect.Request) callconv(.c) http_effect.Response {
+fn hostedHttpSend(request: http_effect.Request) callconv(.c) abi.HostHttp_sendResult {
+    const Result = abi.HostHttp_sendResult;
+    const Union = abi.HostHttp_sendErr;
     enforcePhase("Http.send!", during_wait);
     var effect = EffectScope.begin("Http.send!", 0);
     defer effect.end();
@@ -1867,8 +1961,35 @@ fn hostedHttpSend(request: http_effect.Request) callconv(.c) http_effect.Respons
     const external_started = observatoryMeasurementStart();
     const result = http_effect.send(roc_host, allocatorFromHost(roc_host), request);
     effect.setExternalElapsed(external_started);
-    if (result.err != 0) effect.setOutcome(.runtime_error);
-    return result;
+    if (result.err == http_effect.ERR_OK) {
+        result.err_message.decref(roc_host);
+        return abiTryOk(Result, abi.HostHttp_sendOk{
+            .status = result.status,
+            .headers = result.headers,
+            .body = result.body,
+        });
+    }
+    effect.setOutcome(.runtime_error);
+    result.headers.decref(roc_host);
+    result.body.decref(roc_host);
+    // Only `Other` carries the host's description; the three named failures
+    // say everything they have to say in their own name, so their message is
+    // released rather than passed along.
+    return abiTryErr(Result, switch (result.err) {
+        http_effect.ERR_TIMEOUT => blk: {
+            result.err_message.decref(roc_host);
+            break :blk abiUnion(Union, .Timeout);
+        },
+        http_effect.ERR_NETWORK => blk: {
+            result.err_message.decref(roc_host);
+            break :blk abiUnion(Union, .NetworkError);
+        },
+        http_effect.ERR_BAD_BODY => blk: {
+            result.err_message.decref(roc_host);
+            break :blk abiUnion(Union, .MalformedResponse);
+        },
+        else => abiUnionPayload(Union, .Other, "other", result.err_message),
+    });
 }
 
 /// This process's own environment, as `std.process.Environ`.
@@ -1894,14 +2015,26 @@ fn hostProcessEnviron() std.process.Environ {
     return .empty;
 }
 
-/// A run that started no child, carrying only its code.
-fn cmdRunFailure(code: u8) abi.HostCmd_runRetRecord {
-    return .{
-        .err = code,
-        .exit_code = 0,
-        .stdout = abi.RocListWith(u8, false).empty(),
-        .stderr = abi.RocListWith(u8, false).empty(),
+/// Name a run code in `Cmd.run!`'s vocabulary.
+///
+/// `Timeout` is absent: it is the one variant carrying the output captured
+/// before the deadline, so only the caller holding that output can build it.
+fn cmdRunError(code: u8) abi.HostCmd_runErr {
+    const Union = abi.HostCmd_runErr;
+    return switch (code) {
+        cmd_effect.ERR_COMMAND_NOT_FOUND => abiUnion(Union, .CommandNotFound),
+        cmd_effect.ERR_BUSY => abiUnion(Union, .Busy),
+        cmd_effect.ERR_UNAVAILABLE => abiUnion(Union, .Unavailable),
+        cmd_effect.ERR_STDOUT_LIMIT => abiUnion(Union, .StdoutLimitExceeded),
+        cmd_effect.ERR_STDERR_LIMIT => abiUnion(Union, .StderrLimitExceeded),
+        cmd_effect.ERR_PERMISSION_DENIED => abiUnion(Union, .PermissionDenied),
+        else => abiUnion(Union, .SpawnFailed),
     };
+}
+
+/// A run that started no child, carrying only its refusal.
+fn cmdRunFailure(code: u8) abi.HostCmd_runResult {
+    return abiTryErr(abi.HostCmd_runResult, cmdRunError(code));
 }
 
 /// Copy the command out of the Roc record into host-owned storage.
@@ -1956,7 +2089,8 @@ fn copyCmdSpec(arena: std.mem.Allocator, args: abi.HostCmd_runArgs) ?cmd_effect.
 /// Both streams cross as ordinary copies rather than through the byte-list
 /// transfer path. A run produces two payloads where that path hands over one
 /// allocation per slot, and both are already bounded by limits the app stated.
-fn hostedCmdRun(roc_host: *RocHost, args: abi.HostCmd_runArgs) callconv(.c) abi.HostCmd_runRetRecord {
+fn hostedCmdRun(roc_host: *RocHost, args: abi.HostCmd_runArgs) callconv(.c) abi.HostCmd_runResult {
+    const Result = abi.HostCmd_runResult;
     enforcePhase("Cmd.run!", during_wait);
     var effect = EffectScope.begin("Cmd.run!", 0);
     defer effect.end();
@@ -2005,15 +2139,24 @@ fn hostedCmdRun(roc_host: *RocHost, args: abi.HostCmd_runArgs) callconv(.c) abi.
     defer outcome.deinit(allocator);
     if (outcome.err != 0) effect.setOutcome(.runtime_error);
 
-    return .{
-        .err = outcome.err,
+    // A timeout keeps whatever the child managed to write, so its output is
+    // built on that path too and handed over inside the `Timeout` variant.
+    const captured = abi.HostCmd_runOk{
         .exit_code = outcome.exit_code,
         .stdout = abi.RocListWith(u8, false).fromSlice(outcome.stdout, roc_host),
         .stderr = abi.RocListWith(u8, false).fromSlice(outcome.stderr, roc_host),
     };
+    if (outcome.err == cmd_effect.ERR_TIMED_OUT) {
+        return abiTryErr(Result, abiUnionPayload(abi.HostCmd_runErr, .Timeout, "timeout", captured));
+    }
+    if (outcome.err != 0) {
+        captured.decref(roc_host);
+        return cmdRunFailure(outcome.err);
+    }
+    return abiTryOk(Result, captured);
 }
 
-fn exportedCmdRun(args: abi.HostCmd_runArgs) callconv(.c) abi.HostCmd_runRetRecord {
+fn exportedCmdRun(args: abi.HostCmd_runArgs) callconv(.c) abi.HostCmd_runResult {
     return hostedCmdRun(activeHost(), args);
 }
 
@@ -2026,7 +2169,7 @@ fn exportedCmdRun(args: abi.HostCmd_runArgs) callconv(.c) abi.HostCmd_runRetReco
 /// can hand a turn to the executor, which runs other tasks' Roc code; the
 /// `PhaseScope` restore is what keeps the rest of this `update!` in the right
 /// phase afterwards, exactly as `Task.spawn!` does.
-fn hostedUdpBind(host: *RocHost, args: abi.HostUdp_bindArgs) callconv(.c) abi.HostUdp_bindRetRecord {
+fn hostedUdpBind(host: *RocHost, args: abi.HostUdp_bindArgs) callconv(.c) abi.HostUdp_bindResult {
     enforcePhase("Udp.bind!", during_load);
     var effect = EffectScope.begin("Udp.bind!", args.ip.asSlice().len);
     defer effect.end();
@@ -2058,22 +2201,28 @@ fn hostedUdpBind(host: *RocHost, args: abi.HostUdp_bindArgs) callconv(.c) abi.Ho
         effect.setOutcome(.refused);
         return udpBindFailure(udp_effect.ERR_RESOURCE_LIMIT);
     };
-    return .{
-        .handle = handle,
+    return abiTryOk(abi.HostUdp_bindResult, abi.HostUdp_bindOk{
+        .handle = .{ .handle = handle },
         .ip = socket.local_ip,
         .port = socket.local_port,
-        .err = 0,
-    };
+    });
 }
 
-fn exportedUdpBind(args: abi.HostUdp_bindArgs) callconv(.c) abi.HostUdp_bindRetRecord {
+fn exportedUdpBind(args: abi.HostUdp_bindArgs) callconv(.c) abi.HostUdp_bindResult {
     return hostedUdpBind(activeHost(), args);
 }
 
-/// A bind that produced no socket. The handle is the shared invalid token, so
-/// `Udp` still gets a structurally valid value to discard.
-fn udpBindFailure(code: u8) abi.HostUdp_bindRetRecord {
-    return .{ .handle = invalidResourceHandle(), .ip = 0, .port = 0, .err = code };
+/// A bind that produced no socket, named in `Udp.bind!`'s vocabulary.
+fn udpBindFailure(code: u8) abi.HostUdp_bindResult {
+    const Union = abi.HostUdp_bindErr;
+    return abiTryErr(abi.HostUdp_bindResult, switch (code) {
+        udp_effect.ERR_INVALID_ADDRESS => abiUnion(Union, .invalid_address),
+        udp_effect.ERR_RESOURCE_LIMIT => abiUnion(Union, .resource_limit),
+        udp_effect.ERR_ADDRESS_IN_USE => abiUnion(Union, .address_in_use),
+        udp_effect.ERR_ADDRESS_UNAVAILABLE => abiUnion(Union, .address_unavailable),
+        udp_effect.ERR_PERMISSION_DENIED => abiUnion(Union, .permission_denied),
+        else => abiUnion(Union, .unavailable),
+    });
 }
 
 /// `Udp.send!`: hand one datagram to the kernel, without waiting.
@@ -2089,7 +2238,7 @@ fn hostedUdpSend(host: *RocHost, args: abi.HostUdp_sendArgs) callconv(.c) u8 {
     defer args.decref(host);
 
     const validation_started = observatoryMeasurementStart();
-    const socket = udp_socket_heap.get(args.socket.*) orelse {
+    const socket = udp_socket_heap.get(args.socket.handle.*) orelse {
         effect.setValidationElapsed(validation_started);
         effect.setOutcome(.refused);
         return udp_effect.ERR_UNAVAILABLE;
@@ -2120,13 +2269,13 @@ fn exportedUdpSend(args: abi.HostUdp_sendArgs) callconv(.c) u8 {
 /// The batch is built in host memory first and copied into Roc values only
 /// once it is complete, so a cancelled or failed receive cannot leave a
 /// half-built Roc value behind.
-fn hostedUdpReceive(host: *RocHost, args: abi.HostUdp_receiveArgs) callconv(.c) abi.HostUdp_receiveRetRecord {
+fn hostedUdpReceive(host: *RocHost, args: abi.HostUdp_receiveArgs) callconv(.c) abi.HostUdp_receiveResult {
     enforcePhase("Udp.receive!", during_wait);
     var effect = EffectScope.begin("Udp.receive!", 0);
     defer effect.end();
     defer args.decref(host);
 
-    const socket = udp_socket_heap.get(args.socket.*) orelse {
+    const socket = udp_socket_heap.get(args.socket.handle.*) orelse {
         effect.setOutcome(.refused);
         return udpReceiveFailure(udp_effect.ERR_UNAVAILABLE);
     };
@@ -2160,35 +2309,37 @@ fn hostedUdpReceive(host: *RocHost, args: abi.HostUdp_receiveArgs) callconv(.c) 
         },
     };
     const conversion_started = observatoryMeasurementStart();
-    const result: abi.HostUdp_receiveRetRecord = .{
-        .err = 0,
+    const result = abiTryOk(abi.HostUdp_receiveResult, abi.HostUdp_receiveOk{
         .payload = abi.RocListWith(u8, false).fromSlice(batch.payload, host),
         .slices = udpRocSlices(host, batch.slices),
-    };
+    });
     effect.setConversionElapsed(conversion_started);
     return result;
 }
 
-fn exportedUdpReceive(args: abi.HostUdp_receiveArgs) callconv(.c) abi.HostUdp_receiveRetRecord {
+fn exportedUdpReceive(args: abi.HostUdp_receiveArgs) callconv(.c) abi.HostUdp_receiveResult {
     return hostedUdpReceive(activeHost(), args);
 }
 
 /// A receive that produced no datagrams, carrying only its code.
-fn udpReceiveFailure(code: u8) abi.HostUdp_receiveRetRecord {
-    return .{
-        .err = code,
-        .payload = abi.RocListWith(u8, false).empty(),
-        .slices = abi.RocListWith(abi.HostUdp_receiveSlices, false).empty(),
-    };
+/// A receive that produced no batch, named in `Udp.receive!`'s vocabulary.
+fn udpReceiveFailure(code: u8) abi.HostUdp_receiveResult {
+    const Union = abi.HostUdp_receiveErr;
+    return abiTryErr(abi.HostUdp_receiveResult, switch (code) {
+        udp_effect.ERR_TIMEOUT => abiUnion(Union, .timeout),
+        udp_effect.ERR_ALREADY_RECEIVING => abiUnion(Union, .already_receiving),
+        udp_effect.ERR_UNAVAILABLE => abiUnion(Union, .unavailable),
+        else => abiUnion(Union, .receive_failed),
+    });
 }
 
 /// Copy the batch index into the Roc list `Udp` decodes.
 fn udpRocSlices(
     host: *RocHost,
     slices: []const udp_effect.Slice,
-) abi.RocListWith(abi.HostUdp_receiveSlices, false) {
-    if (slices.len == 0) return abi.RocListWith(abi.HostUdp_receiveSlices, false).empty();
-    const list = abi.RocListWith(abi.HostUdp_receiveSlices, false).allocate(slices.len, host);
+) abi.RocListWith(abi.HostUdp_receiveOkSlices, false) {
+    if (slices.len == 0) return abi.RocListWith(abi.HostUdp_receiveOkSlices, false).empty();
+    const list = abi.RocListWith(abi.HostUdp_receiveOkSlices, false).allocate(slices.len, host);
     const elements = list.elements_ptr.?;
     for (slices, 0..) |slice, index| {
         elements[index] = .{
@@ -2199,6 +2350,68 @@ fn udpRocSlices(
         };
     }
     return list;
+}
+
+/// Name a SQLite outcome in one effect's closed error union.
+///
+/// The host's own refusals are the negative `ERR_*` codes; anything else is a
+/// code SQLite itself produced, and travels with the message it came with. A
+/// union that has no variant for a host refusal cannot receive one, so those
+/// arms are only compiled where they exist.
+fn sqliteError(comptime Union: type, roc_host: *RocHost, err: i64, message: abi.RocStr) Union {
+    const Failure = abi.HostSqlite_closeErr;
+    const Names = if (@typeInfo(Union) == .@"enum")
+        Union
+    else if (@hasField(Union, "tag")) @FieldType(Union, "tag") else void;
+    inline for (.{
+        .{ "TooManyConnections", sqlite_effect.ERR_TOO_MANY_CONNECTIONS },
+        .{ "TooManyStatements", sqlite_effect.ERR_TOO_MANY_STATEMENTS },
+        .{ "MultipleStatements", sqlite_effect.ERR_MULTIPLE_STATEMENTS },
+        .{ "ResultTooLarge", sqlite_effect.ERR_RESULT_TOO_LARGE },
+    }) |refusal| {
+        if (comptime Names != void and abiVariantName(Names, refusal[0]) != null) {
+            if (err == refusal[1]) {
+                message.decref(roc_host);
+                return abiUnionNamed(Union, refusal[0]);
+            }
+        }
+    }
+    const failure = Failure{ .code = err, .message = message };
+    // A single-variant union erases to its payload, so `[SqliteErr(_)]` is the
+    // failure record itself rather than a tagged wrapper around it.
+    if (Union == Failure) return failure;
+    return abiUnionPayload(Union, .SqliteErr, "sqlite_err", failure);
+}
+
+/// Hand one finished query over, or the reason there is none.
+///
+/// `run_stmt!` and `run_once!` answer with the same shape and the same
+/// failures, so the two share this rather than repeating it.
+fn sqliteQueryResult(
+    comptime Result: type,
+    roc_host: *RocHost,
+    effect: *EffectScope,
+    result: sqlite_effect.QueryOutcome,
+) Result {
+    if (result.err != 0) {
+        effect.setOutcome(.runtime_error);
+        result.names.decref(roc_host);
+        result.cells.decref(roc_host);
+        result.payload.decref(roc_host);
+        const Union = @typeInfo(@TypeOf(Result.payload_err)).@"fn".return_type.?;
+        return abiTryErr(Result, sqliteError(Union, roc_host, result.err, result.message));
+    }
+    result.message.decref(roc_host);
+    const Ok = @typeInfo(@TypeOf(Result.payload_ok)).@"fn".return_type.?;
+    return abiTryOk(Result, Ok{
+        .names = result.names,
+        .ncols = result.ncols,
+        .row_count = result.row_count,
+        .cells = result.cells,
+        .payload = result.payload,
+        .changes = result.changes,
+        .last_insert_rowid = result.last_insert_rowid,
+    });
 }
 
 /// The `Sqlite` effects.
@@ -2214,7 +2427,8 @@ fn hostedSqliteOpen(
     mode: u8,
     busy_timeout_ms: u64,
     max_result_bytes: u64,
-) callconv(.c) abi.HostSqlite_open {
+) callconv(.c) abi.HostSqlite_openResult {
+    const Result = abi.HostSqlite_openResult;
     enforcePhase("Sqlite.Db.open!", during_wait);
     var effect = EffectScope.begin("Sqlite.Db.open!", path_arg.asSlice().len);
     defer effect.end();
@@ -2234,11 +2448,16 @@ fn hostedSqliteOpen(
         max_result_bytes,
     );
     effect.setWorkerElapsed(worker_started);
-    if (result.err != 0) effect.setOutcome(.runtime_error);
-    return result;
+    if (result.err != 0) {
+        effect.setOutcome(.runtime_error);
+        return abiTryErr(Result, sqliteError(abi.HostSqlite_openErr, roc_host, result.err, result.message));
+    }
+    result.message.decref(roc_host);
+    return abiTryOk(Result, abi.SqliteDb{ .handle = result.db });
 }
 
-fn hostedSqliteClose(db_arg: *u64) callconv(.c) abi.HostSqlite_close {
+fn hostedSqliteClose(db_arg: *u64) callconv(.c) abi.HostSqlite_closeResult {
+    const Result = abi.HostSqlite_closeResult;
     enforcePhase("Sqlite.Db.close!", during_wait);
     var effect = EffectScope.begin("Sqlite.Db.close!", 0);
     defer effect.end();
@@ -2251,11 +2470,16 @@ fn hostedSqliteClose(db_arg: *u64) callconv(.c) abi.HostSqlite_close {
     const worker_started = observatoryMeasurementStart();
     const result = sqlite_effect.close(roc_host, AppTasks.currentRuntime(), db_arg);
     effect.setWorkerElapsed(worker_started);
-    if (result.err != 0) effect.setOutcome(.runtime_error);
-    return result;
+    if (result.err != 0) {
+        effect.setOutcome(.runtime_error);
+        return abiTryErr(Result, sqliteError(abi.HostSqlite_closeErr, roc_host, result.err, result.message));
+    }
+    result.message.decref(roc_host);
+    return abiTryEmptyOk(Result);
 }
 
-fn hostedSqlitePrepare(db_arg: *u64, sql_arg: abi.RocStr) callconv(.c) abi.HostSqlite_prepare {
+fn hostedSqlitePrepare(db_arg: *u64, sql_arg: abi.RocStr) callconv(.c) abi.HostSqlite_prepareResult {
+    const Result = abi.HostSqlite_prepareResult;
     enforcePhase("Sqlite.prepare!", during_wait);
     var effect = EffectScope.begin("Sqlite.prepare!", sql_arg.asSlice().len);
     defer effect.end();
@@ -2269,14 +2493,18 @@ fn hostedSqlitePrepare(db_arg: *u64, sql_arg: abi.RocStr) callconv(.c) abi.HostS
     const worker_started = observatoryMeasurementStart();
     const result = sqlite_effect.prepare(roc_host, AppTasks.currentRuntime(), db_arg, sql_arg);
     effect.setWorkerElapsed(worker_started);
-    if (result.err != 0) effect.setOutcome(.runtime_error);
-    return result;
+    if (result.err != 0) {
+        effect.setOutcome(.runtime_error);
+        return abiTryErr(Result, sqliteError(abi.HostSqlite_prepareErr, roc_host, result.err, result.message));
+    }
+    result.message.decref(roc_host);
+    return abiTryOk(Result, abi.SqliteStmt{ .handle = result.stmt });
 }
 
 fn hostedSqliteRunStmt(
     stmt_arg: *u64,
     bindings_arg: abi.RocList(abi.HostSqlite_run_stmtArg1),
-) callconv(.c) abi.HostSqlite_run_stmt {
+) callconv(.c) abi.HostSqlite_run_stmtResult {
     enforcePhase("Sqlite.Stmt.query!", during_wait);
     var effect = EffectScope.begin("Sqlite.Stmt.query!", 0);
     defer effect.end();
@@ -2290,15 +2518,14 @@ fn hostedSqliteRunStmt(
     const worker_started = observatoryMeasurementStart();
     const result = sqlite_effect.runStmt(roc_host, AppTasks.currentRuntime(), stmt_arg, bindings_arg);
     effect.setWorkerElapsed(worker_started);
-    if (result.err != 0) effect.setOutcome(.runtime_error);
-    return result;
+    return sqliteQueryResult(abi.HostSqlite_run_stmtResult, roc_host, &effect, result);
 }
 
 fn hostedSqliteRunOnce(
     db_arg: *u64,
     sql_arg: abi.RocStr,
     bindings_arg: abi.RocList(abi.HostSqlite_run_stmtArg1),
-) callconv(.c) abi.HostSqlite_run_once {
+) callconv(.c) abi.HostSqlite_run_onceResult {
     enforcePhase("Sqlite.query!", during_wait);
     var effect = EffectScope.begin("Sqlite.query!", sql_arg.asSlice().len);
     defer effect.end();
@@ -2313,11 +2540,11 @@ fn hostedSqliteRunOnce(
     const worker_started = observatoryMeasurementStart();
     const result = sqlite_effect.runOnce(roc_host, AppTasks.currentRuntime(), db_arg, sql_arg, bindings_arg);
     effect.setWorkerElapsed(worker_started);
-    if (result.err != 0) effect.setOutcome(.runtime_error);
-    return result;
+    return sqliteQueryResult(abi.HostSqlite_run_onceResult, roc_host, &effect, result);
 }
 
-fn hostedSqliteExecScript(db_arg: *u64, sql_arg: abi.RocStr) callconv(.c) abi.HostSqlite_exec_script {
+fn hostedSqliteExecScript(db_arg: *u64, sql_arg: abi.RocStr) callconv(.c) abi.HostSqlite_exec_scriptResult {
+    const Result = abi.HostSqlite_exec_scriptResult;
     enforcePhase("Sqlite.exec_script!", during_wait);
     var effect = EffectScope.begin("Sqlite.exec_script!", sql_arg.asSlice().len);
     defer effect.end();
@@ -2331,8 +2558,12 @@ fn hostedSqliteExecScript(db_arg: *u64, sql_arg: abi.RocStr) callconv(.c) abi.Ho
     const worker_started = observatoryMeasurementStart();
     const result = sqlite_effect.execScript(roc_host, AppTasks.currentRuntime(), db_arg, sql_arg);
     effect.setWorkerElapsed(worker_started);
-    if (result.err != 0) effect.setOutcome(.runtime_error);
-    return result;
+    if (result.err != 0) {
+        effect.setOutcome(.runtime_error);
+        return abiTryErr(Result, sqliteError(abi.HostSqlite_exec_scriptErr, roc_host, result.err, result.message));
+    }
+    result.message.decref(roc_host);
+    return abiTryEmptyOk(Result);
 }
 
 var active_phase: Phase = .idle;
@@ -3408,13 +3639,6 @@ var scissor_scope_count: usize = 0;
 
 const INVALID_RESOURCE_TOKEN = std.math.maxInt(u64);
 
-const InvalidResourceBox = extern struct {
-    refcount: isize = 0,
-    token: u64 = INVALID_RESOURCE_TOKEN,
-};
-
-var invalid_resource_box: InvalidResourceBox = .{};
-
 const DefaultFontBox = extern struct {
     refcount: isize = 0,
     token: u64 = 0,
@@ -3949,6 +4173,99 @@ fn abiTryPayload(
     return result;
 }
 
+/// A `Try` whose success carries nothing.
+///
+/// Glue emits no `payload_ok` accessor for a zero-sized success, so there is
+/// no payload to write and `abiTryOk` has nothing to check against.
+fn abiTryEmptyOk(comptime Result: type) Result {
+    var result: Result = std.mem.zeroes(Result);
+    result.tag = .Ok;
+    return result;
+}
+
+/// One payloadless variant of a generated closed error union.
+///
+/// A union whose variants all carry nothing is generated as a plain `enum`,
+/// and one with any payload as a tagged struct; this names a variant the same
+/// way in both. The payload bytes of the struct form are zeroed rather than
+/// left undefined so a value crossing the boundary never carries stale stack.
+fn abiUnion(comptime Union: type, comptime variant: @TypeOf(.enum_literal)) Union {
+    return abiUnionNamed(Union, @tagName(variant));
+}
+
+/// `abiUnion` for a variant named by a string rather than an enum literal.
+fn abiUnionNamed(comptime Union: type, comptime variant: []const u8) Union {
+    if (@typeInfo(Union) == .@"enum") return @field(Union, abiVariantName(Union, variant).?);
+    const Tag = @FieldType(Union, "tag");
+    var value: Union = std.mem.zeroes(Union);
+    value.tag = @field(Tag, abiVariantName(Tag, variant).?);
+    return value;
+}
+
+/// The member of `Enum` naming `variant`, or null when it has none.
+///
+/// Glue spells a payloadless union's members in snake_case and a tagged one's
+/// in the Roc tag's own PascalCase, so a caller that names a variant one way
+/// is matched against both rather than having to know which shape it got.
+fn abiVariantName(comptime Enum: type, comptime variant: []const u8) ?[]const u8 {
+    comptime {
+        if (@hasField(Enum, variant)) return variant;
+        var snake: [variant.len * 2]u8 = undefined;
+        var len: usize = 0;
+        for (variant, 0..) |char, index| {
+            if (std.ascii.isUpper(char)) {
+                if (index != 0) {
+                    snake[len] = '_';
+                    len += 1;
+                }
+                snake[len] = std.ascii.toLower(char);
+            } else {
+                snake[len] = char;
+            }
+            len += 1;
+        }
+        const final = snake[0..len].*;
+        if (@hasField(Enum, &final)) return &final;
+        return null;
+    }
+}
+
+/// One payload-carrying variant of a generated closed error union.
+///
+/// Shaped like `abiTryPayload`: on 32-bit targets glue stores the payload as
+/// aligned bytes, on 64-bit it emits an extern union, and the generated
+/// `payload_<variant>` accessor is the shared source of truth for the type.
+fn abiUnionPayload(
+    comptime Union: type,
+    comptime tag: @FieldType(Union, "tag"),
+    comptime field: []const u8,
+    value: anytype,
+) Union {
+    comptime {
+        const accessor = "payload_" ++ field;
+        const Expected = @typeInfo(@TypeOf(@field(Union, accessor))).@"fn".return_type.?;
+        if (@TypeOf(value) != Expected)
+            @compileError("ABI union payload does not match its generated accessor type");
+    }
+
+    var result: Union = undefined;
+    result.tag = tag;
+    if (@sizeOf(usize) == 4) {
+        const PayloadStorage = @FieldType(Union, "payload");
+        comptime {
+            if (@sizeOf(@TypeOf(value)) > @sizeOf(PayloadStorage))
+                @compileError("ABI union payload is larger than its generated storage");
+            if (@alignOf(@TypeOf(value)) > @alignOf(PayloadStorage))
+                @compileError("ABI union payload is more aligned than its generated storage");
+        }
+        const payload: *@TypeOf(value) = @ptrCast(@alignCast(&result.payload));
+        payload.* = value;
+    } else {
+        @field(result.payload, field) = value;
+    }
+    return result;
+}
+
 fn abiTryOk(comptime Result: type, value: anytype) Result {
     return abiTryPayload(Result, .ok, value);
 }
@@ -4363,7 +4680,7 @@ test "prepared text allocates long native bytes once and retains its loaded font
         .spacing = 1,
     });
     try std.testing.expectEqual(abi.HostText_prepareResultTag.Ok, result.tag);
-    const prepared = result.payload_ok().prepared;
+    const prepared = result.payload_ok().prepared.handle;
     drainRetiredResourcesUpTo(std.math.maxInt(usize));
     try std.testing.expectEqual(@as(usize, 1), prepared_text_heap.active());
     drainRetiredResourcesUpTo(std.math.maxInt(usize));
@@ -4375,7 +4692,7 @@ test "prepared text allocates long native bytes once and retains its loaded font
     for (0..10) |_| {
         abi.increfBox(@ptrCast(prepared), 1);
         hostedDrawPreparedTextRaw(&roc_host, .{
-            .prepared = prepared,
+            .prepared = .{ .handle = prepared },
             .pos = .{ .x = 20, .y = 30 },
             .color = .{ .r = 255, .g = 255, .b = 255, .a = 255 },
         });
@@ -4412,7 +4729,7 @@ test "prepared text rejects resource kind confusion and releases transferred own
 
     const draw_shader = storeShader(.headless).?;
     hostedDrawPreparedTextRaw(&roc_host, .{
-        .prepared = draw_shader,
+        .prepared = .{ .handle = draw_shader },
         .pos = .{ .x = 0, .y = 0 },
         .color = .{ .r = 0, .g = 0, .b = 0, .a = 255 },
     });
@@ -4983,14 +5300,14 @@ test "resource-free draw handles are inert, and leave real resources alone" {
 
         // Every store-backed loader reports the read it could not make.
         const store_texture = hostedTextureLoadStoreRaw(&roc_host, .{
-            .store = allocateTestResourceStub(&roc_host),
+            .store = .{ .handle = allocateTestResourceStub(&roc_host) },
             .path = abi.RocStr.fromSlice("atlas.png", &roc_host),
         });
         try std.testing.expectEqual(abi.HostTexture_load_storeResultTag.Err, store_texture.tag);
         try std.testing.expectEqual(abi.HostTexture_load_storeErr.read_failed, store_texture.payload_err());
 
         const store_font = hostedTextLoadStoreFontRaw(&roc_host, .{
-            .store = allocateTestResourceStub(&roc_host),
+            .store = .{ .handle = allocateTestResourceStub(&roc_host) },
             .path = abi.RocStr.fromSlice("body.ttf", &roc_host),
             .size = 16,
         });
@@ -4998,7 +5315,7 @@ test "resource-free draw handles are inert, and leave real resources alone" {
         try std.testing.expectEqual(abi.HostText_load_store_fontErr.read_failed, store_font.payload_err());
 
         const store_shader = hostedShaderLoadStoreRaw(&roc_host, .{
-            .store = allocateTestResourceStub(&roc_host),
+            .store = .{ .handle = allocateTestResourceStub(&roc_host) },
             .vertex_path = abi.RocStr.empty(),
             .fragment_path = abi.RocStr.fromSlice("blur.fs", &roc_host),
         });
@@ -5030,7 +5347,7 @@ test "resource-free draw handles are inert, and leave real resources alone" {
         // one is: no draw is counted and nothing faults.
         const draws_before = prepared_text_draw_calls;
         hostedDrawPreparedTextRaw(&roc_host, .{
-            .prepared = allocateTestResourceStub(&roc_host),
+            .prepared = .{ .handle = allocateTestResourceStub(&roc_host) },
             .pos = .{ .x = 10, .y = 20 },
             .color = .{ .r = 255, .g = 255, .b = 255, .a = 255 },
         });
@@ -5441,7 +5758,7 @@ test "every fixed resource heap reports capacity plus one as ResourceLimit" {
             .spacing = 1,
         });
         try std.testing.expectEqual(abi.HostText_prepareResultTag.Ok, result.tag);
-        prepared.* = result.payload_ok().prepared;
+        prepared.* = result.payload_ok().prepared.handle;
     }
     const refused_text = hostedTextPrepareRaw(&roc_host, .{
         .font = defaultFontHandle(),
@@ -6006,7 +6323,7 @@ test "store startup failures close an untransferred root and successful insertio
     try std.testing.expectEqual(@as(usize, 1), store_heap.active());
     // This is the one transferred reference. Its final release retires, then
     // closes, exactly one directory resource.
-    const base: *isize = @ptrFromInt(@intFromPtr(opened.payload_ok()) - @sizeOf(isize));
+    const base: *isize = @ptrFromInt(@intFromPtr(opened.payload_ok().handle) - @sizeOf(isize));
     base.* = 0;
     try std.testing.expectEqual(host_resource.DeallocRoute.deallocated, store_heap.routeDealloc(base));
     try std.testing.expectEqual(@as(usize, 1), store_heap.retiredCount());
@@ -6074,7 +6391,7 @@ test "opening a store and loading a texture from it wait rather than load" {
         defer update.leave();
         last_phase_violation = null;
         _ = hostedTextureLoadStoreRaw(&roc_host, .{
-            .store = allocateTestResourceStub(&roc_host),
+            .store = .{ .handle = allocateTestResourceStub(&roc_host) },
             .path = abi.RocStr.fromSlice("logo.png", &roc_host),
         });
         const violation = last_phase_violation orelse return error.OperationWasNotRejected;
@@ -6192,7 +6509,7 @@ fn hostedStoreOpenRaw(host: *RocHost, args: abi.HostStore_openArgs) callconv(.c)
         return abiTryErr(Result, Error.resource_limit);
     };
     root_transferred = true;
-    return abiTryOk(Result, stored);
+    return abiTryOk(Result, abi.Store{ .handle = stored });
 }
 
 fn exportedStoreOpenRaw(args: abi.HostStore_openArgs) callconv(.c) abi.HostStore_openResult {
@@ -6224,8 +6541,8 @@ fn hostedTextureLoadStoreRaw(host: *RocHost, args: abi.HostTexture_load_storeArg
     const effect = EffectScope.begin("Assets.load_texture!", 0);
     defer effect.end();
     defer args.path.decref(host);
-    defer releaseResourceBox(host, args.store);
-    const store = store_heap.get(args.store.*) orelse return abiTryErr(Result, Error.read_failed);
+    defer releaseResourceBox(host, args.store.handle);
+    const store = store_heap.get(args.store.handle.*) orelse return abiTryErr(Result, Error.read_failed);
     const allocator = allocatorFromHost(host);
     const source = readStoreAsset(allocator, store, args.path.asSlice());
     const bytes = switch (source) {
@@ -6494,11 +6811,11 @@ fn hostedShaderLoadStoreRaw(host: *RocHost, args: abi.HostShader_load_storeArgs)
     defer effect.end();
     defer args.vertex_path.decref(host);
     defer args.fragment_path.decref(host);
-    defer releaseResourceBox(host, args.store);
+    defer releaseResourceBox(host, args.store.handle);
     const vertex_path = args.vertex_path.asSlice();
     const fragment_path = args.fragment_path.asSlice();
     if (vertex_path.len == 0 and fragment_path.len == 0) return abiTryErr(Result, Error.path_invalid);
-    const store = store_heap.get(args.store.*) orelse return abiTryErr(Result, Error.read_failed);
+    const store = store_heap.get(args.store.handle.*) orelse return abiTryErr(Result, Error.read_failed);
     const allocator = allocatorFromHost(host);
 
     const vertex_read = if (vertex_path.len == 0) null else readStoreAsset(allocator, store, vertex_path);
@@ -6991,9 +7308,9 @@ fn hostedTextLoadStoreFontRaw(host: *RocHost, args: abi.HostText_load_store_font
     const effect = EffectScope.begin("Draw.load_store_font!", args.path.asSlice().len);
     defer effect.end();
     defer args.path.decref(host);
-    defer releaseResourceBox(host, args.store);
+    defer releaseResourceBox(host, args.store.handle);
     if (args.size <= 0) return abiTryErr(Result, Error.font_load_failed);
-    const store = store_heap.get(args.store.*) orelse return abiTryErr(Result, Error.read_failed);
+    const store = store_heap.get(args.store.handle.*) orelse return abiTryErr(Result, Error.read_failed);
     const allocator = allocatorFromHost(host);
     const source = readStoreAsset(allocator, store, args.path.asSlice());
     const bytes = switch (source) {
@@ -7057,7 +7374,7 @@ test "the store-backed font and shader loaders wait rather than load" {
         defer update.leave();
         last_phase_violation = null;
         _ = hostedTextLoadStoreFontRaw(&roc_host, .{
-            .store = allocateTestResourceStub(&roc_host),
+            .store = .{ .handle = allocateTestResourceStub(&roc_host) },
             .path = abi.RocStr.fromSlice("body.ttf", &roc_host),
             .size = 16,
         });
@@ -7068,7 +7385,7 @@ test "the store-backed font and shader loaders wait rather than load" {
 
         last_phase_violation = null;
         _ = hostedShaderLoadStoreRaw(&roc_host, .{
-            .store = allocateTestResourceStub(&roc_host),
+            .store = .{ .handle = allocateTestResourceStub(&roc_host) },
             .vertex_path = abi.RocStr.empty(),
             .fragment_path = abi.RocStr.fromSlice("blur.fs", &roc_host),
         });
@@ -7084,7 +7401,7 @@ test "the store-backed font and shader loaders wait rather than load" {
     defer task.leave();
     last_phase_violation = null;
     const font = hostedTextLoadStoreFontRaw(&roc_host, .{
-        .store = retainTestResourceBox(opened.payload_ok()),
+        .store = .{ .handle = retainTestResourceBox(opened.payload_ok().handle) },
         .path = abi.RocStr.fromSlice("body.ttf", &roc_host),
         .size = 16,
     });
@@ -7259,7 +7576,7 @@ fn hostedTextPrepareRaw(host: *RocHost, args: abi.HostText_prepareArgs) callconv
         .spacing = args.spacing,
     }) orelse return abiTryErr(Result, Error.resource_limit);
 
-    return abiTryOk(Result, abi.HostText_prepareOk{ .prepared = prepared, .height = measured.height, .width = measured.width });
+    return abiTryOk(Result, abi.HostText_prepareOk{ .prepared = .{ .handle = prepared }, .height = measured.height, .width = measured.width });
 }
 
 fn exportedTextPrepareRaw(args: abi.HostText_prepareArgs) callconv(.c) abi.HostText_prepareResult {
@@ -7270,8 +7587,8 @@ fn hostedDrawPreparedTextRaw(host: *RocHost, args: abi.HostDraw_draw_prepared_te
     enforcePhase("Text.Prepared.draw!", during_render);
     const effect = EffectScope.begin("Text.Prepared.draw!", 0);
     defer effect.end();
-    defer releaseResourceBox(host, args.prepared);
-    const resource = prepared_text_heap.get(args.prepared.*) orelse return;
+    defer releaseResourceBox(host, args.prepared.handle);
+    const resource = prepared_text_heap.get(args.prepared.handle.*) orelse return;
     prepared_text_draw_calls += 1;
     if (headlessMode()) return;
 
@@ -8179,21 +8496,33 @@ fn exportedCaptureSetVirtualText(text: abi.RocListWith(u32, false)) callconv(.c)
     hostedCaptureSetVirtualText(activeHost(), text);
 }
 
-fn hostedCaptureStopRecording() callconv(.c) abi.HostCapture_stop_recordingRetRecord {
+fn hostedCaptureStopRecording() callconv(.c) abi.HostCapture_stop_recordingResult {
+    const Result = abi.HostCapture_stop_recordingResult;
     enforcePhase("Capture.stop!", during_update);
     const effect = EffectScope.begin("Capture.stop!", 0);
     defer effect.end();
     const frames = capture_session.captured_frames;
     const stop_result = capture_session.stop();
-    if (stop_result == capture.err_not_recording) {
-        return .{ .err = stop_result, .frames = frames, .bytes = capture_recording_bytes };
-    }
+    if (stop_result == capture.err_not_recording)
+        return abiTryErr(Result, abi.HostCapture_stop_recordingErr.not_recording);
 
     // Finalize even when the session already failed: the frames captured
     // before the failure are still worth a readable file.
     const close_result = closeCaptureSink(true);
     const err = if (stop_result != capture.err_none) stop_result else close_result;
-    return .{ .err = err, .frames = frames, .bytes = capture_recording_bytes };
+    if (err != capture.err_none) {
+        const Union = abi.HostCapture_stop_recordingErr;
+        const named: Union = switch (err) {
+            capture.err_not_recording => .not_recording,
+            capture.err_budget_exceeded => .budget_exceeded,
+            capture.err_busy => .busy,
+            capture.err_unavailable => .unavailable,
+            capture.err_target_unavailable => .target_unavailable,
+            else => .readback_failed,
+        };
+        return abiTryErr(Result, named);
+    }
+    return abiTryOk(Result, abi.HostCapture_stop_recordingOk{ .frames = frames, .bytes = capture_recording_bytes });
 }
 
 /// The recording state sampled into every input.
@@ -8225,32 +8554,28 @@ fn captureStateForStep() CaptureFromHost {
 /// decides how big it is, and turning it into a `Str` is a copy and a UTF-8
 /// scan on this thread. Cap it where a text read is capped, and for the same
 /// reason.
-fn hostedReadClipboard(roc_host: *RocHost) callconv(.c) abi.HostWindow_read_clipboardRetRecord {
+fn hostedReadClipboard(roc_host: *RocHost) callconv(.c) abi.HostWindow_read_clipboardResult {
+    const Result = abi.HostWindow_read_clipboardResult;
+    const Error = abi.BusyOrTooLargeOrUnavailable;
     enforcePhase("Window.read_clipboard!", during_update);
     const effect = EffectScope.begin("Window.read_clipboard!", 0);
     defer effect.end();
 
     if (headlessMode()) {
-        if (!headless_clipboard_set) return .{ .err = READ_ERR_UNAVAILABLE, .contents = abi.RocStr.empty() };
-        return .{
-            .err = 0,
-            .contents = abi.RocStr.fromSlice(headless_clipboard[0..headless_clipboard_len], roc_host),
-        };
+        if (!headless_clipboard_set) return abiTryErr(Result, Error.unavailable);
+        return abiTryOk(Result, abi.RocStr.fromSlice(headless_clipboard[0..headless_clipboard_len], roc_host));
     }
 
     // The pointer belongs to the windowing backend: it is null when the
     // clipboard is empty or holds non-text content, must never be freed, and is
     // invalidated by the next clipboard call -- so copy it out now.
-    const text = raylib.getClipboardText() orelse
-        return .{ .err = READ_ERR_UNAVAILABLE, .contents = abi.RocStr.empty() };
+    const text = raylib.getClipboardText() orelse return abiTryErr(Result, Error.unavailable);
     const contents = std.mem.span(text);
-    if (contents.len > MAX_INLINE_READ_BYTES) {
-        return .{ .err = READ_ERR_TOO_LARGE, .contents = abi.RocStr.empty() };
-    }
-    return .{ .err = 0, .contents = abi.RocStr.fromSlice(contents, roc_host) };
+    if (contents.len > MAX_INLINE_READ_BYTES) return abiTryErr(Result, Error.too_large);
+    return abiTryOk(Result, abi.RocStr.fromSlice(contents, roc_host));
 }
 
-fn exportedReadClipboard() callconv(.c) abi.HostWindow_read_clipboardRetRecord {
+fn exportedReadClipboard() callconv(.c) abi.HostWindow_read_clipboardResult {
     return hostedReadClipboard(activeHost());
 }
 
@@ -8363,21 +8688,22 @@ test "headless clipboard round-trips text and refuses oversized writes" {
 
     // Nothing written yet, so a read reports the clipboard as unavailable
     // rather than handing back an empty string.
-    try std.testing.expectEqual(READ_ERR_UNAVAILABLE, hostedReadClipboard(&roc_host).err);
+    try std.testing.expectEqual(abi.HostWindow_read_clipboardResultTag.Err, hostedReadClipboard(&roc_host).tag);
 
     hostedSetClipboardText(&roc_host, abi.RocStr.fromSlice("copied", &roc_host));
     const stored = hostedReadClipboard(&roc_host);
-    defer stored.contents.decref(&roc_host);
-    try std.testing.expectEqual(@as(u8, 0), stored.err);
-    try std.testing.expectEqualStrings("copied", stored.contents.asSlice());
+    try std.testing.expectEqual(abi.HostWindow_read_clipboardResultTag.Ok, stored.tag);
+    defer stored.payload_ok().decref(&roc_host);
+    try std.testing.expectEqualStrings("copied", stored.payload_ok().asSlice());
 
     // A write that cannot fit leaves the previous contents intact, and still
     // releases the Roc string it was handed.
     const oversized = abi.RocStr.fromSlice(&([_]u8{'x'} ** (HEADLESS_CLIPBOARD_CAPACITY + 1)), &roc_host);
     hostedSetClipboardText(&roc_host, oversized);
     const unchanged = hostedReadClipboard(&roc_host);
-    defer unchanged.contents.decref(&roc_host);
-    try std.testing.expectEqualStrings("copied", unchanged.contents.asSlice());
+    try std.testing.expectEqual(abi.HostWindow_read_clipboardResultTag.Ok, unchanged.tag);
+    defer unchanged.payload_ok().decref(&roc_host);
+    try std.testing.expectEqualStrings("copied", unchanged.payload_ok().asSlice());
 }
 
 /// `App.Startup.entropy!`: one draw from the operating system's entropy.
@@ -8405,10 +8731,6 @@ fn hostedRandomI32(min: i32, max: i32) callconv(.c) i32 {
     return raylib.getRandomValue(min, max);
 }
 
-fn invalidResourceHandle() *u64 {
-    return &invalid_resource_box.token;
-}
-
 fn storeSound(resource: SoundResource) ?*u64 {
     return sound_heap.insert(0, resource) orelse {
         var rejected = resource;
@@ -8433,11 +8755,11 @@ fn hostedAudioGenTone(args: abi.HostAudio_gen_toneArgs) callconv(.c) abi.HostAud
     defer effect.end();
     if (headlessMode()) {
         const sound = storeSound(.headless) orelse return abiTryErr(Result, Error.resource_limit);
-        return abiTryOk(Result, sound);
+        return abiTryOk(Result, abi.AudioSound{ .handle = sound });
     }
     const sound = raylib.genTone(args.freq, args.ms) orelse return abiTryErr(Result, Error.sound_generation_failed);
     const stored = storeSound(.{ .native = sound }) orelse return abiTryErr(Result, Error.resource_limit);
-    return abiTryOk(Result, stored);
+    return abiTryOk(Result, abi.AudioSound{ .handle = stored });
 }
 
 fn hostedAudioGenSound(args: abi.HostAudio_gen_soundArgs) callconv(.c) abi.HostAudio_gen_toneResult {
@@ -8448,11 +8770,11 @@ fn hostedAudioGenSound(args: abi.HostAudio_gen_soundArgs) callconv(.c) abi.HostA
     defer effect.end();
     if (headlessMode()) {
         const sound = storeSound(.headless) orelse return abiTryErr(Result, Error.resource_limit);
-        return abiTryOk(Result, sound);
+        return abiTryOk(Result, abi.AudioSound{ .handle = sound });
     }
     const sound = raylib.genSound(args) orelse return abiTryErr(Result, Error.sound_generation_failed);
     const stored = storeSound(.{ .native = sound }) orelse return abiTryErr(Result, Error.resource_limit);
-    return abiTryOk(Result, stored);
+    return abiTryOk(Result, abi.AudioSound{ .handle = stored });
 }
 
 /// The extension raylib's in-memory audio decoders dispatch on.
@@ -8498,14 +8820,14 @@ fn hostedAudioLoadSound(host: *RocHost, path_arg: abi.RocStr) callconv(.c) abi.H
 
     if (headlessMode()) {
         const sound = storeSound(.headless) orelse return abiTryErr(Result, Error.resource_limit);
-        return abiTryOk(Result, sound);
+        return abiTryOk(Result, abi.AudioSound{ .handle = sound });
     }
 
     const file_type = audioFileTypeFromPath(path_slice, false) orelse
         return abiTryErr(Result, Error.sound_load_failed);
     const sound = raylib.loadSoundFromMemory(file_type, bytes) orelse return abiTryErr(Result, Error.sound_load_failed);
     const stored = storeSound(.{ .native = sound }) orelse return abiTryErr(Result, Error.resource_limit);
-    return abiTryOk(Result, stored);
+    return abiTryOk(Result, abi.AudioSound{ .handle = stored });
 }
 
 fn exportedAudioLoadSound(path_arg: abi.RocStr) callconv(.c) abi.HostAudio_load_soundResult {
@@ -8536,7 +8858,7 @@ fn hostedAudioLoadMusic(host: *RocHost, path_arg: abi.RocStr) callconv(.c) abi.H
 
     if (headlessMode()) {
         const music = storeMusic(.headless) orelse return abiTryErr(Result, Error.resource_limit);
-        return abiTryOk(Result, music);
+        return abiTryOk(Result, abi.AudioMusic{ .handle = music });
     }
 
     const file_type = audioFileTypeFromPath(path_slice, true) orelse
@@ -8547,7 +8869,7 @@ fn hostedAudioLoadMusic(host: *RocHost, path_arg: abi.RocStr) callconv(.c) abi.H
         return abiTryErr(Result, Error.resource_limit);
     };
     bytes_transferred = true;
-    return abiTryOk(Result, stored);
+    return abiTryOk(Result, abi.AudioMusic{ .handle = stored });
 }
 
 fn exportedAudioLoadMusic(path_arg: abi.RocStr) callconv(.c) abi.HostAudio_load_musicResult {
@@ -8609,8 +8931,8 @@ test "the audio file loaders wait rather than load" {
     try std.testing.expectEqual(abi.HostAudio_load_soundResultTag.Err, missing.tag);
     try std.testing.expectEqual(abi.HostAudio_load_soundErr.sound_load_failed, missing.payload_err());
 
-    releaseResourceBox(&roc_host, sound.payload_ok());
-    releaseResourceBox(&roc_host, music.payload_ok());
+    releaseResourceBox(&roc_host, sound.payload_ok().handle);
+    releaseResourceBox(&roc_host, music.payload_ok().handle);
 }
 
 test "an extension raylib cannot decode is refused, and module music is music only" {
@@ -10977,20 +11299,19 @@ test "a file that is not text is refused rather than made into a Str" {
     var path_buffer: [capture.path_capacity]u8 = undefined;
 
     const binary = hostedFilesReadText(&roc_host, tmpPathString(&roc_host, &path_buffer, &tmp.sub_path, "binary"));
-    try std.testing.expectEqual(READ_ERR_NOT_UTF8, binary.err);
-    try std.testing.expectEqual(@as(usize, 0), binary.contents.asSlice().len);
-    binary.contents.decref(&roc_host);
+    try std.testing.expectEqual(abi.HostFiles_read_textResultTag.Err, binary.tag);
+    try std.testing.expectEqual(abi.HostFiles_read_textErr.not_utf8, binary.payload_err());
 
     const text = hostedFilesReadText(&roc_host, tmpPathString(&roc_host, &path_buffer, &tmp.sub_path, "text"));
-    try std.testing.expectEqual(@as(u8, 0), text.err);
-    try std.testing.expectEqualStrings("caf\u{e9}", text.contents.asSlice());
-    text.contents.decref(&roc_host);
+    try std.testing.expectEqual(abi.HostFiles_read_textResultTag.Ok, text.tag);
+    try std.testing.expectEqualStrings("caf\u{e9}", text.payload_ok().asSlice());
+    text.payload_ok().decref(&roc_host);
 
     // The empty file is text too, and the shortest way to get it wrong.
     const empty = hostedFilesReadText(&roc_host, tmpPathString(&roc_host, &path_buffer, &tmp.sub_path, "empty"));
-    try std.testing.expectEqual(@as(u8, 0), empty.err);
-    try std.testing.expectEqual(@as(usize, 0), empty.contents.asSlice().len);
-    empty.contents.decref(&roc_host);
+    try std.testing.expectEqual(abi.HostFiles_read_textResultTag.Ok, empty.tag);
+    try std.testing.expectEqual(@as(usize, 0), empty.payload_ok().asSlice().len);
+    empty.payload_ok().decref(&roc_host);
 }
 
 test "a read above the inline cap is refused rather than copied on the frame thread" {
@@ -11016,15 +11337,14 @@ test "a read above the inline cap is refused rather than copied on the frame thr
     var path_buffer: [capture.path_capacity]u8 = undefined;
 
     const fits = hostedFilesReadText(&roc_host, tmpPathString(&roc_host, &path_buffer, &tmp.sub_path, "at-limit"));
-    try std.testing.expectEqual(@as(u8, 0), fits.err);
-    try std.testing.expectEqual(MAX_INLINE_READ_BYTES, fits.contents.asSlice().len);
-    fits.contents.decref(&roc_host);
+    try std.testing.expectEqual(abi.HostFiles_read_textResultTag.Ok, fits.tag);
+    try std.testing.expectEqual(MAX_INLINE_READ_BYTES, fits.payload_ok().asSlice().len);
+    fits.payload_ok().decref(&roc_host);
 
     const refused = hostedFilesReadText(&roc_host, tmpPathString(&roc_host, &path_buffer, &tmp.sub_path, "over"));
-    try std.testing.expectEqual(READ_ERR_TOO_LARGE, refused.err);
-    // Nothing was copied: the answer carries an empty string.
-    try std.testing.expectEqual(@as(usize, 0), refused.contents.asSlice().len);
-    refused.contents.decref(&roc_host);
+    // Nothing was copied: the answer is the refusal alone, with no payload.
+    try std.testing.expectEqual(abi.HostFiles_read_textResultTag.Err, refused.tag);
+    try std.testing.expectEqual(abi.HostFiles_read_textErr.too_large, refused.payload_err());
 }
 
 /// A Roc-owned path string for a file `std.testing.tmpDir` created, resolved
@@ -11115,13 +11435,14 @@ test "the socket ceiling is a refusal an app can bind its way back out of" {
     var handles: [MAX_LIVE_UDP_SOCKETS]*u64 = undefined;
     for (&handles) |*handle| {
         const bound = hostedUdpBind(&roc_host, .{ .ip = abi.RocStr.fromSlice("127.0.0.1", &roc_host), .port = 0 });
-        try std.testing.expectEqual(@as(u8, 0), bound.err);
-        handle.* = bound.handle;
+        try std.testing.expectEqual(abi.HostUdp_bindResultTag.Ok, bound.tag);
+        handle.* = bound.payload_ok().handle.handle;
     }
     try std.testing.expectEqual(MAX_LIVE_UDP_SOCKETS, udp_socket_heap.active());
 
     const refused = hostedUdpBind(&roc_host, .{ .ip = abi.RocStr.fromSlice("127.0.0.1", &roc_host), .port = 0 });
-    try std.testing.expectEqual(udp_effect.ERR_RESOURCE_LIMIT, refused.err);
+    try std.testing.expectEqual(abi.HostUdp_bindResultTag.Err, refused.tag);
+    try std.testing.expectEqual(abi.HostUdp_bindErr.resource_limit, refused.payload_err());
     try std.testing.expectEqual(MAX_LIVE_UDP_SOCKETS, udp_socket_heap.active());
 
     // Release one. The slot is retired rather than free, so the next bind is
@@ -11129,8 +11450,8 @@ test "the socket ceiling is a refusal an app can bind its way back out of" {
     // fail if `insert` did not drain its own heap first.
     releaseResourceBox(&roc_host, handles[0]);
     const reused = hostedUdpBind(&roc_host, .{ .ip = abi.RocStr.fromSlice("127.0.0.1", &roc_host), .port = 0 });
-    try std.testing.expectEqual(@as(u8, 0), reused.err);
-    handles[0] = reused.handle;
+    try std.testing.expectEqual(abi.HostUdp_bindResultTag.Ok, reused.tag);
+    handles[0] = reused.payload_ok().handle.handle;
 
     for (handles) |handle| releaseResourceBox(&roc_host, handle);
     drainRetiredResourcesUpTo(std.math.maxInt(usize));
@@ -11145,7 +11466,8 @@ test "a bad address is refused before any descriptor is opened" {
 
     for ([_][]const u8{ "::1", "localhost", "999.0.0.1", "" }) |text| {
         const result = hostedUdpBind(&roc_host, .{ .ip = abi.RocStr.fromSlice(text, &roc_host), .port = 0 });
-        try std.testing.expectEqual(udp_effect.ERR_INVALID_ADDRESS, result.err);
+        try std.testing.expectEqual(abi.HostUdp_bindResultTag.Err, result.tag);
+        try std.testing.expectEqual(abi.HostUdp_bindErr.invalid_address, result.payload_err());
     }
     try std.testing.expectEqual(@as(usize, 0), udp_socket_heap.active());
 }
@@ -13285,25 +13607,25 @@ test "a stat reports what a path is, how big it is, and when it changed" {
 
     const file = statPathIn(tmp.dir, std.testing.io, "notes.txt");
     try std.testing.expectEqual(@as(u8, 0), file.err);
-    try std.testing.expectEqual(DIR_ENTRY_FILE, file.kind);
-    try std.testing.expectEqual(@as(u64, "twelve bytes".len), file.size_bytes);
+    try std.testing.expectEqual(DIR_ENTRY_FILE, file.found.kind);
+    try std.testing.expectEqual(@as(u64, "twelve bytes".len), file.found.size_bytes);
 
     // The modification time is wall-clock, so it is a plausible instant rather
     // than a counter starting at the app's own start. Anything after 2020 is
     // enough to catch a monotonic clock leaking in here by mistake.
-    try std.testing.expect(file.modified_seconds > 1_577_836_800);
-    try std.testing.expect(file.modified_nanosecond < 1_000_000_000);
+    try std.testing.expect(file.found.modified_seconds > 1_577_836_800);
+    try std.testing.expect(file.found.modified_nanosecond < 1_000_000_000);
 
     const dir = statPathIn(tmp.dir, std.testing.io, "assets");
     try std.testing.expectEqual(@as(u8, 0), dir.err);
-    try std.testing.expectEqual(DIR_ENTRY_DIR, dir.kind);
+    try std.testing.expectEqual(DIR_ENTRY_DIR, dir.found.kind);
 
     // A failed stat answers with the reason and zeroes, so an app cannot read
     // a size or a time out of an answer that has neither.
     const missing = statPathIn(tmp.dir, std.testing.io, "absent.txt");
     try std.testing.expectEqual(READ_ERR_NOT_FOUND, missing.err);
-    try std.testing.expectEqual(@as(u64, 0), missing.size_bytes);
-    try std.testing.expectEqual(@as(i64, 0), missing.modified_seconds);
+    try std.testing.expectEqual(@as(u64, 0), missing.found.size_bytes);
+    try std.testing.expectEqual(@as(i64, 0), missing.found.modified_seconds);
 }
 
 test "a stat rewrites a modification a hot-reload loop can compare" {
@@ -13317,9 +13639,9 @@ test "a stat rewrites a modification a hot-reload loop can compare" {
     try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "shader.fs", .data = "two but longer" });
     const after = statPathIn(tmp.dir, std.testing.io, "shader.fs");
 
-    try std.testing.expect(after.size_bytes > before.size_bytes);
-    const moved = after.modified_seconds > before.modified_seconds or
-        (after.modified_seconds == before.modified_seconds and after.modified_nanosecond >= before.modified_nanosecond);
+    try std.testing.expect(after.found.size_bytes > before.found.size_bytes);
+    const moved = after.found.modified_seconds > before.found.modified_seconds or
+        (after.found.modified_seconds == before.found.modified_seconds and after.found.modified_nanosecond >= before.found.modified_nanosecond);
     try std.testing.expect(moved);
 }
 
@@ -13623,11 +13945,11 @@ test "a screen readback answers with the snapshot's own pixels, top-down" {
     try installTestScreenSnapshot(4, 3);
 
     const read = hostedCapturePixelAt(&roc_host, .{ .source = screenReadbackSource(), .x = 2, .y = 1 });
-    try std.testing.expectEqual(capture.err_none, read.err);
-    try std.testing.expectEqual(@as(u8, 2), read.r);
-    try std.testing.expectEqual(@as(u8, 1), read.g);
-    try std.testing.expectEqual(@as(u8, 7), read.b);
-    try std.testing.expectEqual(@as(u8, 255), read.a);
+    try std.testing.expectEqual(abi.HostCapture_pixel_atResultTag.Ok, read.tag);
+    try std.testing.expectEqual(@as(u8, 2), read.payload_ok().r);
+    try std.testing.expectEqual(@as(u8, 1), read.payload_ok().g);
+    try std.testing.expectEqual(@as(u8, 7), read.payload_ok().b);
+    try std.testing.expectEqual(@as(u8, 255), read.payload_ok().a);
 
     // The region and the point agree at the same coordinates, and the bytes
     // come back row-major from the topmost requested row.
@@ -13638,19 +13960,19 @@ test "a screen readback answers with the snapshot's own pixels, top-down" {
         .width = 2,
         .height = 2,
     });
-    try std.testing.expectEqual(capture.err_none, region.err);
+    try std.testing.expectEqual(abi.HostCapture_read_regionResultTag.Ok, region.tag);
     try std.testing.expectEqualSlices(u8, &.{
         1, 1, 7, 255, 2, 1, 7, 255,
         1, 2, 7, 255, 2, 2, 7, 255,
-    }, region.bytes.items());
+    }, region.payload_ok().items());
 
     // The payload is handed over rather than copied, so it occupies a delivery
     // slot until the app drops it -- and releases the reservation either way.
-    try std.testing.expect(region.bytes.isSeamlessSlice());
+    try std.testing.expect(region.payload_ok().isSeamlessSlice());
     try std.testing.expectEqual(@as(usize, 1), file_bytes_heap.active());
     try std.testing.expectEqual(@as(usize, 0), file_bytes_delivery_reservations.count);
 
-    region.bytes.decref(&roc_host);
+    region.payload_ok().decref(&roc_host);
     drainRetiredResourcesUpTo(std.math.maxInt(usize));
     try std.testing.expectEqual(@as(usize, 0), file_bytes_heap.active());
 }
@@ -13678,8 +14000,8 @@ test "a readback outside its source is refused rather than clamped" {
             .x = point[0],
             .y = point[1],
         });
-        try std.testing.expectEqual(capture.err_region_out_of_bounds, read.err);
-        try std.testing.expectEqual(@as(u8, 0), read.a);
+        try std.testing.expectEqual(abi.HostCapture_pixel_atResultTag.Err, read.tag);
+        try std.testing.expectEqual(abi.HostCapture_pixel_atErr.region_out_of_bounds, read.payload_err());
     }
 
     for ([_]capture.Region{
@@ -13695,8 +14017,8 @@ test "a readback outside its source is refused rather than clamped" {
             .width = region.width,
             .height = region.height,
         });
-        try std.testing.expectEqual(capture.err_region_out_of_bounds, read.err);
-        try std.testing.expectEqual(@as(usize, 0), read.bytes.len());
+        try std.testing.expectEqual(abi.HostCapture_read_regionResultTag.Err, read.tag);
+        try std.testing.expectEqual(abi.HostCapture_read_regionErr.region_out_of_bounds, read.payload_err());
     }
 
     // A refused read leaves nothing behind: no delivery reservation, no slot,
@@ -13729,8 +14051,8 @@ test "a region past the readback cap never reaches a source" {
         .width = 8192,
         .height = 4097,
     });
-    try std.testing.expectEqual(capture.err_region_out_of_bounds, read.err);
-    try std.testing.expectEqual(@as(usize, 0), read.bytes.len());
+    try std.testing.expectEqual(abi.HostCapture_read_regionResultTag.Err, read.tag);
+    try std.testing.expectEqual(abi.HostCapture_read_regionErr.region_out_of_bounds, read.payload_err());
     try std.testing.expect(!screen_snapshot_requested);
 }
 
@@ -13753,7 +14075,8 @@ test "a screen readback with no presented frame is unavailable and arms the next
     // the first `update!`. There is no colour to invent, and the ask is what
     // makes the following frame keep one.
     const read = hostedCapturePixelAt(&roc_host, .{ .source = screenReadbackSource(), .x = 0, .y = 0 });
-    try std.testing.expectEqual(capture.err_unavailable, read.err);
+    try std.testing.expectEqual(abi.HostCapture_pixel_atResultTag.Err, read.tag);
+    try std.testing.expectEqual(abi.HostCapture_pixel_atErr.unavailable, read.payload_err());
     try std.testing.expect(screen_snapshot_requested);
 
     const region = hostedCaptureReadRegion(&roc_host, .{
@@ -13763,7 +14086,8 @@ test "a screen readback with no presented frame is unavailable and arms the next
         .width = 1,
         .height = 1,
     });
-    try std.testing.expectEqual(capture.err_unavailable, region.err);
+    try std.testing.expectEqual(abi.HostCapture_read_regionResultTag.Err, region.tag);
+    try std.testing.expectEqual(abi.HostCapture_read_regionErr.unavailable, region.payload_err());
     try std.testing.expectEqual(@as(usize, 0), file_bytes_delivery_reservations.count);
 }
 
@@ -13785,7 +14109,8 @@ test "a render-target readback reports what the handle resolves to" {
         .x = 0,
         .y = 0,
     });
-    try std.testing.expectEqual(capture.err_target_unavailable, stubbed.err);
+    try std.testing.expectEqual(abi.HostCapture_pixel_atResultTag.Err, stubbed.tag);
+    try std.testing.expectEqual(abi.HostCapture_pixel_atErr.target_unavailable, stubbed.payload_err());
 
     // A headless target holds nothing: every draw into it was a no-op, so
     // there is no pixel to report, exactly as there is no file to export.
@@ -13795,7 +14120,8 @@ test "a render-target readback reports what the handle resolves to" {
         .x = 0,
         .y = 0,
     });
-    try std.testing.expectEqual(capture.err_unavailable, headless.err);
+    try std.testing.expectEqual(abi.HostCapture_pixel_atResultTag.Err, headless.tag);
+    try std.testing.expectEqual(abi.HostCapture_pixel_atErr.unavailable, headless.payload_err());
 
     drainRetiredResourcesUpTo(std.math.maxInt(usize));
     try std.testing.expectEqual(@as(usize, 0), render_texture_heap.active());
@@ -13841,14 +14167,14 @@ test "a full byte-list heap refuses a region read before it reads any pixels" {
         .width = 2,
         .height = 2,
     });
-    try std.testing.expectEqual(capture.err_busy, refused.err);
-    try std.testing.expectEqual(@as(usize, 0), refused.bytes.len());
+    try std.testing.expectEqual(abi.HostCapture_read_regionResultTag.Err, refused.tag);
+    try std.testing.expectEqual(abi.HostCapture_read_regionErr.busy, refused.payload_err());
     try std.testing.expect(!screen_snapshot_requested);
     try std.testing.expectEqual(@as(usize, 0), file_bytes_delivery_reservations.count);
 
     // A single pixel needs no slot, so the same moment still answers it.
     const point = hostedCapturePixelAt(&roc_host, .{ .source = screenReadbackSource(), .x = 0, .y = 0 });
-    try std.testing.expectEqual(capture.err_none, point.err);
+    try std.testing.expectEqual(abi.HostCapture_pixel_atResultTag.Ok, point.tag);
 
     for (held) |item| item.decref(&roc_host);
     drainRetiredResourcesUpTo(std.math.maxInt(usize));
@@ -13886,7 +14212,7 @@ test "a pixel readback called from render! is rejected" {
         .width = 1,
         .height = 1,
     });
-    try std.testing.expectEqual(@as(usize, 0), region.bytes.len());
+    try std.testing.expectEqual(abi.HostCapture_read_regionResultTag.Err, region.tag);
     const region_violation = last_phase_violation orelse return error.OperationWasNotRejected;
     try std.testing.expectEqualStrings("Capture.read_region!", region_violation.operation);
     try std.testing.expect(region_violation.allowed.eql(during_update));

--- a/src/host_native.zig
+++ b/src/host_native.zig
@@ -1253,7 +1253,7 @@ fn writeFileWaitingIn(base: std.Io.Dir, io: std.Io, path: []const u8, bytes: []c
 }
 
 /// `Files.write_text!`: replace a file's contents with a UTF-8 string.
-fn hostedFilesWriteText(roc_host: *RocHost, path_arg: abi.RocStr, contents_arg: abi.RocStr) callconv(.c) u8 {
+fn hostedFilesWriteTextCode(roc_host: *RocHost, path_arg: abi.RocStr, contents_arg: abi.RocStr) u8 {
     enforcePhase("Files.write_text!", during_wait);
     var effect = EffectScope.begin("Files.write_text!", path_arg.asSlice().len +| contents_arg.asSlice().len);
     defer effect.end();
@@ -1264,12 +1264,38 @@ fn hostedFilesWriteText(roc_host: *RocHost, path_arg: abi.RocStr, contents_arg: 
     return result;
 }
 
-fn exportedFilesWriteText(path_arg: abi.RocStr, contents_arg: abi.RocStr) callconv(.c) u8 {
+/// Name a write code in `Files`' vocabulary.
+///
+/// A write fails for reasons a read cannot, so it has a union of its own; the
+/// codes it shares with a read are the same numbers, which is why they are
+/// read out of the same table.
+fn filesWriteResult(code: u8) abi.HostFiles_write_textResult {
+    const Result = abi.HostFiles_write_textResult;
+    const Union = abi.HostFiles_write_textErr;
+    return switch (code) {
+        0 => abiTryEmptyOk(Result),
+        READ_ERR_NOT_FOUND => abiTryErr(Result, Union.not_found),
+        READ_ERR_UNAVAILABLE => abiTryErr(Result, Union.unavailable),
+        WRITE_ERR_PERMISSION_DENIED => abiTryErr(Result, Union.permission_denied),
+        WRITE_ERR_NO_SPACE => abiTryErr(Result, Union.no_space),
+        else => abiTryErr(Result, Union.write_failed),
+    };
+}
+
+fn hostedFilesWriteText(roc_host: *RocHost, path_arg: abi.RocStr, contents_arg: abi.RocStr) callconv(.c) abi.HostFiles_write_textResult {
+    return filesWriteResult(hostedFilesWriteTextCode(roc_host, path_arg, contents_arg));
+}
+
+fn hostedFilesWriteBytes(roc_host: *RocHost, path_arg: abi.RocStr, bytes_arg: abi.RocListWith(u8, false)) callconv(.c) abi.HostFiles_write_bytesResult {
+    return filesWriteResult(hostedFilesWriteBytesCode(roc_host, path_arg, bytes_arg));
+}
+
+fn exportedFilesWriteText(path_arg: abi.RocStr, contents_arg: abi.RocStr) callconv(.c) abi.HostFiles_write_textResult {
     return hostedFilesWriteText(activeHost(), path_arg, contents_arg);
 }
 
 /// `Files.write_bytes!`: replace a file's contents with the app's bytes.
-fn hostedFilesWriteBytes(roc_host: *RocHost, path_arg: abi.RocStr, bytes_arg: abi.RocListWith(u8, false)) callconv(.c) u8 {
+fn hostedFilesWriteBytesCode(roc_host: *RocHost, path_arg: abi.RocStr, bytes_arg: abi.RocListWith(u8, false)) u8 {
     enforcePhase("Files.write_bytes!", during_wait);
     var effect = EffectScope.begin("Files.write_bytes!", path_arg.asSlice().len +| bytes_arg.items().len);
     defer effect.end();
@@ -1280,7 +1306,7 @@ fn hostedFilesWriteBytes(roc_host: *RocHost, path_arg: abi.RocStr, bytes_arg: ab
     return result;
 }
 
-fn exportedFilesWriteBytes(path_arg: abi.RocStr, bytes_arg: abi.RocListWith(u8, false)) callconv(.c) u8 {
+fn exportedFilesWriteBytes(path_arg: abi.RocStr, bytes_arg: abi.RocListWith(u8, false)) callconv(.c) abi.HostFiles_write_bytesResult {
     return hostedFilesWriteBytes(activeHost(), path_arg, bytes_arg);
 }
 
@@ -1344,7 +1370,18 @@ fn queueStreamWrite(stream: u8, head: []const u8, tail: []const u8) u8 {
 }
 
 /// `Stdout.write!` and `Stderr.write!`: the app's string, with nothing added.
-fn hostedStdioWriteText(roc_host: *RocHost, stream: u8, text_arg: abi.RocStr) callconv(.c) u8 {
+/// Name a queued-write code in `Stdout`'s and `Stderr`'s vocabulary.
+fn stdioWriteResult(comptime Result: type, code: u8) Result {
+    const Union = @typeInfo(@TypeOf(Result.payload_err)).@"fn".return_type.?;
+    return switch (code) {
+        stdio_effect.OK => abiTryEmptyOk(Result),
+        stdio_effect.ERR_TOO_LARGE => abiTryErr(Result, abiUnion(Union, .too_large)),
+        stdio_effect.ERR_BUFFER_FULL => abiTryErr(Result, abiUnion(Union, .buffer_full)),
+        else => abiTryErr(Result, abiUnion(Union, .unavailable)),
+    };
+}
+
+fn hostedStdioWriteTextCode(roc_host: *RocHost, stream: u8, text_arg: abi.RocStr) u8 {
     const name = if (stream == STDIO_STREAM_STDOUT) "Stdout.write!" else "Stderr.write!";
     enforcePhase(name, during_update);
     var effect = EffectScope.begin(name, text_arg.asSlice().len);
@@ -1355,7 +1392,11 @@ fn hostedStdioWriteText(roc_host: *RocHost, stream: u8, text_arg: abi.RocStr) ca
     return result;
 }
 
-fn exportedStdioWriteText(stream: u8, text_arg: abi.RocStr) callconv(.c) u8 {
+fn hostedStdioWriteText(roc_host: *RocHost, stream: u8, text_arg: abi.RocStr) callconv(.c) abi.HostStdio_write_textResult {
+    return stdioWriteResult(abi.HostStdio_write_textResult, hostedStdioWriteTextCode(roc_host, stream, text_arg));
+}
+
+fn exportedStdioWriteText(stream: u8, text_arg: abi.RocStr) callconv(.c) abi.HostStdio_write_textResult {
     return hostedStdioWriteText(activeHost(), stream, text_arg);
 }
 
@@ -1363,7 +1404,7 @@ fn exportedStdioWriteText(stream: u8, text_arg: abi.RocStr) callconv(.c) u8 {
 ///
 /// The newline is the host's byte rather than a copy of the app's string with
 /// one appended, so a line costs no allocation and is queued as one payload.
-fn hostedStdioWriteLine(roc_host: *RocHost, stream: u8, text_arg: abi.RocStr) callconv(.c) u8 {
+fn hostedStdioWriteLineCode(roc_host: *RocHost, stream: u8, text_arg: abi.RocStr) u8 {
     const name = if (stream == STDIO_STREAM_STDOUT) "Stdout.line!" else "Stderr.line!";
     enforcePhase(name, during_update);
     var effect = EffectScope.begin(name, text_arg.asSlice().len);
@@ -1374,12 +1415,16 @@ fn hostedStdioWriteLine(roc_host: *RocHost, stream: u8, text_arg: abi.RocStr) ca
     return result;
 }
 
-fn exportedStdioWriteLine(stream: u8, text_arg: abi.RocStr) callconv(.c) u8 {
+fn hostedStdioWriteLine(roc_host: *RocHost, stream: u8, text_arg: abi.RocStr) callconv(.c) abi.HostStdio_write_lineResult {
+    return stdioWriteResult(abi.HostStdio_write_lineResult, hostedStdioWriteLineCode(roc_host, stream, text_arg));
+}
+
+fn exportedStdioWriteLine(stream: u8, text_arg: abi.RocStr) callconv(.c) abi.HostStdio_write_lineResult {
     return hostedStdioWriteLine(activeHost(), stream, text_arg);
 }
 
 /// `Stdout.write_bytes!` and `Stderr.write_bytes!`: bytes, passed through.
-fn hostedStdioWriteBytes(roc_host: *RocHost, stream: u8, bytes_arg: abi.RocListWith(u8, false)) callconv(.c) u8 {
+fn hostedStdioWriteBytesCode(roc_host: *RocHost, stream: u8, bytes_arg: abi.RocListWith(u8, false)) u8 {
     const name = if (stream == STDIO_STREAM_STDOUT) "Stdout.write_bytes!" else "Stderr.write_bytes!";
     enforcePhase(name, during_update);
     var effect = EffectScope.begin(name, bytes_arg.items().len);
@@ -1390,7 +1435,11 @@ fn hostedStdioWriteBytes(roc_host: *RocHost, stream: u8, bytes_arg: abi.RocListW
     return result;
 }
 
-fn exportedStdioWriteBytes(stream: u8, bytes_arg: abi.RocListWith(u8, false)) callconv(.c) u8 {
+fn hostedStdioWriteBytes(roc_host: *RocHost, stream: u8, bytes_arg: abi.RocListWith(u8, false)) callconv(.c) abi.HostStdio_write_bytesResult {
+    return stdioWriteResult(abi.HostStdio_write_bytesResult, hostedStdioWriteBytesCode(roc_host, stream, bytes_arg));
+}
+
+fn exportedStdioWriteBytes(stream: u8, bytes_arg: abi.RocListWith(u8, false)) callconv(.c) abi.HostStdio_write_bytesResult {
     return hostedStdioWriteBytes(activeHost(), stream, bytes_arg);
 }
 
@@ -1405,7 +1454,47 @@ fn exportedStdioWriteBytes(stream: u8, bytes_arg: abi.RocListWith(u8, false)) ca
 /// A task is the only place this works: waiting for the end of a frame from
 /// `init!` would wait for a frame the frame loop has not started yet. See
 /// `during_frame_wait`.
-fn hostedCaptureScreenshot(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c) u8 {
+/// Name a capture code in one `Capture` effect's vocabulary.
+///
+/// The three writers share this because they share the code table; each
+/// union names only the failures its own effect can reach, and an arm it has
+/// no variant for is not compiled for it.
+fn captureWriteResult(comptime Result: type, code: u8) Result {
+    const Union = @typeInfo(@TypeOf(Result.payload_err)).@"fn".return_type.?;
+    if (code == capture.err_none) return abiTryEmptyOk(Result);
+    inline for (.{
+        .{ "path_invalid", capture.err_path_invalid },
+        .{ "path_escapes_output_dir", capture.err_path_escapes },
+        .{ "already_pending", capture.err_already_recording },
+        .{ "already_recording", capture.err_already_recording },
+        .{ "unsupported_format", capture.err_unsupported_format },
+        .{ "budget_exceeded", capture.err_budget_exceeded },
+        .{ "out_of_memory", capture.err_out_of_memory },
+        .{ "busy", capture.err_busy },
+        .{ "unavailable", capture.err_unavailable },
+        .{ "readback_failed", capture.err_readback_failed },
+        .{ "target_unavailable", capture.err_target_unavailable },
+    }) |named| {
+        if (comptime abiVariantName(Union, named[0]) != null) {
+            if (code == named[1]) return abiTryErr(Result, abiUnionNamed(Union, named[0]));
+        }
+    }
+    return abiTryErr(Result, abiUnionNamed(Union, "write_failed"));
+}
+
+fn hostedCaptureScreenshot(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c) abi.HostCapture_screenshotResult {
+    return captureWriteResult(abi.HostCapture_screenshotResult, hostedCaptureScreenshotCode(roc_host, path_arg));
+}
+
+fn hostedCaptureScreenshotTexture(roc_host: *RocHost, args: abi.HostCapture_screenshot_textureArgs) callconv(.c) abi.HostCapture_screenshot_textureResult {
+    return captureWriteResult(abi.HostCapture_screenshot_textureResult, hostedCaptureScreenshotTextureCode(roc_host, args));
+}
+
+fn hostedCaptureStartRecording(roc_host: *RocHost, args: abi.HostCapture_start_recordingArgs) callconv(.c) abi.HostCapture_start_recordingResult {
+    return captureWriteResult(abi.HostCapture_start_recordingResult, hostedCaptureStartRecordingCode(roc_host, args));
+}
+
+fn hostedCaptureScreenshotCode(roc_host: *RocHost, path_arg: abi.RocStr) u8 {
     enforcePhase("Capture.screenshot!", during_frame_wait);
     var effect = EffectScope.begin("Capture.screenshot!", path_arg.asSlice().len);
     defer effect.end();
@@ -1494,7 +1583,7 @@ fn encodeAndWritePng(
     return writeWholeFile(threaded.io(), path, encoded);
 }
 
-fn exportedCaptureScreenshot(path_arg: abi.RocStr) callconv(.c) u8 {
+fn exportedCaptureScreenshot(path_arg: abi.RocStr) callconv(.c) abi.HostCapture_screenshotResult {
     return hostedCaptureScreenshot(activeHost(), path_arg);
 }
 
@@ -1506,7 +1595,7 @@ fn exportedCaptureScreenshot(path_arg: abi.RocStr) callconv(.c) u8 {
 /// whatever the last completed `render!` left in the target. Only the encode
 /// and the write park, on zio's blocking pool, which is why `init!` is a legal
 /// place to call this and is not for `Capture.screenshot!`.
-fn hostedCaptureScreenshotTexture(roc_host: *RocHost, args: abi.HostCapture_screenshot_textureArgs) callconv(.c) u8 {
+fn hostedCaptureScreenshotTextureCode(roc_host: *RocHost, args: abi.HostCapture_screenshot_textureArgs) u8 {
     enforcePhase("Capture.screenshot_texture!", during_wait);
     var effect = EffectScope.begin("Capture.screenshot_texture!", 0);
     defer effect.end();
@@ -1602,7 +1691,7 @@ fn hostedCaptureScreenshotTexture(roc_host: *RocHost, args: abi.HostCapture_scre
     return blocking.join();
 }
 
-fn exportedCaptureScreenshotTexture(args: abi.HostCapture_screenshot_textureArgs) callconv(.c) u8 {
+fn exportedCaptureScreenshotTexture(args: abi.HostCapture_screenshot_textureArgs) callconv(.c) abi.HostCapture_screenshot_textureResult {
     return hostedCaptureScreenshotTexture(activeHost(), args);
 }
 
@@ -2231,7 +2320,7 @@ fn udpBindFailure(code: u8) abi.HostUdp_bindResult {
 /// straight at the non-blocking descriptor. That is what makes this legal in
 /// `update!` -- there is no park for the frame to pay for, and no window in
 /// which another task's Roc code could run in the middle of an update.
-fn hostedUdpSend(host: *RocHost, args: abi.HostUdp_sendArgs) callconv(.c) u8 {
+fn hostedUdpSendCode(host: *RocHost, args: abi.HostUdp_sendArgs) u8 {
     enforcePhase("Udp.send!", during_update);
     var effect = EffectScope.begin("Udp.send!", args.ip.asSlice().len +| args.bytes.items().len);
     defer effect.end();
@@ -2256,7 +2345,31 @@ fn hostedUdpSend(host: *RocHost, args: abi.HostUdp_sendArgs) callconv(.c) u8 {
     return result;
 }
 
-fn exportedUdpSend(args: abi.HostUdp_sendArgs) callconv(.c) u8 {
+/// Name a send code in `Udp`'s vocabulary.
+///
+/// `NoRoute` is what `Udp` exposes as `Unreachable`; the wire spells it
+/// differently because `roc glue` lowers a tag to a Zig enum member and
+/// `unreachable` is a Zig keyword.
+fn udpSendResult(code: u8) abi.HostUdp_sendResult {
+    const Result = abi.HostUdp_sendResult;
+    const Union = abi.HostUdp_sendErr;
+    return switch (code) {
+        0 => abiTryEmptyOk(Result),
+        udp_effect.ERR_UNAVAILABLE => abiTryErr(Result, Union.unavailable),
+        udp_effect.ERR_INVALID_ADDRESS => abiTryErr(Result, Union.invalid_address),
+        udp_effect.ERR_PERMISSION_DENIED => abiTryErr(Result, Union.permission_denied),
+        udp_effect.ERR_TOO_LARGE => abiTryErr(Result, Union.too_large),
+        udp_effect.ERR_WOULD_BLOCK => abiTryErr(Result, Union.would_block),
+        udp_effect.ERR_UNREACHABLE => abiTryErr(Result, Union.no_route),
+        else => abiTryErr(Result, Union.send_failed),
+    };
+}
+
+fn hostedUdpSend(host: *RocHost, args: abi.HostUdp_sendArgs) callconv(.c) abi.HostUdp_sendResult {
+    return udpSendResult(hostedUdpSendCode(host, args));
+}
+
+fn exportedUdpSend(args: abi.HostUdp_sendArgs) callconv(.c) abi.HostUdp_sendResult {
     return hostedUdpSend(activeHost(), args);
 }
 
@@ -4183,6 +4296,16 @@ fn abiTryEmptyOk(comptime Result: type) Result {
     return result;
 }
 
+/// A `Try` whose failure carries nothing.
+///
+/// A closed union with one payloadless variant erases to a zero-sized
+/// payload, so there is nothing to write but the tag.
+fn abiTryEmptyErr(comptime Result: type) Result {
+    var result: Result = std.mem.zeroes(Result);
+    result.tag = .Err;
+    return result;
+}
+
 /// One payloadless variant of a generated closed error union.
 ///
 /// A union whose variants all carry nothing is generated as a plain `enum`,
@@ -4772,8 +4895,8 @@ test "nested render and shader scopes lease last references until matching end" 
 
     const outer_target = storeRenderTexture(.headless).?;
     const inner_target = storeRenderTexture(.headless).?;
-    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginRenderTextureRaw(.{ .handle = outer_target, .height = 90, .width = 160 }));
-    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginRenderTextureRaw(.{ .handle = inner_target, .height = 45, .width = 80 }));
+    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginRenderTextureRawCode(.{ .handle = outer_target, .height = 90, .width = 160 }));
+    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginRenderTextureRawCode(.{ .handle = inner_target, .height = 45, .width = 80 }));
     drainRetiredResourcesUpTo(std.math.maxInt(usize));
     try std.testing.expectEqual(@as(usize, 2), render_texture_heap.active());
     try std.testing.expectEqual(@as(u8, 2), headless_render_texture_depth);
@@ -4787,8 +4910,8 @@ test "nested render and shader scopes lease last references until matching end" 
 
     const outer_shader = storeShader(.headless).?;
     const inner_shader = storeShader(.headless).?;
-    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginShaderRaw(.{ .handle = outer_shader }));
-    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginShaderRaw(.{ .handle = inner_shader }));
+    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginShaderRawCode(.{ .handle = outer_shader }));
+    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginShaderRawCode(.{ .handle = inner_shader }));
     drainRetiredResourcesUpTo(std.math.maxInt(usize));
     try std.testing.expectEqual(@as(usize, 2), shader_heap.active());
     try std.testing.expectEqual(@as(u8, 2), headless_shader_depth);
@@ -4800,12 +4923,12 @@ test "nested render and shader scopes lease last references until matching end" 
     try std.testing.expectEqual(@as(usize, 0), shader_heap.active());
     try std.testing.expectEqual(@as(u8, 0), headless_shader_depth);
 
-    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginBlendRaw(.{ .arg0 = 1 }));
+    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginBlendRawCode(.{ .arg0 = 1 }));
     try std.testing.expectEqual(@as(usize, 1), blend_scope_count);
     hostedDrawEndBlendRaw();
     try std.testing.expectEqual(@as(usize, 0), blend_scope_count);
 
-    try std.testing.expectEqual(SCOPE_UNAVAILABLE, hostedDrawBeginBlendRaw(.{ .arg0 = 6 }));
+    try std.testing.expectEqual(SCOPE_UNAVAILABLE, hostedDrawBeginBlendRawCode(.{ .arg0 = 6 }));
     try std.testing.expectEqual(@as(usize, 0), blend_scope_count);
 }
 
@@ -4822,8 +4945,8 @@ test "nested value scopes restore outer state and report bounded saturation" {
         .rotation = 15,
         .zoom = 0.5,
     };
-    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginCamera(outer_camera));
-    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginCamera(inner_camera));
+    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginCameraCode(outer_camera));
+    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginCameraCode(inner_camera));
     hostedDrawEndCamera();
     try std.testing.expectEqual(@as(usize, 1), camera_scope_count);
     try std.testing.expectEqual(outer_camera.zoom, camera_scopes[0].zoom);
@@ -4831,32 +4954,32 @@ test "nested value scopes restore outer state and report bounded saturation" {
 
     const outer_scissor = abi.HostDraw_begin_scissorArgs{ .x = 10, .y = 20, .width = 300, .height = 200 };
     const inner_scissor = abi.HostDraw_begin_scissorArgs{ .x = 30, .y = 40, .width = 50, .height = 60 };
-    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginScissorRaw(outer_scissor));
-    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginScissorRaw(inner_scissor));
+    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginScissorRawCode(outer_scissor));
+    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginScissorRawCode(inner_scissor));
     hostedDrawEndScissorRaw();
     try std.testing.expectEqual(@as(usize, 1), scissor_scope_count);
     try std.testing.expectEqual(outer_scissor.width, scissor_scopes[0].width);
     hostedDrawEndScissorRaw();
 
-    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginBlendRaw(.{ .arg0 = 2 }));
-    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginBlendRaw(.{ .arg0 = 1 }));
+    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginBlendRawCode(.{ .arg0 = 2 }));
+    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginBlendRawCode(.{ .arg0 = 1 }));
     hostedDrawEndBlendRaw();
     try std.testing.expectEqual(@as(usize, 1), blend_scope_count);
     try std.testing.expectEqual(@as(u8, 2), blend_scopes[0]);
     hostedDrawEndBlendRaw();
 
-    for (0..SCOPE_STACK_LIMIT) |_| try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginBlendRaw(.{ .arg0 = 0 }));
-    try std.testing.expectEqual(SCOPE_LIMIT, hostedDrawBeginBlendRaw(.{ .arg0 = 0 }));
+    for (0..SCOPE_STACK_LIMIT) |_| try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginBlendRawCode(.{ .arg0 = 0 }));
+    try std.testing.expectEqual(SCOPE_LIMIT, hostedDrawBeginBlendRawCode(.{ .arg0 = 0 }));
     for (0..SCOPE_STACK_LIMIT) |_| hostedDrawEndBlendRaw();
     try std.testing.expectEqual(@as(usize, 0), blend_scope_count);
 
-    for (0..SCOPE_STACK_LIMIT) |_| try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginCamera(outer_camera));
-    try std.testing.expectEqual(SCOPE_LIMIT, hostedDrawBeginCamera(inner_camera));
+    for (0..SCOPE_STACK_LIMIT) |_| try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginCameraCode(outer_camera));
+    try std.testing.expectEqual(SCOPE_LIMIT, hostedDrawBeginCameraCode(inner_camera));
     for (0..SCOPE_STACK_LIMIT) |_| hostedDrawEndCamera();
     try std.testing.expectEqual(@as(usize, 0), camera_scope_count);
 
-    for (0..SCOPE_STACK_LIMIT) |_| try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginScissorRaw(outer_scissor));
-    try std.testing.expectEqual(SCOPE_LIMIT, hostedDrawBeginScissorRaw(inner_scissor));
+    for (0..SCOPE_STACK_LIMIT) |_| try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginScissorRawCode(outer_scissor));
+    try std.testing.expectEqual(SCOPE_LIMIT, hostedDrawBeginScissorRawCode(inner_scissor));
     for (0..SCOPE_STACK_LIMIT) |_| hostedDrawEndScissorRaw();
     try std.testing.expectEqual(@as(usize, 0), scissor_scope_count);
 }
@@ -4901,12 +5024,12 @@ test "the frame reports the active render target, and the window again once it c
     const outer_target = storeRenderTexture(.headless).?;
     const inner_target = storeRenderTexture(.headless).?;
 
-    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginRenderTextureRaw(.{ .handle = outer_target, .height = 90, .width = 160 }));
+    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginRenderTextureRawCode(.{ .handle = outer_target, .height = 90, .width = 160 }));
     const outer_size = hostedDrawFrameSizeRaw();
     try std.testing.expectEqual(@as(f32, 160), outer_size.width);
     try std.testing.expectEqual(@as(f32, 90), outer_size.height);
 
-    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginRenderTextureRaw(.{ .handle = inner_target, .height = 45, .width = 80 }));
+    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginRenderTextureRawCode(.{ .handle = inner_target, .height = 45, .width = 80 }));
     const inner_size = hostedDrawFrameSizeRaw();
     try std.testing.expectEqual(@as(f32, 80), inner_size.width);
     try std.testing.expectEqual(@as(f32, 45), inner_size.height);
@@ -4938,8 +5061,8 @@ test "the frame reports the active render target, and the window again once it c
     // A refused scope draws nowhere new, so it must not report anywhere new.
     const saturating = storeRenderTexture(.headless).?;
     abi.increfBox(@ptrCast(saturating), SCOPE_STACK_LIMIT);
-    for (0..SCOPE_STACK_LIMIT) |_| try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginRenderTextureRaw(.{ .handle = saturating, .height = 16, .width = 16 }));
-    try std.testing.expectEqual(SCOPE_LIMIT, hostedDrawBeginRenderTextureRaw(.{ .handle = saturating, .height = 999, .width = 999 }));
+    for (0..SCOPE_STACK_LIMIT) |_| try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginRenderTextureRawCode(.{ .handle = saturating, .height = 16, .width = 16 }));
+    try std.testing.expectEqual(SCOPE_LIMIT, hostedDrawBeginRenderTextureRawCode(.{ .handle = saturating, .height = 999, .width = 999 }));
     const saturated = hostedDrawFrameSizeRaw();
     try std.testing.expectEqual(@as(f32, 16), saturated.width);
     try std.testing.expectEqual(@as(f32, 16), saturated.height);
@@ -4974,16 +5097,16 @@ test "resource scopes report bounded saturation without leaking transferred owne
 
     const target = storeRenderTexture(.headless).?;
     abi.increfBox(@ptrCast(target), SCOPE_STACK_LIMIT);
-    for (0..SCOPE_STACK_LIMIT) |_| try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginRenderTextureRaw(.{ .handle = target, .height = 16, .width = 16 }));
-    try std.testing.expectEqual(SCOPE_LIMIT, hostedDrawBeginRenderTextureRaw(.{ .handle = target, .height = 16, .width = 16 }));
+    for (0..SCOPE_STACK_LIMIT) |_| try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginRenderTextureRawCode(.{ .handle = target, .height = 16, .width = 16 }));
+    try std.testing.expectEqual(SCOPE_LIMIT, hostedDrawBeginRenderTextureRawCode(.{ .handle = target, .height = 16, .width = 16 }));
     for (0..SCOPE_STACK_LIMIT) |_| hostedDrawEndRenderTextureRaw();
     drainRetiredResourcesUpTo(std.math.maxInt(usize));
     try std.testing.expectEqual(@as(usize, 0), render_texture_heap.active());
 
     const shader = storeShader(.headless).?;
     abi.increfBox(@ptrCast(shader), SCOPE_STACK_LIMIT);
-    for (0..SCOPE_STACK_LIMIT) |_| try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginShaderRaw(.{ .handle = shader }));
-    try std.testing.expectEqual(SCOPE_LIMIT, hostedDrawBeginShaderRaw(.{ .handle = shader }));
+    for (0..SCOPE_STACK_LIMIT) |_| try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginShaderRawCode(.{ .handle = shader }));
+    try std.testing.expectEqual(SCOPE_LIMIT, hostedDrawBeginShaderRawCode(.{ .handle = shader }));
     for (0..SCOPE_STACK_LIMIT) |_| hostedDrawEndShaderRaw();
     drainRetiredResourcesUpTo(std.math.maxInt(usize));
     try std.testing.expectEqual(@as(usize, 0), shader_heap.active());
@@ -5005,11 +5128,11 @@ test "scope kind confusion fails and releases transferred owners" {
     }
 
     const shader = storeShader(.headless).?;
-    try std.testing.expectEqual(SCOPE_UNAVAILABLE, hostedDrawBeginRenderTextureRaw(.{ .handle = @ptrCast(shader), .height = 16, .width = 16 }));
+    try std.testing.expectEqual(SCOPE_UNAVAILABLE, hostedDrawBeginRenderTextureRawCode(.{ .handle = @ptrCast(shader), .height = 16, .width = 16 }));
     drainRetiredResourcesUpTo(std.math.maxInt(usize));
     try std.testing.expectEqual(@as(usize, 0), shader_heap.active());
     const target = storeRenderTexture(.headless).?;
-    try std.testing.expectEqual(SCOPE_UNAVAILABLE, hostedDrawBeginShaderRaw(.{ .handle = @ptrCast(target) }));
+    try std.testing.expectEqual(SCOPE_UNAVAILABLE, hostedDrawBeginShaderRawCode(.{ .handle = @ptrCast(target) }));
     drainRetiredResourcesUpTo(std.math.maxInt(usize));
     try std.testing.expectEqual(@as(usize, 0), render_texture_heap.active());
 }
@@ -5195,13 +5318,13 @@ test "resource-free texture is safe across hosted operations and ordinary deallo
         hostedTextureSetFilterRaw(allocateTestTextureStub(&roc_host, 16, 8), 1);
         hostedTextureSetWrapRaw(allocateTestTextureStub(&roc_host, 16, 8), 1);
 
-        const whole_err = hostedTextureUpdateRaw(&roc_host, .{
+        const whole_err = hostedTextureUpdateRawCode(&roc_host, .{
             .pixels = abi.RocListWith(Color, false).empty(),
             .texture = allocateTestTextureStub(&roc_host, 16, 8),
         });
         try std.testing.expectEqual(TEXTURE_UPDATE_NOT_MUTABLE, whole_err);
 
-        const region_err = hostedTextureUpdateRegionRaw(&roc_host, .{
+        const region_err = hostedTextureUpdateRegionRawCode(&roc_host, .{
             .pixels = abi.RocListWith(Color, false).empty(),
             .texture = allocateTestTextureStub(&roc_host, 16, 8),
             .height = 1,
@@ -5293,7 +5416,7 @@ test "resource-free draw handles are inert, and leave real resources alone" {
         try std.testing.expectEqual(@as(usize, 0), prepared_text_heap.active());
 
         // A uniform cannot be resolved on a stub shader.
-        try std.testing.expectEqual(@as(i32, -1), hostedShaderLocationRaw(&roc_host, .{
+        try std.testing.expectEqual(@as(i32, -1), hostedShaderLocationRawCode(&roc_host, .{
             .shader = .{ .handle = allocateTestResourceStub(&roc_host) },
             .name = abi.RocStr.fromSlice("uTime", &roc_host),
         }));
@@ -5333,9 +5456,9 @@ test "resource-free draw handles are inert, and leave real resources alone" {
 
         // A scope cannot be opened on a stub, and reports the same refusal a
         // released resource would. Nothing is leased, so there is no end call.
-        try std.testing.expectEqual(SCOPE_UNAVAILABLE, hostedDrawBeginShaderRaw(.{ .handle = allocateTestResourceStub(&roc_host) }));
+        try std.testing.expectEqual(SCOPE_UNAVAILABLE, hostedDrawBeginShaderRawCode(.{ .handle = allocateTestResourceStub(&roc_host) }));
         try std.testing.expectEqual(@as(usize, 0), shader_lease_count);
-        try std.testing.expectEqual(SCOPE_UNAVAILABLE, hostedDrawBeginRenderTextureRaw(.{
+        try std.testing.expectEqual(SCOPE_UNAVAILABLE, hostedDrawBeginRenderTextureRawCode(.{
             .handle = allocateTestResourceStub(&roc_host),
             .height = 90,
             .width = 160,
@@ -5357,14 +5480,14 @@ test "resource-free draw handles are inert, and leave real resources alone" {
         // the reference each call was given.
         for (0..3) |_| {
             abi.increfBox(@ptrCast(real_shader), 1);
-            try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginShaderRaw(.{ .handle = real_shader }));
+            try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginShaderRawCode(.{ .handle = real_shader }));
         }
         try std.testing.expectEqual(@as(u8, 3), headless_shader_depth);
         for (0..3) |_| hostedDrawEndShaderRaw();
         try std.testing.expectEqual(@as(u8, 0), headless_shader_depth);
 
         abi.increfBox(@ptrCast(real_target), 1);
-        try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginRenderTextureRaw(.{ .handle = real_target, .height = 90, .width = 160 }));
+        try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginRenderTextureRawCode(.{ .handle = real_target, .height = 90, .width = 160 }));
         hostedDrawEndRenderTextureRaw();
     }
 
@@ -5672,7 +5795,7 @@ test "render target textures report not mutable and release ownership" {
     }
 
     const target = storeRenderTexture(.headless).?;
-    const err = hostedTextureUpdateRaw(&roc_host, .{
+    const err = hostedTextureUpdateRawCode(&roc_host, .{
         .pixels = abi.RocListWith(Color, false).empty(),
         .texture = .{ .handle = target, .height = 4, .width = 4 },
     });
@@ -5923,7 +6046,7 @@ test "a structurally valid texture upload is not refused for host capacity" {
     defer std.testing.allocator.free(pixels);
     @memset(pixels, .{ .r = 1, .g = 2, .b = 3, .a = 255 });
     const handle = storeTexture(.{ .headless = .{ .width = width, .height = height } }).?;
-    const result = hostedTextureUpdateRaw(&roc_host, .{
+    const result = hostedTextureUpdateRawCode(&roc_host, .{
         .pixels = abi.RocListWith(Color, false).fromSlice(pixels, &roc_host),
         .texture = .{ .handle = handle, .height = @floatFromInt(height), .width = @floatFromInt(width) },
     });
@@ -5952,14 +6075,14 @@ test "texture updates validate native dimensions instead of public metadata" {
 
     const pixels = [_]Color{.{ .r = 1, .g = 2, .b = 3, .a = 255 }} ** 6;
     const whole_handle = storeTexture(.{ .headless = .{ .width = 2, .height = 3 } }).?;
-    const whole_err = hostedTextureUpdateRaw(&roc_host, .{
+    const whole_err = hostedTextureUpdateRawCode(&roc_host, .{
         .pixels = abi.RocListWith(Color, false).fromSlice(&pixels, &roc_host),
         .texture = .{ .handle = whole_handle, .height = 99, .width = 99 },
     });
     try std.testing.expectEqual(TEXTURE_UPDATE_OK, whole_err);
 
     const region_handle = storeTexture(.{ .headless = .{ .width = 2, .height = 3 } }).?;
-    const region_err = hostedTextureUpdateRegionRaw(&roc_host, .{
+    const region_err = hostedTextureUpdateRegionRawCode(&roc_host, .{
         .pixels = abi.RocListWith(Color, false).fromSlice(pixels[0..2], &roc_host),
         .texture = .{ .handle = region_handle, .height = 99, .width = 99 },
         .height = 1,
@@ -6639,7 +6762,7 @@ fn hostedTextureGenerateCheckedRaw(args: abi.HostTexture_generate_checkedArgs) c
     return abiTryOk(Result, abi.Texture{ .handle = stored, .height = raylib.textureHeight(texture), .width = raylib.textureWidth(texture) });
 }
 
-fn hostedTextureUpdateRaw(host: *RocHost, args: abi.HostTexture_updateArgs) callconv(.c) u8 {
+fn hostedTextureUpdateRawCode(host: *RocHost, args: abi.HostTexture_updateArgs) u8 {
     enforcePhase("Assets.update_texture!", during_update);
     var effect = EffectScope.begin("Assets.update_texture!", drawByteCount(abi.ColorRgba, args.pixels.items().len));
     defer effect.end();
@@ -6667,7 +6790,7 @@ fn hostedTextureUpdateRaw(host: *RocHost, args: abi.HostTexture_updateArgs) call
 /// one pixel of an atlas means re-uploading the atlas. The call carries its
 /// complete payload, so a structurally valid upload is performed rather than
 /// silently refused for transient host capacity.
-fn hostedTextureUpdateRegionRaw(host: *RocHost, args: abi.HostTexture_update_regionArgs) callconv(.c) u8 {
+fn hostedTextureUpdateRegionRawCode(host: *RocHost, args: abi.HostTexture_update_regionArgs) u8 {
     enforcePhase("Assets.update_texture_region!", during_update);
     var effect = EffectScope.begin("Assets.update_texture_region!", drawByteCount(abi.ColorRgba, args.pixels.items().len));
     defer effect.end();
@@ -6704,11 +6827,45 @@ fn hostedTextureUpdateRegionRaw(host: *RocHost, args: abi.HostTexture_update_reg
     return TEXTURE_UPDATE_OK;
 }
 
-fn exportedTextureUpdateRaw(args: abi.HostTexture_updateArgs) callconv(.c) u8 {
+/// Name a whole-texture upload code in `Assets`' vocabulary.
+///
+/// A whole-texture upload covers the texture by definition, so its union has
+/// no out-of-bounds variant to reach.
+fn textureUpdateResult(code: u8) abi.HostTexture_updateResult {
+    const Result = abi.HostTexture_updateResult;
+    const Union = abi.HostTexture_updateErr;
+    return switch (code) {
+        TEXTURE_UPDATE_OK => abiTryEmptyOk(Result),
+        TEXTURE_UPDATE_NOT_MUTABLE => abiTryErr(Result, Union.not_mutable),
+        else => abiTryErr(Result, Union.pixel_count_mismatch),
+    };
+}
+
+/// Name a region upload code in `Assets`' vocabulary.
+fn textureUpdateRegionResult(code: u8) abi.HostTexture_update_regionResult {
+    const Result = abi.HostTexture_update_regionResult;
+    const Union = abi.HostTexture_update_regionErr;
+    return switch (code) {
+        TEXTURE_UPDATE_OK => abiTryEmptyOk(Result),
+        TEXTURE_UPDATE_NOT_MUTABLE => abiTryErr(Result, Union.not_mutable),
+        TEXTURE_UPDATE_OUT_OF_BOUNDS => abiTryErr(Result, Union.region_out_of_bounds),
+        else => abiTryErr(Result, Union.pixel_count_mismatch),
+    };
+}
+
+fn hostedTextureUpdateRaw(host: *RocHost, args: abi.HostTexture_updateArgs) callconv(.c) abi.HostTexture_updateResult {
+    return textureUpdateResult(hostedTextureUpdateRawCode(host, args));
+}
+
+fn hostedTextureUpdateRegionRaw(host: *RocHost, args: abi.HostTexture_update_regionArgs) callconv(.c) abi.HostTexture_update_regionResult {
+    return textureUpdateRegionResult(hostedTextureUpdateRegionRawCode(host, args));
+}
+
+fn exportedTextureUpdateRaw(args: abi.HostTexture_updateArgs) callconv(.c) abi.HostTexture_updateResult {
     return hostedTextureUpdateRaw(activeHost(), args);
 }
 
-fn exportedTextureUpdateRegionRaw(args: abi.HostTexture_update_regionArgs) callconv(.c) u8 {
+fn exportedTextureUpdateRegionRaw(args: abi.HostTexture_update_regionArgs) callconv(.c) abi.HostTexture_update_regionResult {
     return hostedTextureUpdateRegionRaw(activeHost(), args);
 }
 
@@ -6871,7 +7028,21 @@ fn nativeTextureForToken(token: u64) ?raylib.Texture {
     return null;
 }
 
-fn hostedDrawBeginRenderTextureRaw(args: abi.HostDraw_begin_render_textureArgs) callconv(.c) u8 {
+/// Name a scope code in `Draw`'s vocabulary.
+///
+/// Every `with_*!` scope shares one union: the two that cannot report
+/// `ScopeUnavailable` simply never reach that arm, and say so where they are
+/// used rather than by having a union of their own.
+fn drawScopeResult(comptime Result: type, code: u8) Result {
+    const Union = @typeInfo(@TypeOf(Result.payload_err)).@"fn".return_type.?;
+    return switch (code) {
+        SCOPE_OK => abiTryEmptyOk(Result),
+        SCOPE_LIMIT => abiTryErr(Result, abiUnion(Union, .scope_limit)),
+        else => abiTryErr(Result, abiUnion(Union, .scope_unavailable)),
+    };
+}
+
+fn hostedDrawBeginRenderTextureRawCode(args: abi.HostDraw_begin_render_textureArgs) u8 {
     enforcePhase("Draw.with_render_texture!", during_render);
     const effect = EffectScope.begin("Draw.with_render_texture!", 0);
     defer effect.end();
@@ -6893,6 +7064,10 @@ fn hostedDrawBeginRenderTextureRaw(args: abi.HostDraw_begin_render_textureArgs) 
     render_target_sizes[render_texture_lease_count] = .{ .height = args.height, .width = args.width };
     render_texture_lease_count += 1;
     return SCOPE_OK;
+}
+
+fn hostedDrawBeginRenderTextureRaw(args: abi.HostDraw_begin_render_textureArgs) callconv(.c) abi.HostDraw_begin_render_textureResult {
+    return drawScopeResult(abi.HostDraw_begin_render_textureResult, hostedDrawBeginRenderTextureRawCode(args));
 }
 
 fn hostedDrawEndRenderTextureRaw() callconv(.c) void {
@@ -6930,7 +7105,7 @@ fn hostedDrawFrameSizeRaw() callconv(.c) abi.HostDraw_frame_size {
     return .{ .height = @floatFromInt(window.size.height), .width = @floatFromInt(window.size.width) };
 }
 
-fn hostedDrawBeginShaderRaw(args: abi.HostDraw_begin_shaderArgs) callconv(.c) u8 {
+fn hostedDrawBeginShaderRawCode(args: abi.HostDraw_begin_shaderArgs) u8 {
     enforcePhase("Draw.with_shader!", during_render);
     const effect = EffectScope.begin("Draw.with_shader!", 0);
     defer effect.end();
@@ -6953,6 +7128,10 @@ fn hostedDrawBeginShaderRaw(args: abi.HostDraw_begin_shaderArgs) callconv(.c) u8
     return SCOPE_OK;
 }
 
+fn hostedDrawBeginShaderRaw(args: abi.HostDraw_begin_shaderArgs) callconv(.c) abi.HostDraw_begin_shaderResult {
+    return drawScopeResult(abi.HostDraw_begin_shaderResult, hostedDrawBeginShaderRawCode(args));
+}
+
 fn hostedDrawEndShaderRaw() callconv(.c) void {
     enforcePhase("Draw.with_shader!", during_render);
     const effect = EffectScope.begin("Draw.with_shader!", 0);
@@ -6969,7 +7148,7 @@ fn hostedDrawEndShaderRaw() callconv(.c) void {
     releaseResourceBox(activeHost(), owner);
 }
 
-fn hostedDrawBeginBlendRaw(args: abi.HostDraw_begin_blendArgs) callconv(.c) u8 {
+fn hostedDrawBeginBlendRawCode(args: abi.HostDraw_begin_blendArgs) u8 {
     enforcePhase("Draw.with_blend_mode!", during_render);
     const effect = EffectScope.begin("Draw.with_blend_mode!", 0);
     defer effect.end();
@@ -6979,6 +7158,10 @@ fn hostedDrawBeginBlendRaw(args: abi.HostDraw_begin_blendArgs) callconv(.c) u8 {
     blend_scopes[blend_scope_count] = args.arg0;
     blend_scope_count += 1;
     return SCOPE_OK;
+}
+
+fn hostedDrawBeginBlendRaw(args: abi.HostDraw_begin_blendArgs) callconv(.c) abi.HostDraw_begin_blendResult {
+    return drawScopeResult(abi.HostDraw_begin_blendResult, hostedDrawBeginBlendRawCode(args));
 }
 
 fn hostedDrawEndBlendRaw() callconv(.c) void {
@@ -6991,7 +7174,7 @@ fn hostedDrawEndBlendRaw() callconv(.c) void {
     if (!headlessMode() and blend_scope_count > 0) raylib.beginBlendMode(blend_scopes[blend_scope_count - 1]);
 }
 
-fn hostedShaderLocationRaw(host: *RocHost, args: abi.HostShader_locationArgs) callconv(.c) i32 {
+fn hostedShaderLocationRawCode(host: *RocHost, args: abi.HostShader_locationArgs) i32 {
     enforcePhase("Draw.Shader.uniform_*!", during_load);
     const effect = EffectScope.begin("Draw.Shader.uniform_*!", args.name.asSlice().len);
     defer effect.end();
@@ -7012,7 +7195,15 @@ fn hostedShaderLocationRaw(host: *RocHost, args: abi.HostShader_locationArgs) ca
     }
 }
 
-fn exportedShaderLocationRaw(args: abi.HostShader_locationArgs) callconv(.c) i32 {
+/// A uniform raylib could not find is a refusal rather than a negative index.
+fn hostedShaderLocationRaw(host: *RocHost, args: abi.HostShader_locationArgs) callconv(.c) abi.HostShader_locationResult {
+    const Result = abi.HostShader_locationResult;
+    const location = hostedShaderLocationRawCode(host, args);
+    if (location < 0) return abiTryEmptyErr(Result);
+    return abiTryOk(Result, location);
+}
+
+fn exportedShaderLocationRaw(args: abi.HostShader_locationArgs) callconv(.c) abi.HostShader_locationResult {
     return hostedShaderLocationRaw(activeHost(), args);
 }
 
@@ -7090,7 +7281,7 @@ fn hostedShaderSetTextureRaw(args: abi.HostShader_set_textureArgs) callconv(.c) 
 }
 
 /// Forward Roc scissor bounds to the raylib backend.
-fn hostedDrawBeginScissorRaw(args: abi.HostDraw_begin_scissorArgs) callconv(.c) u8 {
+fn hostedDrawBeginScissorRawCode(args: abi.HostDraw_begin_scissorArgs) u8 {
     enforcePhase("Draw.with_scissor!", during_render);
     const effect = EffectScope.begin("Draw.with_scissor!", 0);
     defer effect.end();
@@ -7099,6 +7290,10 @@ fn hostedDrawBeginScissorRaw(args: abi.HostDraw_begin_scissorArgs) callconv(.c) 
     scissor_scopes[scissor_scope_count] = args;
     scissor_scope_count += 1;
     return SCOPE_OK;
+}
+
+fn hostedDrawBeginScissorRaw(args: abi.HostDraw_begin_scissorArgs) callconv(.c) abi.HostDraw_begin_scissorResult {
+    return drawScopeResult(abi.HostDraw_begin_scissorResult, hostedDrawBeginScissorRawCode(args));
 }
 
 /// End the scissor region opened by the Roc renderer.
@@ -7115,7 +7310,7 @@ fn hostedDrawEndScissorRaw() callconv(.c) void {
     }
 }
 
-fn hostedDrawBeginCamera(args: abi.HostDraw_begin_cameraArgs) callconv(.c) u8 {
+fn hostedDrawBeginCameraCode(args: abi.HostDraw_begin_cameraArgs) u8 {
     enforcePhase("Draw.with_camera!", during_render);
     const effect = EffectScope.begin("Draw.with_camera!", 0);
     defer effect.end();
@@ -7124,6 +7319,10 @@ fn hostedDrawBeginCamera(args: abi.HostDraw_begin_cameraArgs) callconv(.c) u8 {
     camera_scopes[camera_scope_count] = args;
     camera_scope_count += 1;
     return SCOPE_OK;
+}
+
+fn hostedDrawBeginCamera(args: abi.HostDraw_begin_cameraArgs) callconv(.c) abi.HostDraw_begin_cameraResult {
+    return drawScopeResult(abi.HostDraw_begin_cameraResult, hostedDrawBeginCameraCode(args));
 }
 
 fn hostedDrawCircleRaw(args: abi.HostDraw_circleArgs) callconv(.c) void {
@@ -8179,7 +8378,7 @@ fn framePathForIndex(buffer: []u8, path: []const u8, index: u64) ?[]const u8 {
 ///
 /// Refusals are latched in the session for the next `input.capture`. The return
 /// code preserves the hosted ABI and supports direct tests.
-fn hostedCaptureStartRecording(roc_host: *RocHost, args: abi.HostCapture_start_recordingArgs) callconv(.c) u8 {
+fn hostedCaptureStartRecordingCode(roc_host: *RocHost, args: abi.HostCapture_start_recordingArgs) u8 {
     enforcePhase("Capture.start!", during_update);
     const effect = EffectScope.begin("Capture.start!", 0);
     defer effect.end();
@@ -8200,7 +8399,7 @@ fn hostedCaptureStartRecording(roc_host: *RocHost, args: abi.HostCapture_start_r
     return result;
 }
 
-fn exportedCaptureStartRecording(args: abi.HostCapture_start_recordingArgs) callconv(.c) u8 {
+fn exportedCaptureStartRecording(args: abi.HostCapture_start_recordingArgs) callconv(.c) abi.HostCapture_start_recordingResult {
     return hostedCaptureStartRecording(activeHost(), args);
 }
 
@@ -11756,7 +11955,7 @@ test "a screenshot path that escapes the output directory is refused, not rewrit
 
     try std.testing.expectEqual(
         capture.err_path_escapes,
-        hostedCaptureScreenshot(&roc_host, abi.RocStr.fromSlice("../escaped.png", &roc_host)),
+        hostedCaptureScreenshotCode(&roc_host, abi.RocStr.fromSlice("../escaped.png", &roc_host)),
     );
 
     // A valid path gets past the sandbox. Tests run headless, where there is
@@ -11764,7 +11963,7 @@ test "a screenshot path that escapes the output directory is refused, not rewrit
     // zeroes rather than parking for a frame that cannot arrive.
     try std.testing.expectEqual(
         capture.err_none,
-        hostedCaptureScreenshot(&roc_host, abi.RocStr.fromSlice("scene.png", &roc_host)),
+        hostedCaptureScreenshotCode(&roc_host, abi.RocStr.fromSlice("scene.png", &roc_host)),
     );
 }
 
@@ -11784,7 +11983,7 @@ test "an offscreen export refuses an escaping path and releases the target eithe
     const target = storeRenderTexture(.headless).?;
     abi.increfBox(@ptrCast(target), 1);
 
-    try std.testing.expectEqual(capture.err_path_escapes, hostedCaptureScreenshotTexture(&roc_host, .{
+    try std.testing.expectEqual(capture.err_path_escapes, hostedCaptureScreenshotTextureCode(&roc_host, .{
         .path = abi.RocStr.fromSlice("../escaped.png", &roc_host),
         .target = .{ .handle = target, .height = 8, .width = 16 },
     }));
@@ -11792,7 +11991,7 @@ test "an offscreen export refuses an escaping path and releases the target eithe
     // A headless target has no pixels: every draw into it was a no-op, so the
     // export answers without writing a file of zeroes, exactly as a screenshot
     // does with no framebuffer.
-    try std.testing.expectEqual(capture.err_none, hostedCaptureScreenshotTexture(&roc_host, .{
+    try std.testing.expectEqual(capture.err_none, hostedCaptureScreenshotTextureCode(&roc_host, .{
         .path = abi.RocStr.fromSlice("poster.png", &roc_host),
         .target = .{ .handle = target, .height = 8, .width = 16 },
     }));
@@ -11816,13 +12015,13 @@ test "an offscreen export of a handle that resolves to nothing is unavailable" {
         active_roc_host = null;
     }
 
-    try std.testing.expectEqual(capture.err_target_unavailable, hostedCaptureScreenshotTexture(&roc_host, .{
+    try std.testing.expectEqual(capture.err_target_unavailable, hostedCaptureScreenshotTextureCode(&roc_host, .{
         .path = abi.RocStr.fromSlice("poster.png", &roc_host),
         .target = .{ .handle = &invalid_texture_box.payload, .height = 0, .width = 0 },
     }));
 
     const shader = storeShader(.headless).?;
-    try std.testing.expectEqual(capture.err_target_unavailable, hostedCaptureScreenshotTexture(&roc_host, .{
+    try std.testing.expectEqual(capture.err_target_unavailable, hostedCaptureScreenshotTextureCode(&roc_host, .{
         .path = abi.RocStr.fromSlice("poster.png", &roc_host),
         .target = .{ .handle = @ptrCast(shader), .height = 8, .width = 16 },
     }));
@@ -11848,7 +12047,7 @@ test "an offscreen export called from update! is rejected" {
     }
 
     const target = storeRenderTexture(.headless).?;
-    _ = hostedCaptureScreenshotTexture(&roc_host, .{
+    _ = hostedCaptureScreenshotTextureCode(&roc_host, .{
         .path = abi.RocStr.fromSlice("poster.png", &roc_host),
         .target = .{ .handle = target, .height = 8, .width = 16 },
     });
@@ -11980,7 +12179,7 @@ test "a drawing primitive called from update is rejected" {
     defer last_phase_violation = null;
     defer blend_scope_count = 0;
 
-    _ = hostedDrawBeginBlendRaw(.{ .arg0 = 1 });
+    _ = hostedDrawBeginBlendRawCode(.{ .arg0 = 1 });
 
     const violation = last_phase_violation orelse return error.OperationWasNotRejected;
     try std.testing.expectEqualStrings("Draw.with_blend_mode!", violation.operation);
@@ -12244,7 +12443,7 @@ test "an operation called from its own phase is not rejected" {
     defer last_phase_violation = null;
     defer blend_scope_count = 0;
 
-    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginBlendRaw(.{ .arg0 = 1 }));
+    try std.testing.expectEqual(SCOPE_OK, hostedDrawBeginBlendRawCode(.{ .arg0 = 1 }));
     hostedDrawEndBlendRaw();
     try std.testing.expect(last_phase_violation == null);
 }
@@ -13768,14 +13967,14 @@ test "a stream payload past the whole queue is refused and still releases the st
     // this test if the early return skips it.
     try std.testing.expectEqual(
         stdio_effect.ERR_TOO_LARGE,
-        hostedStdioWriteText(&roc_host, STDIO_STREAM_STDOUT, abi.RocStr.fromSlice(oversized, &roc_host)),
+        hostedStdioWriteTextCode(&roc_host, STDIO_STREAM_STDOUT, abi.RocStr.fromSlice(oversized, &roc_host)),
     );
 
     // A line queues the newline with its text, so the longest string a line
     // can carry is one byte shorter than the longest `write!` can.
     try std.testing.expectEqual(
         stdio_effect.ERR_TOO_LARGE,
-        hostedStdioWriteLine(&roc_host, STDIO_STREAM_STDOUT, abi.RocStr.fromSlice(oversized[0..stdio_effect.ring_capacity], &roc_host)),
+        hostedStdioWriteLineCode(&roc_host, STDIO_STREAM_STDOUT, abi.RocStr.fromSlice(oversized[0..stdio_effect.ring_capacity], &roc_host)),
     );
 }
 
@@ -13818,7 +14017,7 @@ test "a queued write with no drainer running is unavailable" {
     // drain is refused rather than accepted and forgotten.
     try std.testing.expectEqual(
         stdio_effect.ERR_UNAVAILABLE,
-        hostedStdioWriteLine(&roc_host, STDIO_STREAM_STDOUT, abi.RocStr.fromSlice("nobody home", &roc_host)),
+        hostedStdioWriteLineCode(&roc_host, STDIO_STREAM_STDOUT, abi.RocStr.fromSlice("nobody home", &roc_host)),
     );
 }
 
@@ -13844,7 +14043,7 @@ test "lines queued from update! reach the stream in order, and shutdown drains t
             const text = std.fmt.bufPrint(&digits, "line {d}", .{line}) catch unreachable;
             try std.testing.expectEqual(
                 @as(u8, 0),
-                hostedStdioWriteLine(&roc_host, STDIO_STREAM_STDOUT, abi.RocStr.fromSlice(text, &roc_host)),
+                hostedStdioWriteLineCode(&roc_host, STDIO_STREAM_STDOUT, abi.RocStr.fromSlice(text, &roc_host)),
             );
         }
 
@@ -13852,7 +14051,7 @@ test "lines queued from update! reach the stream in order, and shutdown drains t
         const raw = [_]u8{ 'r', 'a', 'w', '\n' };
         try std.testing.expectEqual(
             @as(u8, 0),
-            hostedStdioWriteBytes(&roc_host, STDIO_STREAM_STDOUT, abi.RocListWith(u8, false).fromSlice(&raw, &roc_host)),
+            hostedStdioWriteBytesCode(&roc_host, STDIO_STREAM_STDOUT, abi.RocListWith(u8, false).fromSlice(&raw, &roc_host)),
         );
     }
 

--- a/src/http_effect.zig
+++ b/src/http_effect.zig
@@ -34,11 +34,22 @@ const abi = @import("roc_platform_abi.zig");
 /// The flattened request `Http` hands the host, as `roc glue` generated it.
 pub const Request = abi.HostHttp_sendArgs;
 
-/// The flattened response the host hands back.
-pub const Response = abi.HostHttp_send;
+/// A finished exchange, before it is named in the app's vocabulary.
+///
+/// The exchange has one internal code table because every failure it can hit
+/// is described the same way here; `host_native` translates it into the
+/// hosted function's closed error union on the way out. `err_message` is
+/// meaningful only for `ERR_OTHER`, and the payload fields only for `ERR_OK`.
+pub const Response = struct {
+    err: u8,
+    err_message: abi.RocStr,
+    status: u16,
+    headers: abi.RocList(HeaderPair),
+    body: abi.RocListWith(u8, false),
+};
 
 /// One header on the wire, in the order the peer sent or expects it.
-pub const HeaderPair = abi.HostHttp_sendHeaders;
+pub const HeaderPair = abi.HostHttp_sendOkHeaders;
 
 /// The exchange completed; `status`, `headers` and `body` are meaningful.
 pub const ERR_OK: u8 = 0;

--- a/src/roc_platform_abi.zig
+++ b/src/roc_platform_abi.zig
@@ -6891,6 +6891,181 @@ comptime {
 }
 
 /// Tag discriminant for Try.
+pub const HostTexture_updateResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostTexture_updateResultPayload = extern union {
+    err: NotMutableOrPixelCountMismatch,
+    ok: [0]u8,
+};
+
+/// Tag union: Try
+pub const HostTexture_updateResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [1]u8 align(1),
+    tag: HostTexture_updateResultTag,
+    pub fn payload_err(self: *const @This()) NotMutableOrPixelCountMismatch {
+        const ptr: *const NotMutableOrPixelCountMismatch = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostTexture_updateResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostTexture_updateResult(self, amount);
+    }
+} else extern struct {
+    payload: HostTexture_updateResultPayload,
+    tag: HostTexture_updateResultTag,
+    pub fn payload_err(self: *const @This()) NotMutableOrPixelCountMismatch {
+        return self.payload.err;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostTexture_updateResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostTexture_updateResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostTexture_updateResult) != 2) @compileError("HostTexture_updateResult size mismatch");
+        if (@alignOf(HostTexture_updateResult) != 1) @compileError("HostTexture_updateResult alignment mismatch");
+        if (@offsetOf(HostTexture_updateResult, "tag") != 1) @compileError("HostTexture_updateResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostTexture_updateResult) != 2) @compileError("HostTexture_updateResult size mismatch");
+        if (@alignOf(HostTexture_updateResult) != 1) @compileError("HostTexture_updateResult alignment mismatch");
+        if (@offsetOf(HostTexture_updateResult, "tag") != 1) @compileError("HostTexture_updateResult tag offset mismatch");
+    }
+}
+
+/// Tag union: NotMutableOrPixelCountMismatch
+pub const NotMutableOrPixelCountMismatch = enum(u8) {
+    not_mutable = 0,
+    pixel_count_mismatch = 1,
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        _ = self;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        _ = self;
+        _ = amount;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(NotMutableOrPixelCountMismatch) != 1) @compileError("NotMutableOrPixelCountMismatch size mismatch");
+        if (@alignOf(NotMutableOrPixelCountMismatch) != 1) @compileError("NotMutableOrPixelCountMismatch alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(NotMutableOrPixelCountMismatch) != 1) @compileError("NotMutableOrPixelCountMismatch size mismatch");
+        if (@alignOf(NotMutableOrPixelCountMismatch) != 1) @compileError("NotMutableOrPixelCountMismatch alignment mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostTexture_update_regionResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostTexture_update_regionResultPayload = extern union {
+    err: NotMutableOrPixelCountMismatchOrRegionOutOfBounds,
+    ok: [0]u8,
+};
+
+/// Tag union: Try
+pub const HostTexture_update_regionResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [1]u8 align(1),
+    tag: HostTexture_update_regionResultTag,
+    pub fn payload_err(self: *const @This()) NotMutableOrPixelCountMismatchOrRegionOutOfBounds {
+        const ptr: *const NotMutableOrPixelCountMismatchOrRegionOutOfBounds = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostTexture_update_regionResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostTexture_update_regionResult(self, amount);
+    }
+} else extern struct {
+    payload: HostTexture_update_regionResultPayload,
+    tag: HostTexture_update_regionResultTag,
+    pub fn payload_err(self: *const @This()) NotMutableOrPixelCountMismatchOrRegionOutOfBounds {
+        return self.payload.err;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostTexture_update_regionResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostTexture_update_regionResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostTexture_update_regionResult) != 2) @compileError("HostTexture_update_regionResult size mismatch");
+        if (@alignOf(HostTexture_update_regionResult) != 1) @compileError("HostTexture_update_regionResult alignment mismatch");
+        if (@offsetOf(HostTexture_update_regionResult, "tag") != 1) @compileError("HostTexture_update_regionResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostTexture_update_regionResult) != 2) @compileError("HostTexture_update_regionResult size mismatch");
+        if (@alignOf(HostTexture_update_regionResult) != 1) @compileError("HostTexture_update_regionResult alignment mismatch");
+        if (@offsetOf(HostTexture_update_regionResult, "tag") != 1) @compileError("HostTexture_update_regionResult tag offset mismatch");
+    }
+}
+
+/// Tag union: NotMutableOrPixelCountMismatchOrRegionOutOfBounds
+pub const NotMutableOrPixelCountMismatchOrRegionOutOfBounds = enum(u8) {
+    not_mutable = 0,
+    pixel_count_mismatch = 1,
+    region_out_of_bounds = 2,
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        _ = self;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        _ = self;
+        _ = amount;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(NotMutableOrPixelCountMismatchOrRegionOutOfBounds) != 1) @compileError("NotMutableOrPixelCountMismatchOrRegionOutOfBounds size mismatch");
+        if (@alignOf(NotMutableOrPixelCountMismatchOrRegionOutOfBounds) != 1) @compileError("NotMutableOrPixelCountMismatchOrRegionOutOfBounds alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(NotMutableOrPixelCountMismatchOrRegionOutOfBounds) != 1) @compileError("NotMutableOrPixelCountMismatchOrRegionOutOfBounds size mismatch");
+        if (@alignOf(NotMutableOrPixelCountMismatchOrRegionOutOfBounds) != 1) @compileError("NotMutableOrPixelCountMismatchOrRegionOutOfBounds alignment mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
 pub const HostTexture_load_render_targetResultTag = enum(u8) {
     Err = 0,
     Ok = 1,
@@ -7554,6 +7729,65 @@ comptime {
     if (@sizeOf(usize) == 4) {
         if (@sizeOf(NotFoundOrPathInvalidOrReadFailedOrResourceLimitOrShaderLoadFailed) != 1) @compileError("NotFoundOrPathInvalidOrReadFailedOrResourceLimitOrShaderLoadFailed size mismatch");
         if (@alignOf(NotFoundOrPathInvalidOrReadFailedOrResourceLimitOrShaderLoadFailed) != 1) @compileError("NotFoundOrPathInvalidOrReadFailedOrResourceLimitOrShaderLoadFailed alignment mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostShader_locationResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostShader_locationResultPayload = extern union {
+    err: [0]u8,
+    ok: i32,
+};
+
+/// Tag union: Try
+pub const HostShader_locationResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [4]u8 align(4),
+    tag: HostShader_locationResultTag,
+    pub fn payload_ok(self: *const @This()) i32 {
+        const ptr: *const i32 = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostShader_locationResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostShader_locationResult(self, amount);
+    }
+} else extern struct {
+    payload: HostShader_locationResultPayload,
+    tag: HostShader_locationResultTag,
+    pub fn payload_ok(self: *const @This()) i32 {
+        return self.payload.ok;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostShader_locationResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostShader_locationResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostShader_locationResult) != 8) @compileError("HostShader_locationResult size mismatch");
+        if (@alignOf(HostShader_locationResult) != 4) @compileError("HostShader_locationResult alignment mismatch");
+        if (@offsetOf(HostShader_locationResult, "tag") != 4) @compileError("HostShader_locationResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostShader_locationResult) != 8) @compileError("HostShader_locationResult size mismatch");
+        if (@alignOf(HostShader_locationResult) != 4) @compileError("HostShader_locationResult alignment mismatch");
+        if (@offsetOf(HostShader_locationResult, "tag") != 4) @compileError("HostShader_locationResult tag offset mismatch");
     }
 }
 
@@ -8334,6 +8568,96 @@ comptime {
 }
 
 /// Tag discriminant for Try.
+pub const HostFiles_write_textResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostFiles_write_textResultPayload = extern union {
+    err: NoSpaceOrNotFoundOrPermissionDeniedOrUnavailableOrWriteFailed,
+    ok: [0]u8,
+};
+
+/// Tag union: Try
+pub const HostFiles_write_textResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [1]u8 align(1),
+    tag: HostFiles_write_textResultTag,
+    pub fn payload_err(self: *const @This()) NoSpaceOrNotFoundOrPermissionDeniedOrUnavailableOrWriteFailed {
+        const ptr: *const NoSpaceOrNotFoundOrPermissionDeniedOrUnavailableOrWriteFailed = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostFiles_write_textResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostFiles_write_textResult(self, amount);
+    }
+} else extern struct {
+    payload: HostFiles_write_textResultPayload,
+    tag: HostFiles_write_textResultTag,
+    pub fn payload_err(self: *const @This()) NoSpaceOrNotFoundOrPermissionDeniedOrUnavailableOrWriteFailed {
+        return self.payload.err;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostFiles_write_textResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostFiles_write_textResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostFiles_write_textResult) != 2) @compileError("HostFiles_write_textResult size mismatch");
+        if (@alignOf(HostFiles_write_textResult) != 1) @compileError("HostFiles_write_textResult alignment mismatch");
+        if (@offsetOf(HostFiles_write_textResult, "tag") != 1) @compileError("HostFiles_write_textResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostFiles_write_textResult) != 2) @compileError("HostFiles_write_textResult size mismatch");
+        if (@alignOf(HostFiles_write_textResult) != 1) @compileError("HostFiles_write_textResult alignment mismatch");
+        if (@offsetOf(HostFiles_write_textResult, "tag") != 1) @compileError("HostFiles_write_textResult tag offset mismatch");
+    }
+}
+
+/// Tag union: NoSpaceOrNotFoundOrPermissionDeniedOrUnavailableOrWriteFailed
+pub const NoSpaceOrNotFoundOrPermissionDeniedOrUnavailableOrWriteFailed = enum(u8) {
+    no_space = 0,
+    not_found = 1,
+    permission_denied = 2,
+    unavailable = 3,
+    write_failed = 4,
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        _ = self;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        _ = self;
+        _ = amount;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(NoSpaceOrNotFoundOrPermissionDeniedOrUnavailableOrWriteFailed) != 1) @compileError("NoSpaceOrNotFoundOrPermissionDeniedOrUnavailableOrWriteFailed size mismatch");
+        if (@alignOf(NoSpaceOrNotFoundOrPermissionDeniedOrUnavailableOrWriteFailed) != 1) @compileError("NoSpaceOrNotFoundOrPermissionDeniedOrUnavailableOrWriteFailed alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(NoSpaceOrNotFoundOrPermissionDeniedOrUnavailableOrWriteFailed) != 1) @compileError("NoSpaceOrNotFoundOrPermissionDeniedOrUnavailableOrWriteFailed size mismatch");
+        if (@alignOf(NoSpaceOrNotFoundOrPermissionDeniedOrUnavailableOrWriteFailed) != 1) @compileError("NoSpaceOrNotFoundOrPermissionDeniedOrUnavailableOrWriteFailed alignment mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
 pub const HostHttp_sendResultTag = enum(u8) {
     Err = 0,
     Ok = 1,
@@ -8600,6 +8924,94 @@ comptime {
 }
 
 /// Tag discriminant for Try.
+pub const HostStdio_write_textResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostStdio_write_textResultPayload = extern union {
+    err: BufferFullOrTooLargeOrUnavailable,
+    ok: [0]u8,
+};
+
+/// Tag union: Try
+pub const HostStdio_write_textResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [1]u8 align(1),
+    tag: HostStdio_write_textResultTag,
+    pub fn payload_err(self: *const @This()) BufferFullOrTooLargeOrUnavailable {
+        const ptr: *const BufferFullOrTooLargeOrUnavailable = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostStdio_write_textResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostStdio_write_textResult(self, amount);
+    }
+} else extern struct {
+    payload: HostStdio_write_textResultPayload,
+    tag: HostStdio_write_textResultTag,
+    pub fn payload_err(self: *const @This()) BufferFullOrTooLargeOrUnavailable {
+        return self.payload.err;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostStdio_write_textResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostStdio_write_textResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostStdio_write_textResult) != 2) @compileError("HostStdio_write_textResult size mismatch");
+        if (@alignOf(HostStdio_write_textResult) != 1) @compileError("HostStdio_write_textResult alignment mismatch");
+        if (@offsetOf(HostStdio_write_textResult, "tag") != 1) @compileError("HostStdio_write_textResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostStdio_write_textResult) != 2) @compileError("HostStdio_write_textResult size mismatch");
+        if (@alignOf(HostStdio_write_textResult) != 1) @compileError("HostStdio_write_textResult alignment mismatch");
+        if (@offsetOf(HostStdio_write_textResult, "tag") != 1) @compileError("HostStdio_write_textResult tag offset mismatch");
+    }
+}
+
+/// Tag union: BufferFullOrTooLargeOrUnavailable
+pub const BufferFullOrTooLargeOrUnavailable = enum(u8) {
+    buffer_full = 0,
+    too_large = 1,
+    unavailable = 2,
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        _ = self;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        _ = self;
+        _ = amount;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(BufferFullOrTooLargeOrUnavailable) != 1) @compileError("BufferFullOrTooLargeOrUnavailable size mismatch");
+        if (@alignOf(BufferFullOrTooLargeOrUnavailable) != 1) @compileError("BufferFullOrTooLargeOrUnavailable alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(BufferFullOrTooLargeOrUnavailable) != 1) @compileError("BufferFullOrTooLargeOrUnavailable size mismatch");
+        if (@alignOf(BufferFullOrTooLargeOrUnavailable) != 1) @compileError("BufferFullOrTooLargeOrUnavailable alignment mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
 pub const HostUdp_bindResultTag = enum(u8) {
     Err = 0,
     Ok = 1,
@@ -8694,6 +9106,98 @@ comptime {
     if (@sizeOf(usize) == 4) {
         if (@sizeOf(AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable) != 1) @compileError("AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable size mismatch");
         if (@alignOf(AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable) != 1) @compileError("AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable alignment mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostUdp_sendResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostUdp_sendResultPayload = extern union {
+    err: InvalidAddressOrNoRouteOrPermissionDeniedOrSendFailedOrTooLargeOrUnavailableOrWouldBlock,
+    ok: [0]u8,
+};
+
+/// Tag union: Try
+pub const HostUdp_sendResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [1]u8 align(1),
+    tag: HostUdp_sendResultTag,
+    pub fn payload_err(self: *const @This()) InvalidAddressOrNoRouteOrPermissionDeniedOrSendFailedOrTooLargeOrUnavailableOrWouldBlock {
+        const ptr: *const InvalidAddressOrNoRouteOrPermissionDeniedOrSendFailedOrTooLargeOrUnavailableOrWouldBlock = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostUdp_sendResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostUdp_sendResult(self, amount);
+    }
+} else extern struct {
+    payload: HostUdp_sendResultPayload,
+    tag: HostUdp_sendResultTag,
+    pub fn payload_err(self: *const @This()) InvalidAddressOrNoRouteOrPermissionDeniedOrSendFailedOrTooLargeOrUnavailableOrWouldBlock {
+        return self.payload.err;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostUdp_sendResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostUdp_sendResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostUdp_sendResult) != 2) @compileError("HostUdp_sendResult size mismatch");
+        if (@alignOf(HostUdp_sendResult) != 1) @compileError("HostUdp_sendResult alignment mismatch");
+        if (@offsetOf(HostUdp_sendResult, "tag") != 1) @compileError("HostUdp_sendResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostUdp_sendResult) != 2) @compileError("HostUdp_sendResult size mismatch");
+        if (@alignOf(HostUdp_sendResult) != 1) @compileError("HostUdp_sendResult alignment mismatch");
+        if (@offsetOf(HostUdp_sendResult, "tag") != 1) @compileError("HostUdp_sendResult tag offset mismatch");
+    }
+}
+
+/// Tag union: InvalidAddressOrNoRouteOrPermissionDeniedOrSendFailedOrTooLargeOrUnavailableOrWouldBlock
+pub const InvalidAddressOrNoRouteOrPermissionDeniedOrSendFailedOrTooLargeOrUnavailableOrWouldBlock = enum(u8) {
+    invalid_address = 0,
+    no_route = 1,
+    permission_denied = 2,
+    send_failed = 3,
+    too_large = 4,
+    unavailable = 5,
+    would_block = 6,
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        _ = self;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        _ = self;
+        _ = amount;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(InvalidAddressOrNoRouteOrPermissionDeniedOrSendFailedOrTooLargeOrUnavailableOrWouldBlock) != 1) @compileError("InvalidAddressOrNoRouteOrPermissionDeniedOrSendFailedOrTooLargeOrUnavailableOrWouldBlock size mismatch");
+        if (@alignOf(InvalidAddressOrNoRouteOrPermissionDeniedOrSendFailedOrTooLargeOrUnavailableOrWouldBlock) != 1) @compileError("InvalidAddressOrNoRouteOrPermissionDeniedOrSendFailedOrTooLargeOrUnavailableOrWouldBlock alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(InvalidAddressOrNoRouteOrPermissionDeniedOrSendFailedOrTooLargeOrUnavailableOrWouldBlock) != 1) @compileError("InvalidAddressOrNoRouteOrPermissionDeniedOrSendFailedOrTooLargeOrUnavailableOrWouldBlock size mismatch");
+        if (@alignOf(InvalidAddressOrNoRouteOrPermissionDeniedOrSendFailedOrTooLargeOrUnavailableOrWouldBlock) != 1) @compileError("InvalidAddressOrNoRouteOrPermissionDeniedOrSendFailedOrTooLargeOrUnavailableOrWouldBlock alignment mismatch");
     }
 }
 
@@ -9604,6 +10108,185 @@ comptime {
 }
 
 /// Tag discriminant for Try.
+pub const HostDraw_begin_scissorResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostDraw_begin_scissorResultPayload = extern union {
+    err: ScopeLimitOrScopeUnavailable,
+    ok: [0]u8,
+};
+
+/// Tag union: Try
+pub const HostDraw_begin_scissorResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [1]u8 align(1),
+    tag: HostDraw_begin_scissorResultTag,
+    pub fn payload_err(self: *const @This()) ScopeLimitOrScopeUnavailable {
+        const ptr: *const ScopeLimitOrScopeUnavailable = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostDraw_begin_scissorResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostDraw_begin_scissorResult(self, amount);
+    }
+} else extern struct {
+    payload: HostDraw_begin_scissorResultPayload,
+    tag: HostDraw_begin_scissorResultTag,
+    pub fn payload_err(self: *const @This()) ScopeLimitOrScopeUnavailable {
+        return self.payload.err;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostDraw_begin_scissorResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostDraw_begin_scissorResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostDraw_begin_scissorResult) != 2) @compileError("HostDraw_begin_scissorResult size mismatch");
+        if (@alignOf(HostDraw_begin_scissorResult) != 1) @compileError("HostDraw_begin_scissorResult alignment mismatch");
+        if (@offsetOf(HostDraw_begin_scissorResult, "tag") != 1) @compileError("HostDraw_begin_scissorResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostDraw_begin_scissorResult) != 2) @compileError("HostDraw_begin_scissorResult size mismatch");
+        if (@alignOf(HostDraw_begin_scissorResult) != 1) @compileError("HostDraw_begin_scissorResult alignment mismatch");
+        if (@offsetOf(HostDraw_begin_scissorResult, "tag") != 1) @compileError("HostDraw_begin_scissorResult tag offset mismatch");
+    }
+}
+
+/// Tag union: ScopeLimitOrScopeUnavailable
+pub const ScopeLimitOrScopeUnavailable = enum(u8) {
+    scope_limit = 0,
+    scope_unavailable = 1,
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        _ = self;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        _ = self;
+        _ = amount;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(ScopeLimitOrScopeUnavailable) != 1) @compileError("ScopeLimitOrScopeUnavailable size mismatch");
+        if (@alignOf(ScopeLimitOrScopeUnavailable) != 1) @compileError("ScopeLimitOrScopeUnavailable alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(ScopeLimitOrScopeUnavailable) != 1) @compileError("ScopeLimitOrScopeUnavailable size mismatch");
+        if (@alignOf(ScopeLimitOrScopeUnavailable) != 1) @compileError("ScopeLimitOrScopeUnavailable alignment mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostCapture_start_recordingResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostCapture_start_recordingResultPayload = extern union {
+    err: AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed,
+    ok: [0]u8,
+};
+
+/// Tag union: Try
+pub const HostCapture_start_recordingResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [1]u8 align(1),
+    tag: HostCapture_start_recordingResultTag,
+    pub fn payload_err(self: *const @This()) AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed {
+        const ptr: *const AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostCapture_start_recordingResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostCapture_start_recordingResult(self, amount);
+    }
+} else extern struct {
+    payload: HostCapture_start_recordingResultPayload,
+    tag: HostCapture_start_recordingResultTag,
+    pub fn payload_err(self: *const @This()) AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed {
+        return self.payload.err;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostCapture_start_recordingResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostCapture_start_recordingResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostCapture_start_recordingResult) != 2) @compileError("HostCapture_start_recordingResult size mismatch");
+        if (@alignOf(HostCapture_start_recordingResult) != 1) @compileError("HostCapture_start_recordingResult alignment mismatch");
+        if (@offsetOf(HostCapture_start_recordingResult, "tag") != 1) @compileError("HostCapture_start_recordingResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostCapture_start_recordingResult) != 2) @compileError("HostCapture_start_recordingResult size mismatch");
+        if (@alignOf(HostCapture_start_recordingResult) != 1) @compileError("HostCapture_start_recordingResult alignment mismatch");
+        if (@offsetOf(HostCapture_start_recordingResult, "tag") != 1) @compileError("HostCapture_start_recordingResult tag offset mismatch");
+    }
+}
+
+/// Tag union: AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed
+pub const AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed = enum(u8) {
+    already_recording = 0,
+    busy = 1,
+    path_escapes_output_dir = 2,
+    path_invalid = 3,
+    unavailable = 4,
+    unsupported_format = 5,
+    write_failed = 6,
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        _ = self;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        _ = self;
+        _ = amount;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed) != 1) @compileError("AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed size mismatch");
+        if (@alignOf(AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed) != 1) @compileError("AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed) != 1) @compileError("AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed size mismatch");
+        if (@alignOf(AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed) != 1) @compileError("AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed alignment mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
 pub const HostCapture_stop_recordingResultTag = enum(u8) {
     Err = 0,
     Ok = 1,
@@ -9698,6 +10381,191 @@ comptime {
     if (@sizeOf(usize) == 4) {
         if (@sizeOf(BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable) != 1) @compileError("BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable size mismatch");
         if (@alignOf(BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable) != 1) @compileError("BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable alignment mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostCapture_screenshotResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostCapture_screenshotResultPayload = extern union {
+    err: AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed,
+    ok: [0]u8,
+};
+
+/// Tag union: Try
+pub const HostCapture_screenshotResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [1]u8 align(1),
+    tag: HostCapture_screenshotResultTag,
+    pub fn payload_err(self: *const @This()) AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed {
+        const ptr: *const AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostCapture_screenshotResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostCapture_screenshotResult(self, amount);
+    }
+} else extern struct {
+    payload: HostCapture_screenshotResultPayload,
+    tag: HostCapture_screenshotResultTag,
+    pub fn payload_err(self: *const @This()) AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed {
+        return self.payload.err;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostCapture_screenshotResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostCapture_screenshotResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostCapture_screenshotResult) != 2) @compileError("HostCapture_screenshotResult size mismatch");
+        if (@alignOf(HostCapture_screenshotResult) != 1) @compileError("HostCapture_screenshotResult alignment mismatch");
+        if (@offsetOf(HostCapture_screenshotResult, "tag") != 1) @compileError("HostCapture_screenshotResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostCapture_screenshotResult) != 2) @compileError("HostCapture_screenshotResult size mismatch");
+        if (@alignOf(HostCapture_screenshotResult) != 1) @compileError("HostCapture_screenshotResult alignment mismatch");
+        if (@offsetOf(HostCapture_screenshotResult, "tag") != 1) @compileError("HostCapture_screenshotResult tag offset mismatch");
+    }
+}
+
+/// Tag union: AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed
+pub const AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed = enum(u8) {
+    already_pending = 0,
+    busy = 1,
+    path_escapes_output_dir = 2,
+    path_invalid = 3,
+    unavailable = 4,
+    write_failed = 5,
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        _ = self;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        _ = self;
+        _ = amount;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed) != 1) @compileError("AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed size mismatch");
+        if (@alignOf(AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed) != 1) @compileError("AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed) != 1) @compileError("AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed size mismatch");
+        if (@alignOf(AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed) != 1) @compileError("AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed alignment mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostCapture_screenshot_textureResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostCapture_screenshot_textureResultPayload = extern union {
+    err: BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed,
+    ok: [0]u8,
+};
+
+/// Tag union: Try
+pub const HostCapture_screenshot_textureResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [1]u8 align(1),
+    tag: HostCapture_screenshot_textureResultTag,
+    pub fn payload_err(self: *const @This()) BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed {
+        const ptr: *const BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostCapture_screenshot_textureResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostCapture_screenshot_textureResult(self, amount);
+    }
+} else extern struct {
+    payload: HostCapture_screenshot_textureResultPayload,
+    tag: HostCapture_screenshot_textureResultTag,
+    pub fn payload_err(self: *const @This()) BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed {
+        return self.payload.err;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostCapture_screenshot_textureResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostCapture_screenshot_textureResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostCapture_screenshot_textureResult) != 2) @compileError("HostCapture_screenshot_textureResult size mismatch");
+        if (@alignOf(HostCapture_screenshot_textureResult) != 1) @compileError("HostCapture_screenshot_textureResult alignment mismatch");
+        if (@offsetOf(HostCapture_screenshot_textureResult, "tag") != 1) @compileError("HostCapture_screenshot_textureResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostCapture_screenshot_textureResult) != 2) @compileError("HostCapture_screenshot_textureResult size mismatch");
+        if (@alignOf(HostCapture_screenshot_textureResult) != 1) @compileError("HostCapture_screenshot_textureResult alignment mismatch");
+        if (@offsetOf(HostCapture_screenshot_textureResult, "tag") != 1) @compileError("HostCapture_screenshot_textureResult tag offset mismatch");
+    }
+}
+
+/// Tag union: BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed
+pub const BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed = enum(u8) {
+    budget_exceeded = 0,
+    busy = 1,
+    out_of_memory = 2,
+    path_escapes_output_dir = 3,
+    path_invalid = 4,
+    readback_failed = 5,
+    target_unavailable = 6,
+    unavailable = 7,
+    write_failed = 8,
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        _ = self;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        _ = self;
+        _ = amount;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed) != 1) @compileError("BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed size mismatch");
+        if (@alignOf(BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed) != 1) @compileError("BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed) != 1) @compileError("BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed size mismatch");
+        if (@alignOf(BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed) != 1) @compileError("BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed alignment mismatch");
     }
 }
 
@@ -10405,7 +11273,7 @@ comptime {
 }
 
 /// Arguments for Host.texture_update!
-/// Roc signature: { pixels : List(Color.Rgba), texture : Texture } => U8
+/// Roc signature: { pixels : List(Color.Rgba), texture : Texture } => Try({}, [NotMutable, PixelCountMismatch])
 /// Refcounted fields are owned by the hosted function.
 pub const HostTexture_updateArgs = if (@sizeOf(usize) == 4) extern struct {
     pixels: RocListWith(ColorRgba, false),
@@ -10453,7 +11321,7 @@ comptime {
 }
 
 /// Arguments for Host.texture_update_region!
-/// Roc signature: { height : I32, pixels : List(Color.Rgba), texture : Texture, width : I32, x : I32, y : I32 } => U8
+/// Roc signature: { height : I32, pixels : List(Color.Rgba), texture : Texture, width : I32, x : I32, y : I32 } => Try({}, [NotMutable, PixelCountMismatch, RegionOutOfBounds])
 /// Refcounted fields are owned by the hosted function.
 pub const HostTexture_update_regionArgs = if (@sizeOf(usize) == 4) extern struct {
     pixels: RocListWith(ColorRgba, false),
@@ -11224,7 +12092,7 @@ pub const HostAudio_set_master_volumeArgs = extern struct {
 };
 
 /// Arguments for Host.draw_begin_scissor!
-/// Roc signature: { height : F32, width : F32, x : F32, y : F32 } => U8
+/// Roc signature: { height : F32, width : F32, x : F32, y : F32 } => Try({}, [ScopeLimit, ScopeUnavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostDraw_begin_scissorArgs = if (@sizeOf(usize) == 4) extern struct {
     height: f32,
@@ -12632,7 +13500,7 @@ pub const HostFiles_metadataArgs = extern struct {
 };
 
 /// Arguments for Host.files_write_text!
-/// Roc signature: Str, Str => U8
+/// Roc signature: Str, Str => Try({}, [NoSpace, NotFound, PermissionDenied, Unavailable, WriteFailed])
 /// Refcounted fields are owned by the hosted function.
 pub const HostFiles_write_textArgs = extern struct {
     arg0: RocStr,
@@ -12640,7 +13508,7 @@ pub const HostFiles_write_textArgs = extern struct {
 };
 
 /// Arguments for Host.files_write_bytes!
-/// Roc signature: Str, List(U8) => U8
+/// Roc signature: Str, List(U8) => Try({}, [NoSpace, NotFound, PermissionDenied, Unavailable, WriteFailed])
 /// Refcounted fields are owned by the hosted function.
 pub const HostFiles_write_bytesArgs = extern struct {
     arg0: RocStr,
@@ -12757,7 +13625,7 @@ pub const HostCapture_set_virtual_textArgs = extern struct {
 };
 
 /// Arguments for Host.capture_start_recording!
-/// Roc signature: { cursor : U8, every_nth : U32, format : U8, fps : I32, max_frames : U64, path : Str, quality : U8, scale_denominator : U32, scale_numerator : U32, timing : U8 } => U8
+/// Roc signature: { cursor : U8, every_nth : U32, format : U8, fps : I32, max_frames : U64, path : Str, quality : U8, scale_denominator : U32, scale_numerator : U32, timing : U8 } => Try({}, [AlreadyRecording, Busy, PathEscapesOutputDir, PathInvalid, Unavailable, UnsupportedFormat, WriteFailed])
 /// Refcounted fields are owned by the hosted function.
 pub const HostCapture_start_recordingArgs = if (@sizeOf(usize) == 4) extern struct {
     max_frames: u64,
@@ -12817,14 +13685,14 @@ comptime {
 }
 
 /// Arguments for Host.capture_screenshot!
-/// Roc signature: Str => U8
+/// Roc signature: Str => Try({}, [AlreadyPending, Busy, PathEscapesOutputDir, PathInvalid, Unavailable, WriteFailed])
 /// Refcounted fields are owned by the hosted function.
 pub const HostCapture_screenshotArgs = extern struct {
     arg0: RocStr,
 };
 
 /// Arguments for Host.capture_screenshot_texture!
-/// Roc signature: { path : Str, target : Texture } => U8
+/// Roc signature: { path : Str, target : Texture } => Try({}, [BudgetExceeded, Busy, OutOfMemory, PathEscapesOutputDir, PathInvalid, ReadbackFailed, TargetUnavailable, Unavailable, WriteFailed])
 /// Refcounted fields are owned by the hosted function.
 pub const HostCapture_screenshot_textureArgs = if (@sizeOf(usize) == 4) extern struct {
     path: RocStr,
@@ -13280,7 +14148,7 @@ comptime {
 }
 
 /// Arguments for Host.draw_begin_camera!
-/// Roc signature: Camera.Camera2D => U8
+/// Roc signature: Camera.Camera2D => Try({}, [ScopeLimit, ScopeUnavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostDraw_begin_cameraArgs = if (@sizeOf(usize) == 4) extern struct {
     offset: MathVec2,
@@ -13332,14 +14200,14 @@ comptime {
 }
 
 /// Arguments for Host.draw_begin_blend!
-/// Roc signature: U8 => U8
+/// Roc signature: U8 => Try({}, [ScopeLimit, ScopeUnavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostDraw_begin_blendArgs = extern struct {
     arg0: u8,
 };
 
 /// Arguments for Host.draw_begin_render_texture!
-/// Roc signature: Texture => U8
+/// Roc signature: Texture => Try({}, [ScopeLimit, ScopeUnavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostDraw_begin_render_textureArgs = if (@sizeOf(usize) == 4) extern struct {
     handle: *u64,
@@ -13385,7 +14253,7 @@ comptime {
 }
 
 /// Arguments for Host.draw_begin_shader!
-/// Roc signature: Shader => U8
+/// Roc signature: Shader => Try({}, [ScopeLimit, ScopeUnavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostDraw_begin_shaderArgs = if (@sizeOf(usize) == 4) extern struct {
     handle: *u64,
@@ -13577,7 +14445,7 @@ comptime {
 }
 
 /// Arguments for Host.shader_location!
-/// Roc signature: { name : Str, shader : Shader } => I32
+/// Roc signature: { name : Str, shader : Shader } => Try(I32, [UniformNotFound])
 /// Refcounted fields are owned by the hosted function.
 pub const HostShader_locationArgs = if (@sizeOf(usize) == 4) extern struct {
     name: RocStr,
@@ -13971,7 +14839,7 @@ comptime {
 }
 
 /// Arguments for Host.stdio_write_text!
-/// Roc signature: U8, Str => U8
+/// Roc signature: U8, Str => Try({}, [BufferFull, TooLarge, Unavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostStdio_write_textArgs = extern struct {
     arg0: u8,
@@ -13979,7 +14847,7 @@ pub const HostStdio_write_textArgs = extern struct {
 };
 
 /// Arguments for Host.stdio_write_line!
-/// Roc signature: U8, Str => U8
+/// Roc signature: U8, Str => Try({}, [BufferFull, TooLarge, Unavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostStdio_write_lineArgs = extern struct {
     arg0: u8,
@@ -13987,7 +14855,7 @@ pub const HostStdio_write_lineArgs = extern struct {
 };
 
 /// Arguments for Host.stdio_write_bytes!
-/// Roc signature: U8, List(U8) => U8
+/// Roc signature: U8, List(U8) => Try({}, [BufferFull, TooLarge, Unavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostStdio_write_bytesArgs = extern struct {
     arg0: u8,
@@ -14039,7 +14907,7 @@ comptime {
 }
 
 /// Arguments for Host.udp_send!
-/// Roc signature: { bytes : List(U8), ip : Str, port : U16, socket : UdpSocket } => U8
+/// Roc signature: { bytes : List(U8), ip : Str, port : U16, socket : UdpSocket } => Try({}, [InvalidAddress, NoRoute, PermissionDenied, SendFailed, TooLarge, Unavailable, WouldBlock])
 /// Refcounted fields are owned by the hosted function.
 pub const HostUdp_sendArgs = if (@sizeOf(usize) == 4) extern struct {
     bytes: RocListWith(u8, false),
@@ -14354,8 +15222,10 @@ pub const HostTexture_generate_checkedErr = ResourceLimitOrTextureGenerationFail
 pub const HostTexture_generate_checkedOk = Texture;
 pub const HostTexture_updateArg0 = __AnonStruct_8e0d47be14ad0be3;
 pub const HostTexture_updateArg0Pixels = ColorRgba;
+pub const HostTexture_updateErr = NotMutableOrPixelCountMismatch;
 pub const HostTexture_update_regionArg0 = __AnonStruct_307d51efe2380633;
 pub const HostTexture_update_regionArg0Pixels = ColorRgba;
+pub const HostTexture_update_regionErr = NotMutableOrPixelCountMismatchOrRegionOutOfBounds;
 pub const HostAudio_gen_toneArg0 = __AnonStruct_74e1febaa758f087;
 pub const HostAudio_gen_toneErr = ResourceLimitOrSoundGenerationFailed;
 pub const HostAudio_gen_toneOk = AudioSound;
@@ -14370,6 +15240,7 @@ pub const HostAudio_load_soundOk = AudioSound;
 pub const HostAudio_load_musicErr = MusicLoadFailedOrResourceLimit;
 pub const HostAudio_load_musicOk = AudioMusic;
 pub const HostDraw_begin_scissorArg0 = __AnonStruct_5d393593a1f032cb;
+pub const HostDraw_begin_scissorErr = ScopeLimitOrScopeUnavailable;
 pub const HostDraw_circle_gradientArg0 = __AnonStruct_f8a458371716c148;
 pub const HostDraw_circle_linesArg0 = __AnonStruct_8b18bd818a3a6ac2;
 pub const HostDraw_circleArg0 = __AnonStruct_e430ec55b5760490;
@@ -14412,12 +15283,20 @@ pub const HostFiles_read_bytesErr = BusyOrNotFoundOrReadFailedOrTooLargeOrUnavai
 pub const HostFiles_listErr = BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable;
 pub const HostFiles_metadataErr = NotFoundOrPermissionDeniedOrReadFailedOrUnavailable;
 pub const HostFiles_metadataOk = __AnonStruct_a1f5c33e74b3920b;
+pub const HostFiles_write_textErr = NoSpaceOrNotFoundOrPermissionDeniedOrUnavailableOrWriteFailed;
+pub const HostFiles_write_bytesResult = HostFiles_write_textResult;
+pub const HostFiles_write_bytesResultPayload = HostFiles_write_textResultPayload;
+pub const HostFiles_write_bytesResultTag = HostFiles_write_textResultTag;
+pub const HostFiles_write_bytesErr = NoSpaceOrNotFoundOrPermissionDeniedOrUnavailableOrWriteFailed;
 pub const HostCapture_set_virtual_mouseArg0 = __AnonStruct_e20342da83229f51;
 pub const HostCapture_set_virtual_keysArg0 = __AnonStruct_c3425bb1e3730c6e;
 pub const HostCapture_start_recordingArg0 = __AnonStruct_96bd4e483c462501;
+pub const HostCapture_start_recordingErr = AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed;
 pub const HostCapture_stop_recordingErr = BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable;
 pub const HostCapture_stop_recordingOk = __AnonStruct_5c978c17ba0c990a;
+pub const HostCapture_screenshotErr = AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed;
 pub const HostCapture_screenshot_textureArg0 = __AnonStruct_aa2779af0bb79965;
+pub const HostCapture_screenshot_textureErr = BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed;
 pub const HostCapture_pixel_atArg0 = __AnonStruct_30827bd86e7a53b3;
 pub const HostCapture_pixel_atArg0Source = __AnonStruct_29524f9bb2f9574c;
 pub const HostCapture_pixel_atErr = BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable;
@@ -14443,6 +15322,22 @@ pub const HostTilemap_load_tmxOkTilesets = __AnonStruct_756aabd194c61573;
 pub const HostTilemap_drawArg0 = __AnonStruct_bcdb8f2e5f1946e1;
 pub const HostTilemap_drawArg0Layers = __AnonStruct_66e2af4e09d9cfd8;
 pub const HostTilemap_drawArg0Tilesets = __AnonStruct_9f9f7e660a5e922b;
+pub const HostDraw_begin_cameraResult = HostDraw_begin_scissorResult;
+pub const HostDraw_begin_cameraResultPayload = HostDraw_begin_scissorResultPayload;
+pub const HostDraw_begin_cameraResultTag = HostDraw_begin_scissorResultTag;
+pub const HostDraw_begin_cameraErr = ScopeLimitOrScopeUnavailable;
+pub const HostDraw_begin_blendResult = HostDraw_begin_scissorResult;
+pub const HostDraw_begin_blendResultPayload = HostDraw_begin_scissorResultPayload;
+pub const HostDraw_begin_blendResultTag = HostDraw_begin_scissorResultTag;
+pub const HostDraw_begin_blendErr = ScopeLimitOrScopeUnavailable;
+pub const HostDraw_begin_render_textureResult = HostDraw_begin_scissorResult;
+pub const HostDraw_begin_render_textureResultPayload = HostDraw_begin_scissorResultPayload;
+pub const HostDraw_begin_render_textureResultTag = HostDraw_begin_scissorResultTag;
+pub const HostDraw_begin_render_textureErr = ScopeLimitOrScopeUnavailable;
+pub const HostDraw_begin_shaderResult = HostDraw_begin_scissorResult;
+pub const HostDraw_begin_shaderResultPayload = HostDraw_begin_scissorResultPayload;
+pub const HostDraw_begin_shaderResultTag = HostDraw_begin_scissorResultTag;
+pub const HostDraw_begin_shaderErr = ScopeLimitOrScopeUnavailable;
 pub const HostTexture_load_render_targetArg0 = __AnonStruct_bc8fa73ca49a5ac0;
 pub const HostTexture_load_render_targetErr = RenderTextureLoadFailedOrResourceLimit;
 pub const HostTexture_load_render_targetOk = Texture;
@@ -14475,10 +15370,20 @@ pub const HostHttp_sendErrTag = MalformedResponseOrNetworkErrorOrOtherOrTimeoutT
 pub const HostHttp_sendOk = __AnonStruct_a14cd3b7d5755441;
 pub const HostHttp_sendOkHeaders = __AnonStruct_82a96c5d55d63488;
 pub const HostTime_now = __AnonStruct_bbf5049c4fa71893;
+pub const HostStdio_write_textErr = BufferFullOrTooLargeOrUnavailable;
+pub const HostStdio_write_lineResult = HostStdio_write_textResult;
+pub const HostStdio_write_lineResultPayload = HostStdio_write_textResultPayload;
+pub const HostStdio_write_lineResultTag = HostStdio_write_textResultTag;
+pub const HostStdio_write_lineErr = BufferFullOrTooLargeOrUnavailable;
+pub const HostStdio_write_bytesResult = HostStdio_write_textResult;
+pub const HostStdio_write_bytesResultPayload = HostStdio_write_textResultPayload;
+pub const HostStdio_write_bytesResultTag = HostStdio_write_textResultTag;
+pub const HostStdio_write_bytesErr = BufferFullOrTooLargeOrUnavailable;
 pub const HostUdp_bindArg0 = __AnonStruct_63b1422749dba501;
 pub const HostUdp_bindErr = AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable;
 pub const HostUdp_bindOk = __AnonStruct_77531de58035959;
 pub const HostUdp_sendArg0 = __AnonStruct_53d84a4d5bb34dcd;
+pub const HostUdp_sendErr = InvalidAddressOrNoRouteOrPermissionDeniedOrSendFailedOrTooLargeOrUnavailableOrWouldBlock;
 pub const HostUdp_receiveArg0 = __AnonStruct_c0489e409fcc99cd;
 pub const HostUdp_receiveErr = AlreadyReceivingOrReceiveFailedOrTimeoutOrUnavailable;
 pub const HostUdp_receiveOk = __AnonStruct_1772298ecb801858;
@@ -14669,8 +15574,56 @@ pub const __AnonStruct_8ffafd56eb173f8dRelease = struct {
     }
 };
 
+fn decrefHostTexture_updateResult(value: HostTexture_updateResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {},
+    }
+}
+
+fn increfHostTexture_updateResult(value: HostTexture_updateResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {},
+    }
+}
+
+pub const HostTexture_updateResultRelease = struct {
+    pub fn release(value: HostTexture_updateResult, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
 pub const __AnonStruct_8e0d47be14ad0be3Release = struct {
     pub fn release(value: __AnonStruct_8e0d47be14ad0be3, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+fn decrefHostTexture_update_regionResult(value: HostTexture_update_regionResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {},
+    }
+}
+
+fn increfHostTexture_update_regionResult(value: HostTexture_update_regionResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {},
+    }
+}
+
+pub const HostTexture_update_regionResultRelease = struct {
+    pub fn release(value: HostTexture_update_regionResult, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -14945,6 +15898,28 @@ pub const HostShader_load_storeResultRelease = struct {
 
 pub const __AnonStruct_87e8defa2945b71dRelease = struct {
     pub fn release(value: __AnonStruct_87e8defa2945b71d, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+fn decrefHostShader_locationResult(value: HostShader_locationResult, roc_host: *RocHost) void {
+    _ = roc_host;
+    switch (value.tag) {
+        .Err => {},
+        .Ok => {},
+    }
+}
+
+fn increfHostShader_locationResult(value: HostShader_locationResult, amount: isize) void {
+    _ = amount;
+    switch (value.tag) {
+        .Err => {},
+        .Ok => {},
+    }
+}
+
+pub const HostShader_locationResultRelease = struct {
+    pub fn release(value: HostShader_locationResult, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -15281,6 +16256,30 @@ pub const HostFiles_listResultRelease = struct {
     }
 };
 
+fn decrefHostFiles_write_textResult(value: HostFiles_write_textResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {},
+    }
+}
+
+fn increfHostFiles_write_textResult(value: HostFiles_write_textResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {},
+    }
+}
+
+pub const HostFiles_write_textResultRelease = struct {
+    pub fn release(value: HostFiles_write_textResult, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
 fn decrefHostHttp_sendResult(value: HostHttp_sendResult, roc_host: *RocHost) void {
     switch (value.tag) {
         .Err => {
@@ -15431,6 +16430,30 @@ pub const __AnonStruct_3fe396bc5ba0c31cRelease = struct {
     }
 };
 
+fn decrefHostStdio_write_textResult(value: HostStdio_write_textResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {},
+    }
+}
+
+fn increfHostStdio_write_textResult(value: HostStdio_write_textResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {},
+    }
+}
+
+pub const HostStdio_write_textResultRelease = struct {
+    pub fn release(value: HostStdio_write_textResult, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
 fn decrefHostUdp_bindResult(value: HostUdp_bindResult, roc_host: *RocHost) void {
     switch (value.tag) {
         .Err => {
@@ -15473,6 +16496,30 @@ pub const UdpSocketRelease = struct {
 
 pub const __AnonStruct_63b1422749dba501Release = struct {
     pub fn release(value: __AnonStruct_63b1422749dba501, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+fn decrefHostUdp_sendResult(value: HostUdp_sendResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {},
+    }
+}
+
+fn increfHostUdp_sendResult(value: HostUdp_sendResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {},
+    }
+}
+
+pub const HostUdp_sendResultRelease = struct {
+    pub fn release(value: HostUdp_sendResult, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -15951,6 +16998,30 @@ pub const __AnonStruct_90c9f98ccd96f8ceRelease = struct {
     }
 };
 
+fn decrefHostDraw_begin_scissorResult(value: HostDraw_begin_scissorResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {},
+    }
+}
+
+fn increfHostDraw_begin_scissorResult(value: HostDraw_begin_scissorResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {},
+    }
+}
+
+pub const HostDraw_begin_scissorResultRelease = struct {
+    pub fn release(value: HostDraw_begin_scissorResult, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
 pub const CameraCamera2DRelease = struct {
     pub fn release(value: CameraCamera2D, roc_host: *RocHost) void {
         value.decref(roc_host);
@@ -16113,6 +17184,30 @@ pub const __AnonStruct_c3425bb1e3730c6eRelease = struct {
     }
 };
 
+fn decrefHostCapture_start_recordingResult(value: HostCapture_start_recordingResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {},
+    }
+}
+
+fn increfHostCapture_start_recordingResult(value: HostCapture_start_recordingResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {},
+    }
+}
+
+pub const HostCapture_start_recordingResultRelease = struct {
+    pub fn release(value: HostCapture_start_recordingResult, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
 pub const __AnonStruct_96bd4e483c462501Release = struct {
     pub fn release(value: __AnonStruct_96bd4e483c462501, roc_host: *RocHost) void {
         value.decref(roc_host);
@@ -16149,6 +17244,54 @@ pub const HostCapture_stop_recordingResultRelease = struct {
 
 pub const __AnonStruct_5c978c17ba0c990aRelease = struct {
     pub fn release(value: __AnonStruct_5c978c17ba0c990a, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+fn decrefHostCapture_screenshotResult(value: HostCapture_screenshotResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {},
+    }
+}
+
+fn increfHostCapture_screenshotResult(value: HostCapture_screenshotResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {},
+    }
+}
+
+pub const HostCapture_screenshotResultRelease = struct {
+    pub fn release(value: HostCapture_screenshotResult, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+fn decrefHostCapture_screenshot_textureResult(value: HostCapture_screenshot_textureResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {},
+    }
+}
+
+fn increfHostCapture_screenshot_textureResult(value: HostCapture_screenshot_textureResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {},
+    }
+}
+
+pub const HostCapture_screenshot_textureResultRelease = struct {
+    pub fn release(value: HostCapture_screenshot_textureResult, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -16668,18 +17811,18 @@ pub extern fn roc_texture_generate_color_raw(arg0: HostTexture_generate_colorArg
 pub extern fn roc_texture_generate_checked_raw(arg0: HostTexture_generate_checkedArgs) callconv(.c) HostTexture_generate_colorResult;
 
 /// Hosted symbol for Host.texture_update!
-/// Roc signature: { pixels : List(Color.Rgba), texture : Texture } => U8
+/// Roc signature: { pixels : List(Color.Rgba), texture : Texture } => Try({}, [NotMutable, PixelCountMismatch])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
-pub extern fn roc_texture_update_raw(arg0: HostTexture_updateArgs) callconv(.c) u8;
+pub extern fn roc_texture_update_raw(arg0: HostTexture_updateArgs) callconv(.c) HostTexture_updateResult;
 
 /// Hosted symbol for Host.texture_update_region!
-/// Roc signature: { height : I32, pixels : List(Color.Rgba), texture : Texture, width : I32, x : I32, y : I32 } => U8
+/// Roc signature: { height : I32, pixels : List(Color.Rgba), texture : Texture, width : I32, x : I32, y : I32 } => Try({}, [NotMutable, PixelCountMismatch, RegionOutOfBounds])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
-pub extern fn roc_texture_update_region_raw(arg0: HostTexture_update_regionArgs) callconv(.c) u8;
+pub extern fn roc_texture_update_region_raw(arg0: HostTexture_update_regionArgs) callconv(.c) HostTexture_update_regionResult;
 
 /// Hosted symbol for Host.texture_set_filter!
 /// Roc signature: Texture, U8 => {}
@@ -16866,8 +18009,8 @@ pub extern fn roc_audio_music_time_played_raw(arg0: AudioMusic) callconv(.c) f32
 pub extern fn roc_audio_set_master_volume_raw(arg0: f32) callconv(.c) void;
 
 /// Hosted symbol for Host.draw_begin_scissor!
-/// Roc signature: { height : F32, width : F32, x : F32, y : F32 } => U8
-pub extern fn roc_draw_begin_scissor_raw(arg0: HostDraw_begin_scissorArgs) callconv(.c) u8;
+/// Roc signature: { height : F32, width : F32, x : F32, y : F32 } => Try({}, [ScopeLimit, ScopeUnavailable])
+pub extern fn roc_draw_begin_scissor_raw(arg0: HostDraw_begin_scissorArgs) callconv(.c) HostDraw_begin_scissorResult;
 
 /// Hosted symbol for Host.draw_circle_gradient!
 /// Roc signature: { center : Math.Vec2, color_inner : Color.Rgba, color_outer : Color.Rgba, radius : F32 } => {}
@@ -17051,20 +18194,20 @@ pub extern fn roc_files_list(arg0: RocStr) callconv(.c) HostFiles_listResult;
 pub extern fn roc_files_metadata(arg0: RocStr) callconv(.c) HostFiles_metadataResult;
 
 /// Hosted symbol for Host.files_write_text!
-/// Roc signature: Str, Str => U8
+/// Roc signature: Str, Str => Try({}, [NoSpace, NotFound, PermissionDenied, Unavailable, WriteFailed])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
 ///     arg1.decref(roc_host);
-pub extern fn roc_files_write_text(arg0: RocStr, arg1: RocStr) callconv(.c) u8;
+pub extern fn roc_files_write_text(arg0: RocStr, arg1: RocStr) callconv(.c) HostFiles_write_textResult;
 
 /// Hosted symbol for Host.files_write_bytes!
-/// Roc signature: Str, List(U8) => U8
+/// Roc signature: Str, List(U8) => Try({}, [NoSpace, NotFound, PermissionDenied, Unavailable, WriteFailed])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
 ///     arg1.decref(roc_host);
-pub extern fn roc_files_write_bytes(arg0: RocStr, arg1: RocListWith(u8, false)) callconv(.c) u8;
+pub extern fn roc_files_write_bytes(arg0: RocStr, arg1: RocListWith(u8, false)) callconv(.c) HostFiles_write_textResult;
 
 /// Hosted symbol for Host.capture_set_virtual_mouse!
 /// Roc signature: { active : Bool, left : Bool, middle : Bool, right : Bool, wheel : F32, x : F32, y : F32 } => {}
@@ -17085,29 +18228,29 @@ pub extern fn roc_capture_set_virtual_keys(arg0: HostCapture_set_virtual_keysArg
 pub extern fn roc_capture_set_virtual_text(arg0: RocListWith(u32, false)) callconv(.c) void;
 
 /// Hosted symbol for Host.capture_start_recording!
-/// Roc signature: { cursor : U8, every_nth : U32, format : U8, fps : I32, max_frames : U64, path : Str, quality : U8, scale_denominator : U32, scale_numerator : U32, timing : U8 } => U8
+/// Roc signature: { cursor : U8, every_nth : U32, format : U8, fps : I32, max_frames : U64, path : Str, quality : U8, scale_denominator : U32, scale_numerator : U32, timing : U8 } => Try({}, [AlreadyRecording, Busy, PathEscapesOutputDir, PathInvalid, Unavailable, UnsupportedFormat, WriteFailed])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
-pub extern fn roc_capture_start_recording(arg0: HostCapture_start_recordingArgs) callconv(.c) u8;
+pub extern fn roc_capture_start_recording(arg0: HostCapture_start_recordingArgs) callconv(.c) HostCapture_start_recordingResult;
 
 /// Hosted symbol for Host.capture_stop_recording!
 /// Roc signature: {} => Try({ bytes : U64, frames : U64 }, [BudgetExceeded, Busy, NotRecording, ReadbackFailed, TargetUnavailable, Unavailable])
 pub extern fn roc_capture_stop_recording() callconv(.c) HostCapture_stop_recordingResult;
 
 /// Hosted symbol for Host.capture_screenshot!
-/// Roc signature: Str => U8
+/// Roc signature: Str => Try({}, [AlreadyPending, Busy, PathEscapesOutputDir, PathInvalid, Unavailable, WriteFailed])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
-pub extern fn roc_capture_screenshot(arg0: RocStr) callconv(.c) u8;
+pub extern fn roc_capture_screenshot(arg0: RocStr) callconv(.c) HostCapture_screenshotResult;
 
 /// Hosted symbol for Host.capture_screenshot_texture!
-/// Roc signature: { path : Str, target : Texture } => U8
+/// Roc signature: { path : Str, target : Texture } => Try({}, [BudgetExceeded, Busy, OutOfMemory, PathEscapesOutputDir, PathInvalid, ReadbackFailed, TargetUnavailable, Unavailable, WriteFailed])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
-pub extern fn roc_capture_screenshot_texture(arg0: HostCapture_screenshot_textureArgs) callconv(.c) u8;
+pub extern fn roc_capture_screenshot_texture(arg0: HostCapture_screenshot_textureArgs) callconv(.c) HostCapture_screenshot_textureResult;
 
 /// Hosted symbol for Host.capture_pixel_at!
 /// Roc signature: { source : { screen : Bool, target : Texture }, x : I32, y : I32 } => Try({ a : U8, b : U8, g : U8, r : U8 }, [Busy, ReadbackFailed, RegionOutOfBounds, TargetUnavailable, Unavailable])
@@ -17237,29 +18380,29 @@ pub extern fn roc_tilemap_load_tmx_raw(arg0: RocStr) callconv(.c) HostTilemap_lo
 pub extern fn roc_tilemap_draw_raw(arg0: HostTilemap_drawArgs) callconv(.c) void;
 
 /// Hosted symbol for Host.draw_begin_camera!
-/// Roc signature: Camera.Camera2D => U8
+/// Roc signature: Camera.Camera2D => Try({}, [ScopeLimit, ScopeUnavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
-pub extern fn roc_draw_begin_camera(arg0: CameraCamera2D) callconv(.c) u8;
+pub extern fn roc_draw_begin_camera(arg0: CameraCamera2D) callconv(.c) HostDraw_begin_scissorResult;
 
 /// Hosted symbol for Host.draw_begin_blend!
-/// Roc signature: U8 => U8
-pub extern fn roc_draw_begin_blend_raw(arg0: u8) callconv(.c) u8;
+/// Roc signature: U8 => Try({}, [ScopeLimit, ScopeUnavailable])
+pub extern fn roc_draw_begin_blend_raw(arg0: u8) callconv(.c) HostDraw_begin_scissorResult;
 
 /// Hosted symbol for Host.draw_begin_render_texture!
-/// Roc signature: Texture => U8
+/// Roc signature: Texture => Try({}, [ScopeLimit, ScopeUnavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
-pub extern fn roc_draw_begin_render_texture_raw(arg0: Texture) callconv(.c) u8;
+pub extern fn roc_draw_begin_render_texture_raw(arg0: Texture) callconv(.c) HostDraw_begin_scissorResult;
 
 /// Hosted symbol for Host.draw_begin_shader!
-/// Roc signature: Shader => U8
+/// Roc signature: Shader => Try({}, [ScopeLimit, ScopeUnavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
-pub extern fn roc_draw_begin_shader_raw(arg0: Shader) callconv(.c) u8;
+pub extern fn roc_draw_begin_shader_raw(arg0: Shader) callconv(.c) HostDraw_begin_scissorResult;
 
 /// Hosted symbol for Host.draw_end_camera!
 /// Roc signature: {} => {}
@@ -17299,11 +18442,11 @@ pub extern fn roc_shader_load_source_raw(arg0: HostShader_load_sourceArgs) callc
 pub extern fn roc_shader_load_store_raw(arg0: HostShader_load_storeArgs) callconv(.c) HostShader_load_storeResult;
 
 /// Hosted symbol for Host.shader_location!
-/// Roc signature: { name : Str, shader : Shader } => I32
+/// Roc signature: { name : Str, shader : Shader } => Try(I32, [UniformNotFound])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
-pub extern fn roc_shader_location_raw(arg0: HostShader_locationArgs) callconv(.c) i32;
+pub extern fn roc_shader_location_raw(arg0: HostShader_locationArgs) callconv(.c) HostShader_locationResult;
 
 /// Hosted symbol for Host.shader_set_float!
 /// Roc signature: { uniform : { location : I32, shader : Shader }, value : F32 } => {}
@@ -17360,25 +18503,25 @@ pub extern fn roc_http_send(arg0: HostHttp_sendArgs) callconv(.c) HostHttp_sendR
 pub extern fn roc_time_now() callconv(.c) __AnonStruct_bbf5049c4fa71893;
 
 /// Hosted symbol for Host.stdio_write_text!
-/// Roc signature: U8, Str => U8
+/// Roc signature: U8, Str => Try({}, [BufferFull, TooLarge, Unavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg1.decref(roc_host);
-pub extern fn roc_stdio_write_text(arg0: u8, arg1: RocStr) callconv(.c) u8;
+pub extern fn roc_stdio_write_text(arg0: u8, arg1: RocStr) callconv(.c) HostStdio_write_textResult;
 
 /// Hosted symbol for Host.stdio_write_line!
-/// Roc signature: U8, Str => U8
+/// Roc signature: U8, Str => Try({}, [BufferFull, TooLarge, Unavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg1.decref(roc_host);
-pub extern fn roc_stdio_write_line(arg0: u8, arg1: RocStr) callconv(.c) u8;
+pub extern fn roc_stdio_write_line(arg0: u8, arg1: RocStr) callconv(.c) HostStdio_write_textResult;
 
 /// Hosted symbol for Host.stdio_write_bytes!
-/// Roc signature: U8, List(U8) => U8
+/// Roc signature: U8, List(U8) => Try({}, [BufferFull, TooLarge, Unavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg1.decref(roc_host);
-pub extern fn roc_stdio_write_bytes(arg0: u8, arg1: RocListWith(u8, false)) callconv(.c) u8;
+pub extern fn roc_stdio_write_bytes(arg0: u8, arg1: RocListWith(u8, false)) callconv(.c) HostStdio_write_textResult;
 
 /// Hosted symbol for Host.udp_bind!
 /// Roc signature: { ip : Str, port : U16 } => Try({ handle : UdpSocket, ip : U32, port : U16 }, [AddressInUse, AddressUnavailable, InvalidAddress, PermissionDenied, ResourceLimit, Unavailable])
@@ -17389,11 +18532,11 @@ pub extern fn roc_stdio_write_bytes(arg0: u8, arg1: RocListWith(u8, false)) call
 pub extern fn roc_udp_bind(arg0: HostUdp_bindArgs) callconv(.c) HostUdp_bindResult;
 
 /// Hosted symbol for Host.udp_send!
-/// Roc signature: { bytes : List(U8), ip : Str, port : U16, socket : UdpSocket } => U8
+/// Roc signature: { bytes : List(U8), ip : Str, port : U16, socket : UdpSocket } => Try({}, [InvalidAddress, NoRoute, PermissionDenied, SendFailed, TooLarge, Unavailable, WouldBlock])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
-pub extern fn roc_udp_send(arg0: HostUdp_sendArgs) callconv(.c) u8;
+pub extern fn roc_udp_send(arg0: HostUdp_sendArgs) callconv(.c) HostUdp_sendResult;
 
 /// Hosted symbol for Host.udp_receive!
 /// Roc signature: { max_datagrams : U32, socket : UdpSocket, timeout_ms : U64 } => Try({ payload : List(U8), slices : List({ ip : U32, len : U64, port : U16, start : U64 }) }, [AlreadyReceiving, ReceiveFailed, Timeout, Unavailable])

--- a/src/roc_platform_abi.zig
+++ b/src/roc_platform_abi.zig
@@ -745,49 +745,89 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct_e6634fb4c190c214
-pub const __AnonStruct_e6634fb4c190c214 = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct_fcb9c18e638f68bc
+pub const __AnonStruct_fcb9c18e638f68bc = if (@sizeOf(usize) == 4) extern struct {
     path: RocStr,
-    store: *u64,
+    store: Store,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
         value.path.decref(roc_host);
-        decrefBoxWith(@ptrCast(value.store), @alignOf(u64), false, null, roc_host);
+        value.store.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
         value.path.incref(amount);
-        increfBox(@ptrCast(value.store), amount);
+        value.store.incref(amount);
     }
 } else extern struct {
     path: RocStr,
-    store: *u64,
+    store: Store,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
         value.path.decref(roc_host);
-        decrefBoxWith(@ptrCast(value.store), @alignOf(u64), false, null, roc_host);
+        value.store.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
         value.path.incref(amount);
-        increfBox(@ptrCast(value.store), amount);
+        value.store.incref(amount);
     }
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_e6634fb4c190c214) != 32) @compileError("__AnonStruct_e6634fb4c190c214 size mismatch");
-        if (@alignOf(__AnonStruct_e6634fb4c190c214) != 8) @compileError("__AnonStruct_e6634fb4c190c214 alignment mismatch");
+        if (@sizeOf(__AnonStruct_fcb9c18e638f68bc) != 32) @compileError("__AnonStruct_fcb9c18e638f68bc size mismatch");
+        if (@alignOf(__AnonStruct_fcb9c18e638f68bc) != 8) @compileError("__AnonStruct_fcb9c18e638f68bc alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_e6634fb4c190c214) != 16) @compileError("__AnonStruct_e6634fb4c190c214 size mismatch");
-        if (@alignOf(__AnonStruct_e6634fb4c190c214) != 4) @compileError("__AnonStruct_e6634fb4c190c214 alignment mismatch");
+        if (@sizeOf(__AnonStruct_fcb9c18e638f68bc) != 16) @compileError("__AnonStruct_fcb9c18e638f68bc size mismatch");
+        if (@alignOf(__AnonStruct_fcb9c18e638f68bc) != 4) @compileError("__AnonStruct_fcb9c18e638f68bc alignment mismatch");
+    }
+}
+
+/// Element type for Store
+pub const Store = if (@sizeOf(usize) == 4) extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+} else extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(Store) != 8) @compileError("Store size mismatch");
+        if (@alignOf(Store) != 8) @compileError("Store alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(Store) != 4) @compileError("Store size mismatch");
+        if (@alignOf(Store) != 4) @compileError("Store alignment mismatch");
     }
 }
 
@@ -1317,95 +1357,135 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct_80c864420ea33e1e
-pub const __AnonStruct_80c864420ea33e1e = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct_aba52beeae923776
+pub const __AnonStruct_aba52beeae923776 = if (@sizeOf(usize) == 4) extern struct {
     path: RocStr,
-    store: *u64,
+    store: Store,
     size: i32,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
         value.path.decref(roc_host);
-        decrefBoxWith(@ptrCast(value.store), @alignOf(u64), false, null, roc_host);
+        value.store.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
         value.path.incref(amount);
-        increfBox(@ptrCast(value.store), amount);
+        value.store.incref(amount);
     }
 } else extern struct {
     path: RocStr,
-    store: *u64,
+    store: Store,
     size: i32,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
         value.path.decref(roc_host);
-        decrefBoxWith(@ptrCast(value.store), @alignOf(u64), false, null, roc_host);
+        value.store.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
         value.path.incref(amount);
-        increfBox(@ptrCast(value.store), amount);
+        value.store.incref(amount);
     }
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_80c864420ea33e1e) != 40) @compileError("__AnonStruct_80c864420ea33e1e size mismatch");
-        if (@alignOf(__AnonStruct_80c864420ea33e1e) != 8) @compileError("__AnonStruct_80c864420ea33e1e alignment mismatch");
+        if (@sizeOf(__AnonStruct_aba52beeae923776) != 40) @compileError("__AnonStruct_aba52beeae923776 size mismatch");
+        if (@alignOf(__AnonStruct_aba52beeae923776) != 8) @compileError("__AnonStruct_aba52beeae923776 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_80c864420ea33e1e) != 20) @compileError("__AnonStruct_80c864420ea33e1e size mismatch");
-        if (@alignOf(__AnonStruct_80c864420ea33e1e) != 4) @compileError("__AnonStruct_80c864420ea33e1e alignment mismatch");
+        if (@sizeOf(__AnonStruct_aba52beeae923776) != 20) @compileError("__AnonStruct_aba52beeae923776 size mismatch");
+        if (@alignOf(__AnonStruct_aba52beeae923776) != 4) @compileError("__AnonStruct_aba52beeae923776 alignment mismatch");
     }
 }
 
-/// Element type for __AnonStruct_e1165210b218b76c
-pub const __AnonStruct_e1165210b218b76c = if (@sizeOf(usize) == 4) extern struct {
-    prepared: *u64,
+/// Element type for __AnonStruct_34e6157b936793f4
+pub const __AnonStruct_34e6157b936793f4 = if (@sizeOf(usize) == 4) extern struct {
+    prepared: TextPrepared,
     height: f32,
     width: f32,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        decrefBoxWith(@ptrCast(value.prepared), @alignOf(u64), false, null, roc_host);
+        value.prepared.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        increfBox(@ptrCast(value.prepared), amount);
+        value.prepared.incref(amount);
     }
 } else extern struct {
-    prepared: *u64,
+    prepared: TextPrepared,
     height: f32,
     width: f32,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        decrefBoxWith(@ptrCast(value.prepared), @alignOf(u64), false, null, roc_host);
+        value.prepared.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        increfBox(@ptrCast(value.prepared), amount);
+        value.prepared.incref(amount);
     }
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_e1165210b218b76c) != 16) @compileError("__AnonStruct_e1165210b218b76c size mismatch");
-        if (@alignOf(__AnonStruct_e1165210b218b76c) != 8) @compileError("__AnonStruct_e1165210b218b76c alignment mismatch");
+        if (@sizeOf(__AnonStruct_34e6157b936793f4) != 16) @compileError("__AnonStruct_34e6157b936793f4 size mismatch");
+        if (@alignOf(__AnonStruct_34e6157b936793f4) != 8) @compileError("__AnonStruct_34e6157b936793f4 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_e1165210b218b76c) != 12) @compileError("__AnonStruct_e1165210b218b76c size mismatch");
-        if (@alignOf(__AnonStruct_e1165210b218b76c) != 4) @compileError("__AnonStruct_e1165210b218b76c alignment mismatch");
+        if (@sizeOf(__AnonStruct_34e6157b936793f4) != 12) @compileError("__AnonStruct_34e6157b936793f4 size mismatch");
+        if (@alignOf(__AnonStruct_34e6157b936793f4) != 4) @compileError("__AnonStruct_34e6157b936793f4 alignment mismatch");
+    }
+}
+
+/// Element type for TextPrepared
+pub const TextPrepared = if (@sizeOf(usize) == 4) extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+} else extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(TextPrepared) != 8) @compileError("TextPrepared size mismatch");
+        if (@alignOf(TextPrepared) != 8) @compileError("TextPrepared alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(TextPrepared) != 4) @compileError("TextPrepared size mismatch");
+        if (@alignOf(TextPrepared) != 4) @compileError("TextPrepared alignment mismatch");
     }
 }
 
@@ -1545,16 +1625,16 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct_3e85b4e878c74d96
-pub const __AnonStruct_3e85b4e878c74d96 = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct_87e8defa2945b71d
+pub const __AnonStruct_87e8defa2945b71d = if (@sizeOf(usize) == 4) extern struct {
     fragment_path: RocStr,
-    store: *u64,
+    store: Store,
     vertex_path: RocStr,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
         value.fragment_path.decref(roc_host);
-        decrefBoxWith(@ptrCast(value.store), @alignOf(u64), false, null, roc_host);
+        value.store.decref(roc_host);
         value.vertex_path.decref(roc_host);
     }
 
@@ -1562,18 +1642,18 @@ pub const __AnonStruct_3e85b4e878c74d96 = if (@sizeOf(usize) == 4) extern struct
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
         value.fragment_path.incref(amount);
-        increfBox(@ptrCast(value.store), amount);
+        value.store.incref(amount);
         value.vertex_path.incref(amount);
     }
 } else extern struct {
     fragment_path: RocStr,
-    store: *u64,
+    store: Store,
     vertex_path: RocStr,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
         value.fragment_path.decref(roc_host);
-        decrefBoxWith(@ptrCast(value.store), @alignOf(u64), false, null, roc_host);
+        value.store.decref(roc_host);
         value.vertex_path.decref(roc_host);
     }
 
@@ -1581,19 +1661,19 @@ pub const __AnonStruct_3e85b4e878c74d96 = if (@sizeOf(usize) == 4) extern struct
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
         value.fragment_path.incref(amount);
-        increfBox(@ptrCast(value.store), amount);
+        value.store.incref(amount);
         value.vertex_path.incref(amount);
     }
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_3e85b4e878c74d96) != 56) @compileError("__AnonStruct_3e85b4e878c74d96 size mismatch");
-        if (@alignOf(__AnonStruct_3e85b4e878c74d96) != 8) @compileError("__AnonStruct_3e85b4e878c74d96 alignment mismatch");
+        if (@sizeOf(__AnonStruct_87e8defa2945b71d) != 56) @compileError("__AnonStruct_87e8defa2945b71d size mismatch");
+        if (@alignOf(__AnonStruct_87e8defa2945b71d) != 8) @compileError("__AnonStruct_87e8defa2945b71d alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_3e85b4e878c74d96) != 28) @compileError("__AnonStruct_3e85b4e878c74d96 size mismatch");
-        if (@alignOf(__AnonStruct_3e85b4e878c74d96) != 4) @compileError("__AnonStruct_3e85b4e878c74d96 alignment mismatch");
+        if (@sizeOf(__AnonStruct_87e8defa2945b71d) != 28) @compileError("__AnonStruct_87e8defa2945b71d size mismatch");
+        if (@alignOf(__AnonStruct_87e8defa2945b71d) != 4) @compileError("__AnonStruct_87e8defa2945b71d alignment mismatch");
     }
 }
 
@@ -2205,6 +2285,46 @@ comptime {
     }
 }
 
+/// Element type for AudioSound
+pub const AudioSound = if (@sizeOf(usize) == 4) extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+} else extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(AudioSound) != 8) @compileError("AudioSound size mismatch");
+        if (@alignOf(AudioSound) != 8) @compileError("AudioSound alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(AudioSound) != 4) @compileError("AudioSound size mismatch");
+        if (@alignOf(AudioSound) != 4) @compileError("AudioSound alignment mismatch");
+    }
+}
+
 /// Element type for __AnonStruct_74e1febaa758f087
 pub const __AnonStruct_74e1febaa758f087 = if (@sizeOf(usize) == 4) extern struct {
     freq: f32,
@@ -2311,54 +2431,51 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct_e98c7d72bcd7a610
-pub const __AnonStruct_e98c7d72bcd7a610 = if (@sizeOf(usize) == 4) extern struct {
-    contents: RocStr,
-    err: u8,
+/// Element type for AudioMusic
+pub const AudioMusic = if (@sizeOf(usize) == 4) extern struct {
+    handle: *u64,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        value.contents.decref(roc_host);
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        value.contents.incref(amount);
+        increfBox(@ptrCast(value.handle), amount);
     }
 } else extern struct {
-    contents: RocStr,
-    err: u8,
+    handle: *u64,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        value.contents.decref(roc_host);
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        value.contents.incref(amount);
+        increfBox(@ptrCast(value.handle), amount);
     }
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_e98c7d72bcd7a610) != 32) @compileError("__AnonStruct_e98c7d72bcd7a610 size mismatch");
-        if (@alignOf(__AnonStruct_e98c7d72bcd7a610) != 8) @compileError("__AnonStruct_e98c7d72bcd7a610 alignment mismatch");
+        if (@sizeOf(AudioMusic) != 8) @compileError("AudioMusic size mismatch");
+        if (@alignOf(AudioMusic) != 8) @compileError("AudioMusic alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_e98c7d72bcd7a610) != 16) @compileError("__AnonStruct_e98c7d72bcd7a610 size mismatch");
-        if (@alignOf(__AnonStruct_e98c7d72bcd7a610) != 4) @compileError("__AnonStruct_e98c7d72bcd7a610 alignment mismatch");
+        if (@sizeOf(AudioMusic) != 4) @compileError("AudioMusic size mismatch");
+        if (@alignOf(AudioMusic) != 4) @compileError("AudioMusic alignment mismatch");
     }
 }
 
-/// Element type for __AnonStruct_ee584b0815816939
-pub const __AnonStruct_ee584b0815816939 = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct_a1f5c33e74b3920b
+pub const __AnonStruct_a1f5c33e74b3920b = if (@sizeOf(usize) == 4) extern struct {
     modified_seconds: i64,
     size_bytes: u64,
     modified_nanosecond: u32,
-    err: u8,
     kind: u8,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
@@ -2377,7 +2494,6 @@ pub const __AnonStruct_ee584b0815816939 = if (@sizeOf(usize) == 4) extern struct
     modified_seconds: i64,
     size_bytes: u64,
     modified_nanosecond: u32,
-    err: u8,
     kind: u8,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
@@ -2396,69 +2512,24 @@ pub const __AnonStruct_ee584b0815816939 = if (@sizeOf(usize) == 4) extern struct
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_ee584b0815816939) != 24) @compileError("__AnonStruct_ee584b0815816939 size mismatch");
-        if (@alignOf(__AnonStruct_ee584b0815816939) != 8) @compileError("__AnonStruct_ee584b0815816939 alignment mismatch");
+        if (@sizeOf(__AnonStruct_a1f5c33e74b3920b) != 24) @compileError("__AnonStruct_a1f5c33e74b3920b size mismatch");
+        if (@alignOf(__AnonStruct_a1f5c33e74b3920b) != 8) @compileError("__AnonStruct_a1f5c33e74b3920b alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_ee584b0815816939) != 24) @compileError("__AnonStruct_ee584b0815816939 size mismatch");
-        if (@alignOf(__AnonStruct_ee584b0815816939) != 8) @compileError("__AnonStruct_ee584b0815816939 alignment mismatch");
+        if (@sizeOf(__AnonStruct_a1f5c33e74b3920b) != 24) @compileError("__AnonStruct_a1f5c33e74b3920b size mismatch");
+        if (@alignOf(__AnonStruct_a1f5c33e74b3920b) != 8) @compileError("__AnonStruct_a1f5c33e74b3920b alignment mismatch");
     }
 }
 
-/// Element type for __AnonStruct_5b08b74ffdd2f118
-pub const __AnonStruct_5b08b74ffdd2f118 = if (@sizeOf(usize) == 4) extern struct {
-    bytes: RocListWith(u8, false),
-    err: u8,
-    /// Recursively decrement Roc-owned fields.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        const value = self;
-        value.bytes.decref(roc_host);
-    }
-
-    /// Increment Roc-owned fields.
-    pub fn incref(self: @This(), amount: isize) void {
-        const value = self;
-        value.bytes.incref(amount);
-    }
-} else extern struct {
-    bytes: RocListWith(u8, false),
-    err: u8,
-    /// Recursively decrement Roc-owned fields.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        const value = self;
-        value.bytes.decref(roc_host);
-    }
-
-    /// Increment Roc-owned fields.
-    pub fn incref(self: @This(), amount: isize) void {
-        const value = self;
-        value.bytes.incref(amount);
-    }
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_5b08b74ffdd2f118) != 32) @compileError("__AnonStruct_5b08b74ffdd2f118 size mismatch");
-        if (@alignOf(__AnonStruct_5b08b74ffdd2f118) != 8) @compileError("__AnonStruct_5b08b74ffdd2f118 alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_5b08b74ffdd2f118) != 16) @compileError("__AnonStruct_5b08b74ffdd2f118 size mismatch");
-        if (@alignOf(__AnonStruct_5b08b74ffdd2f118) != 4) @compileError("__AnonStruct_5b08b74ffdd2f118 alignment mismatch");
-    }
-}
-
-/// Element type for __AnonStruct_da7cbd33c88fa20a
-pub const __AnonStruct_da7cbd33c88fa20a = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct_a14cd3b7d5755441
+pub const __AnonStruct_a14cd3b7d5755441 = if (@sizeOf(usize) == 4) extern struct {
     body: RocListWith(u8, false),
-    err_message: RocStr,
     headers: RocList(__AnonStruct_82a96c5d55d63488),
     status: u16,
-    err: u8,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
         value.body.decref(roc_host);
-        value.err_message.decref(roc_host);
         decrefListOf__AnonStruct_82a96c5d55d63488(value.headers, roc_host);
     }
 
@@ -2466,20 +2537,16 @@ pub const __AnonStruct_da7cbd33c88fa20a = if (@sizeOf(usize) == 4) extern struct
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
         value.body.incref(amount);
-        value.err_message.incref(amount);
         value.headers.incref(amount);
     }
 } else extern struct {
     body: RocListWith(u8, false),
-    err_message: RocStr,
     headers: RocList(__AnonStruct_82a96c5d55d63488),
     status: u16,
-    err: u8,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
         value.body.decref(roc_host);
-        value.err_message.decref(roc_host);
         decrefListOf__AnonStruct_82a96c5d55d63488(value.headers, roc_host);
     }
 
@@ -2487,19 +2554,18 @@ pub const __AnonStruct_da7cbd33c88fa20a = if (@sizeOf(usize) == 4) extern struct
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
         value.body.incref(amount);
-        value.err_message.incref(amount);
         value.headers.incref(amount);
     }
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_da7cbd33c88fa20a) != 80) @compileError("__AnonStruct_da7cbd33c88fa20a size mismatch");
-        if (@alignOf(__AnonStruct_da7cbd33c88fa20a) != 8) @compileError("__AnonStruct_da7cbd33c88fa20a alignment mismatch");
+        if (@sizeOf(__AnonStruct_a14cd3b7d5755441) != 56) @compileError("__AnonStruct_a14cd3b7d5755441 size mismatch");
+        if (@alignOf(__AnonStruct_a14cd3b7d5755441) != 8) @compileError("__AnonStruct_a14cd3b7d5755441 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_da7cbd33c88fa20a) != 40) @compileError("__AnonStruct_da7cbd33c88fa20a size mismatch");
-        if (@alignOf(__AnonStruct_da7cbd33c88fa20a) != 4) @compileError("__AnonStruct_da7cbd33c88fa20a alignment mismatch");
+        if (@sizeOf(__AnonStruct_a14cd3b7d5755441) != 28) @compileError("__AnonStruct_a14cd3b7d5755441 size mismatch");
+        if (@alignOf(__AnonStruct_a14cd3b7d5755441) != 4) @compileError("__AnonStruct_a14cd3b7d5755441 alignment mismatch");
     }
 }
 
@@ -2613,12 +2679,11 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct_fa110e8829dc221b
-pub const __AnonStruct_fa110e8829dc221b = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct_45d496287297bf7f
+pub const __AnonStruct_45d496287297bf7f = if (@sizeOf(usize) == 4) extern struct {
     exit_code: i64,
     stderr: RocListWith(u8, false),
     stdout: RocListWith(u8, false),
-    err: u8,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
@@ -2636,7 +2701,6 @@ pub const __AnonStruct_fa110e8829dc221b = if (@sizeOf(usize) == 4) extern struct
     exit_code: i64,
     stderr: RocListWith(u8, false),
     stdout: RocListWith(u8, false),
-    err: u8,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
@@ -2654,12 +2718,12 @@ pub const __AnonStruct_fa110e8829dc221b = if (@sizeOf(usize) == 4) extern struct
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_fa110e8829dc221b) != 64) @compileError("__AnonStruct_fa110e8829dc221b size mismatch");
-        if (@alignOf(__AnonStruct_fa110e8829dc221b) != 8) @compileError("__AnonStruct_fa110e8829dc221b alignment mismatch");
+        if (@sizeOf(__AnonStruct_45d496287297bf7f) != 56) @compileError("__AnonStruct_45d496287297bf7f size mismatch");
+        if (@alignOf(__AnonStruct_45d496287297bf7f) != 8) @compileError("__AnonStruct_45d496287297bf7f alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_fa110e8829dc221b) != 40) @compileError("__AnonStruct_fa110e8829dc221b size mismatch");
-        if (@alignOf(__AnonStruct_fa110e8829dc221b) != 8) @compileError("__AnonStruct_fa110e8829dc221b alignment mismatch");
+        if (@sizeOf(__AnonStruct_45d496287297bf7f) != 32) @compileError("__AnonStruct_45d496287297bf7f size mismatch");
+        if (@alignOf(__AnonStruct_45d496287297bf7f) != 8) @compileError("__AnonStruct_45d496287297bf7f alignment mismatch");
     }
 }
 
@@ -2729,12 +2793,53 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct_c53c193ad2a36104
-pub const __AnonStruct_c53c193ad2a36104 = if (@sizeOf(usize) == 4) extern struct {
-    handle: *u64,
+/// Element type for __AnonStruct_77531de58035959
+pub const __AnonStruct_77531de58035959 = if (@sizeOf(usize) == 4) extern struct {
+    handle: UdpSocket,
     ip: u32,
     port: u16,
-    err: u8,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        value.handle.decref(roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        value.handle.incref(amount);
+    }
+} else extern struct {
+    handle: UdpSocket,
+    ip: u32,
+    port: u16,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        value.handle.decref(roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        value.handle.incref(amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(__AnonStruct_77531de58035959) != 16) @compileError("__AnonStruct_77531de58035959 size mismatch");
+        if (@alignOf(__AnonStruct_77531de58035959) != 8) @compileError("__AnonStruct_77531de58035959 alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(__AnonStruct_77531de58035959) != 12) @compileError("__AnonStruct_77531de58035959 size mismatch");
+        if (@alignOf(__AnonStruct_77531de58035959) != 4) @compileError("__AnonStruct_77531de58035959 alignment mismatch");
+    }
+}
+
+/// Element type for UdpSocket
+pub const UdpSocket = if (@sizeOf(usize) == 4) extern struct {
+    handle: *u64,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
@@ -2748,9 +2853,6 @@ pub const __AnonStruct_c53c193ad2a36104 = if (@sizeOf(usize) == 4) extern struct
     }
 } else extern struct {
     handle: *u64,
-    ip: u32,
-    port: u16,
-    err: u8,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
@@ -2766,12 +2868,12 @@ pub const __AnonStruct_c53c193ad2a36104 = if (@sizeOf(usize) == 4) extern struct
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_c53c193ad2a36104) != 16) @compileError("__AnonStruct_c53c193ad2a36104 size mismatch");
-        if (@alignOf(__AnonStruct_c53c193ad2a36104) != 8) @compileError("__AnonStruct_c53c193ad2a36104 alignment mismatch");
+        if (@sizeOf(UdpSocket) != 8) @compileError("UdpSocket size mismatch");
+        if (@alignOf(UdpSocket) != 8) @compileError("UdpSocket alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_c53c193ad2a36104) != 12) @compileError("__AnonStruct_c53c193ad2a36104 size mismatch");
-        if (@alignOf(__AnonStruct_c53c193ad2a36104) != 4) @compileError("__AnonStruct_c53c193ad2a36104 alignment mismatch");
+        if (@sizeOf(UdpSocket) != 4) @compileError("UdpSocket size mismatch");
+        if (@alignOf(UdpSocket) != 4) @compileError("UdpSocket alignment mismatch");
     }
 }
 
@@ -2817,18 +2919,18 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct_686570ce13fde405
-pub const __AnonStruct_686570ce13fde405 = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct_53d84a4d5bb34dcd
+pub const __AnonStruct_53d84a4d5bb34dcd = if (@sizeOf(usize) == 4) extern struct {
     bytes: RocListWith(u8, false),
     ip: RocStr,
-    socket: *u64,
+    socket: UdpSocket,
     port: u16,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
         value.bytes.decref(roc_host);
         value.ip.decref(roc_host);
-        decrefBoxWith(@ptrCast(value.socket), @alignOf(u64), false, null, roc_host);
+        value.socket.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
@@ -2836,19 +2938,19 @@ pub const __AnonStruct_686570ce13fde405 = if (@sizeOf(usize) == 4) extern struct
         const value = self;
         value.bytes.incref(amount);
         value.ip.incref(amount);
-        increfBox(@ptrCast(value.socket), amount);
+        value.socket.incref(amount);
     }
 } else extern struct {
     bytes: RocListWith(u8, false),
     ip: RocStr,
-    socket: *u64,
+    socket: UdpSocket,
     port: u16,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
         value.bytes.decref(roc_host);
         value.ip.decref(roc_host);
-        decrefBoxWith(@ptrCast(value.socket), @alignOf(u64), false, null, roc_host);
+        value.socket.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
@@ -2856,26 +2958,25 @@ pub const __AnonStruct_686570ce13fde405 = if (@sizeOf(usize) == 4) extern struct
         const value = self;
         value.bytes.incref(amount);
         value.ip.incref(amount);
-        increfBox(@ptrCast(value.socket), amount);
+        value.socket.incref(amount);
     }
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_686570ce13fde405) != 64) @compileError("__AnonStruct_686570ce13fde405 size mismatch");
-        if (@alignOf(__AnonStruct_686570ce13fde405) != 8) @compileError("__AnonStruct_686570ce13fde405 alignment mismatch");
+        if (@sizeOf(__AnonStruct_53d84a4d5bb34dcd) != 64) @compileError("__AnonStruct_53d84a4d5bb34dcd size mismatch");
+        if (@alignOf(__AnonStruct_53d84a4d5bb34dcd) != 8) @compileError("__AnonStruct_53d84a4d5bb34dcd alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_686570ce13fde405) != 32) @compileError("__AnonStruct_686570ce13fde405 size mismatch");
-        if (@alignOf(__AnonStruct_686570ce13fde405) != 4) @compileError("__AnonStruct_686570ce13fde405 alignment mismatch");
+        if (@sizeOf(__AnonStruct_53d84a4d5bb34dcd) != 32) @compileError("__AnonStruct_53d84a4d5bb34dcd size mismatch");
+        if (@alignOf(__AnonStruct_53d84a4d5bb34dcd) != 4) @compileError("__AnonStruct_53d84a4d5bb34dcd alignment mismatch");
     }
 }
 
-/// Element type for __AnonStruct_c44117854a91f9a7
-pub const __AnonStruct_c44117854a91f9a7 = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct_1772298ecb801858
+pub const __AnonStruct_1772298ecb801858 = if (@sizeOf(usize) == 4) extern struct {
     payload: RocListWith(u8, false),
     slices: RocListWith(__AnonStruct_4dd3180405b3f44f, false),
-    err: u8,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
@@ -2892,7 +2993,6 @@ pub const __AnonStruct_c44117854a91f9a7 = if (@sizeOf(usize) == 4) extern struct
 } else extern struct {
     payload: RocListWith(u8, false),
     slices: RocListWith(__AnonStruct_4dd3180405b3f44f, false),
-    err: u8,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
@@ -2910,12 +3010,12 @@ pub const __AnonStruct_c44117854a91f9a7 = if (@sizeOf(usize) == 4) extern struct
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_c44117854a91f9a7) != 56) @compileError("__AnonStruct_c44117854a91f9a7 size mismatch");
-        if (@alignOf(__AnonStruct_c44117854a91f9a7) != 8) @compileError("__AnonStruct_c44117854a91f9a7 alignment mismatch");
+        if (@sizeOf(__AnonStruct_1772298ecb801858) != 48) @compileError("__AnonStruct_1772298ecb801858 size mismatch");
+        if (@alignOf(__AnonStruct_1772298ecb801858) != 8) @compileError("__AnonStruct_1772298ecb801858 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_c44117854a91f9a7) != 28) @compileError("__AnonStruct_c44117854a91f9a7 size mismatch");
-        if (@alignOf(__AnonStruct_c44117854a91f9a7) != 4) @compileError("__AnonStruct_c44117854a91f9a7 alignment mismatch");
+        if (@sizeOf(__AnonStruct_1772298ecb801858) != 24) @compileError("__AnonStruct_1772298ecb801858 size mismatch");
+        if (@alignOf(__AnonStruct_1772298ecb801858) != 4) @compileError("__AnonStruct_1772298ecb801858 alignment mismatch");
     }
 }
 
@@ -2969,47 +3069,47 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct_3d573c3bcb10a375
-pub const __AnonStruct_3d573c3bcb10a375 = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct_c0489e409fcc99cd
+pub const __AnonStruct_c0489e409fcc99cd = if (@sizeOf(usize) == 4) extern struct {
     timeout_ms: u64,
-    socket: *u64,
+    socket: UdpSocket,
     max_datagrams: u32,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        decrefBoxWith(@ptrCast(value.socket), @alignOf(u64), false, null, roc_host);
+        value.socket.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        increfBox(@ptrCast(value.socket), amount);
+        value.socket.incref(amount);
     }
 } else extern struct {
     timeout_ms: u64,
-    socket: *u64,
+    socket: UdpSocket,
     max_datagrams: u32,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        decrefBoxWith(@ptrCast(value.socket), @alignOf(u64), false, null, roc_host);
+        value.socket.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        increfBox(@ptrCast(value.socket), amount);
+        value.socket.incref(amount);
     }
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_3d573c3bcb10a375) != 24) @compileError("__AnonStruct_3d573c3bcb10a375 size mismatch");
-        if (@alignOf(__AnonStruct_3d573c3bcb10a375) != 8) @compileError("__AnonStruct_3d573c3bcb10a375 alignment mismatch");
+        if (@sizeOf(__AnonStruct_c0489e409fcc99cd) != 24) @compileError("__AnonStruct_c0489e409fcc99cd size mismatch");
+        if (@alignOf(__AnonStruct_c0489e409fcc99cd) != 8) @compileError("__AnonStruct_c0489e409fcc99cd alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_3d573c3bcb10a375) != 16) @compileError("__AnonStruct_3d573c3bcb10a375 size mismatch");
-        if (@alignOf(__AnonStruct_3d573c3bcb10a375) != 8) @compileError("__AnonStruct_3d573c3bcb10a375 alignment mismatch");
+        if (@sizeOf(__AnonStruct_c0489e409fcc99cd) != 16) @compileError("__AnonStruct_c0489e409fcc99cd size mismatch");
+        if (@alignOf(__AnonStruct_c0489e409fcc99cd) != 8) @compileError("__AnonStruct_c0489e409fcc99cd alignment mismatch");
     }
 }
 
@@ -3711,57 +3811,9 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct_d1ff90659ed42132
-pub const __AnonStruct_d1ff90659ed42132 = if (@sizeOf(usize) == 4) extern struct {
-    err: i64,
-    db: *u64,
-    message: RocStr,
-    /// Recursively decrement Roc-owned fields.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        const value = self;
-        decrefBoxWith(@ptrCast(value.db), @alignOf(u64), false, null, roc_host);
-        value.message.decref(roc_host);
-    }
-
-    /// Increment Roc-owned fields.
-    pub fn incref(self: @This(), amount: isize) void {
-        const value = self;
-        increfBox(@ptrCast(value.db), amount);
-        value.message.incref(amount);
-    }
-} else extern struct {
-    err: i64,
-    db: *u64,
-    message: RocStr,
-    /// Recursively decrement Roc-owned fields.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        const value = self;
-        decrefBoxWith(@ptrCast(value.db), @alignOf(u64), false, null, roc_host);
-        value.message.decref(roc_host);
-    }
-
-    /// Increment Roc-owned fields.
-    pub fn incref(self: @This(), amount: isize) void {
-        const value = self;
-        increfBox(@ptrCast(value.db), amount);
-        value.message.incref(amount);
-    }
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_d1ff90659ed42132) != 40) @compileError("__AnonStruct_d1ff90659ed42132 size mismatch");
-        if (@alignOf(__AnonStruct_d1ff90659ed42132) != 8) @compileError("__AnonStruct_d1ff90659ed42132 alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_d1ff90659ed42132) != 24) @compileError("__AnonStruct_d1ff90659ed42132 size mismatch");
-        if (@alignOf(__AnonStruct_d1ff90659ed42132) != 8) @compileError("__AnonStruct_d1ff90659ed42132 alignment mismatch");
-    }
-}
-
-/// Element type for __AnonStruct_e7ff50a9dfab1a8d
-pub const __AnonStruct_e7ff50a9dfab1a8d = if (@sizeOf(usize) == 4) extern struct {
-    err: i64,
+/// Element type for __AnonStruct_22cf486058afc711
+pub const __AnonStruct_22cf486058afc711 = if (@sizeOf(usize) == 4) extern struct {
+    code: i64,
     message: RocStr,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
@@ -3775,7 +3827,7 @@ pub const __AnonStruct_e7ff50a9dfab1a8d = if (@sizeOf(usize) == 4) extern struct
         value.message.incref(amount);
     }
 } else extern struct {
-    err: i64,
+    code: i64,
     message: RocStr,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
@@ -3792,79 +3844,108 @@ pub const __AnonStruct_e7ff50a9dfab1a8d = if (@sizeOf(usize) == 4) extern struct
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_e7ff50a9dfab1a8d) != 32) @compileError("__AnonStruct_e7ff50a9dfab1a8d size mismatch");
-        if (@alignOf(__AnonStruct_e7ff50a9dfab1a8d) != 8) @compileError("__AnonStruct_e7ff50a9dfab1a8d alignment mismatch");
+        if (@sizeOf(__AnonStruct_22cf486058afc711) != 32) @compileError("__AnonStruct_22cf486058afc711 size mismatch");
+        if (@alignOf(__AnonStruct_22cf486058afc711) != 8) @compileError("__AnonStruct_22cf486058afc711 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_e7ff50a9dfab1a8d) != 24) @compileError("__AnonStruct_e7ff50a9dfab1a8d size mismatch");
-        if (@alignOf(__AnonStruct_e7ff50a9dfab1a8d) != 8) @compileError("__AnonStruct_e7ff50a9dfab1a8d alignment mismatch");
+        if (@sizeOf(__AnonStruct_22cf486058afc711) != 24) @compileError("__AnonStruct_22cf486058afc711 size mismatch");
+        if (@alignOf(__AnonStruct_22cf486058afc711) != 8) @compileError("__AnonStruct_22cf486058afc711 alignment mismatch");
     }
 }
 
-/// Element type for __AnonStruct_cff0e6766f0cb5bf
-pub const __AnonStruct_cff0e6766f0cb5bf = if (@sizeOf(usize) == 4) extern struct {
-    err: i64,
-    message: RocStr,
-    stmt: *u64,
+/// Element type for SqliteDb
+pub const SqliteDb = if (@sizeOf(usize) == 4) extern struct {
+    handle: *u64,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        value.message.decref(roc_host);
-        decrefBoxWith(@ptrCast(value.stmt), @alignOf(u64), false, null, roc_host);
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        value.message.incref(amount);
-        increfBox(@ptrCast(value.stmt), amount);
+        increfBox(@ptrCast(value.handle), amount);
     }
 } else extern struct {
-    err: i64,
-    message: RocStr,
-    stmt: *u64,
+    handle: *u64,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        value.message.decref(roc_host);
-        decrefBoxWith(@ptrCast(value.stmt), @alignOf(u64), false, null, roc_host);
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        value.message.incref(amount);
-        increfBox(@ptrCast(value.stmt), amount);
+        increfBox(@ptrCast(value.handle), amount);
     }
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_cff0e6766f0cb5bf) != 40) @compileError("__AnonStruct_cff0e6766f0cb5bf size mismatch");
-        if (@alignOf(__AnonStruct_cff0e6766f0cb5bf) != 8) @compileError("__AnonStruct_cff0e6766f0cb5bf alignment mismatch");
+        if (@sizeOf(SqliteDb) != 8) @compileError("SqliteDb size mismatch");
+        if (@alignOf(SqliteDb) != 8) @compileError("SqliteDb alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_cff0e6766f0cb5bf) != 24) @compileError("__AnonStruct_cff0e6766f0cb5bf size mismatch");
-        if (@alignOf(__AnonStruct_cff0e6766f0cb5bf) != 8) @compileError("__AnonStruct_cff0e6766f0cb5bf alignment mismatch");
+        if (@sizeOf(SqliteDb) != 4) @compileError("SqliteDb size mismatch");
+        if (@alignOf(SqliteDb) != 4) @compileError("SqliteDb alignment mismatch");
     }
 }
 
-/// Element type for __AnonStruct_4bc5d3695423e2f1
-pub const __AnonStruct_4bc5d3695423e2f1 = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for SqliteStmt
+pub const SqliteStmt = if (@sizeOf(usize) == 4) extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+} else extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(SqliteStmt) != 8) @compileError("SqliteStmt size mismatch");
+        if (@alignOf(SqliteStmt) != 8) @compileError("SqliteStmt alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(SqliteStmt) != 4) @compileError("SqliteStmt size mismatch");
+        if (@alignOf(SqliteStmt) != 4) @compileError("SqliteStmt alignment mismatch");
+    }
+}
+
+/// Element type for __AnonStruct_566a76c01f44ee92
+pub const __AnonStruct_566a76c01f44ee92 = if (@sizeOf(usize) == 4) extern struct {
     changes: i64,
-    err: i64,
     last_insert_rowid: i64,
     ncols: u64,
     row_count: u64,
     cells: RocListWith(__AnonStruct_3a90da783672cf8d, false),
-    message: RocStr,
     names: RocListWith(u8, false),
     payload: RocListWith(u8, false),
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
         value.cells.decref(roc_host);
-        value.message.decref(roc_host);
         value.names.decref(roc_host);
         value.payload.decref(roc_host);
     }
@@ -3873,25 +3954,21 @@ pub const __AnonStruct_4bc5d3695423e2f1 = if (@sizeOf(usize) == 4) extern struct
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
         value.cells.incref(amount);
-        value.message.incref(amount);
         value.names.incref(amount);
         value.payload.incref(amount);
     }
 } else extern struct {
     changes: i64,
-    err: i64,
     last_insert_rowid: i64,
     ncols: u64,
     row_count: u64,
     cells: RocListWith(__AnonStruct_3a90da783672cf8d, false),
-    message: RocStr,
     names: RocListWith(u8, false),
     payload: RocListWith(u8, false),
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
         value.cells.decref(roc_host);
-        value.message.decref(roc_host);
         value.names.decref(roc_host);
         value.payload.decref(roc_host);
     }
@@ -3900,7 +3977,6 @@ pub const __AnonStruct_4bc5d3695423e2f1 = if (@sizeOf(usize) == 4) extern struct
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
         value.cells.incref(amount);
-        value.message.incref(amount);
         value.names.incref(amount);
         value.payload.incref(amount);
     }
@@ -3908,12 +3984,12 @@ pub const __AnonStruct_4bc5d3695423e2f1 = if (@sizeOf(usize) == 4) extern struct
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_4bc5d3695423e2f1) != 136) @compileError("__AnonStruct_4bc5d3695423e2f1 size mismatch");
-        if (@alignOf(__AnonStruct_4bc5d3695423e2f1) != 8) @compileError("__AnonStruct_4bc5d3695423e2f1 alignment mismatch");
+        if (@sizeOf(__AnonStruct_566a76c01f44ee92) != 104) @compileError("__AnonStruct_566a76c01f44ee92 size mismatch");
+        if (@alignOf(__AnonStruct_566a76c01f44ee92) != 8) @compileError("__AnonStruct_566a76c01f44ee92 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_4bc5d3695423e2f1) != 88) @compileError("__AnonStruct_4bc5d3695423e2f1 size mismatch");
-        if (@alignOf(__AnonStruct_4bc5d3695423e2f1) != 8) @compileError("__AnonStruct_4bc5d3695423e2f1 alignment mismatch");
+        if (@sizeOf(__AnonStruct_566a76c01f44ee92) != 72) @compileError("__AnonStruct_566a76c01f44ee92 size mismatch");
+        if (@alignOf(__AnonStruct_566a76c01f44ee92) != 8) @compileError("__AnonStruct_566a76c01f44ee92 alignment mismatch");
     }
 }
 
@@ -4381,15 +4457,15 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct_6bff15fb6a4cb85a
-pub const __AnonStruct_6bff15fb6a4cb85a = if (@sizeOf(usize) == 4) extern struct {
-    prepared: *u64,
+/// Element type for __AnonStruct_8dc97a0a319d4d53
+pub const __AnonStruct_8dc97a0a319d4d53 = if (@sizeOf(usize) == 4) extern struct {
+    prepared: TextPrepared,
     pos: MathVec2,
     color: ColorRgba,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        decrefBoxWith(@ptrCast(value.prepared), @alignOf(u64), false, null, roc_host);
+        value.prepared.decref(roc_host);
         value.pos.decref(roc_host);
         value.color.decref(roc_host);
     }
@@ -4397,18 +4473,18 @@ pub const __AnonStruct_6bff15fb6a4cb85a = if (@sizeOf(usize) == 4) extern struct
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        increfBox(@ptrCast(value.prepared), amount);
+        value.prepared.incref(amount);
         value.pos.incref(amount);
         value.color.incref(amount);
     }
 } else extern struct {
-    prepared: *u64,
+    prepared: TextPrepared,
     pos: MathVec2,
     color: ColorRgba,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        decrefBoxWith(@ptrCast(value.prepared), @alignOf(u64), false, null, roc_host);
+        value.prepared.decref(roc_host);
         value.pos.decref(roc_host);
         value.color.decref(roc_host);
     }
@@ -4416,7 +4492,7 @@ pub const __AnonStruct_6bff15fb6a4cb85a = if (@sizeOf(usize) == 4) extern struct
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        increfBox(@ptrCast(value.prepared), amount);
+        value.prepared.incref(amount);
         value.pos.incref(amount);
         value.color.incref(amount);
     }
@@ -4424,12 +4500,12 @@ pub const __AnonStruct_6bff15fb6a4cb85a = if (@sizeOf(usize) == 4) extern struct
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_6bff15fb6a4cb85a) != 24) @compileError("__AnonStruct_6bff15fb6a4cb85a size mismatch");
-        if (@alignOf(__AnonStruct_6bff15fb6a4cb85a) != 8) @compileError("__AnonStruct_6bff15fb6a4cb85a alignment mismatch");
+        if (@sizeOf(__AnonStruct_8dc97a0a319d4d53) != 24) @compileError("__AnonStruct_8dc97a0a319d4d53 size mismatch");
+        if (@alignOf(__AnonStruct_8dc97a0a319d4d53) != 8) @compileError("__AnonStruct_8dc97a0a319d4d53 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_6bff15fb6a4cb85a) != 16) @compileError("__AnonStruct_6bff15fb6a4cb85a size mismatch");
-        if (@alignOf(__AnonStruct_6bff15fb6a4cb85a) != 4) @compileError("__AnonStruct_6bff15fb6a4cb85a alignment mismatch");
+        if (@sizeOf(__AnonStruct_8dc97a0a319d4d53) != 16) @compileError("__AnonStruct_8dc97a0a319d4d53 size mismatch");
+        if (@alignOf(__AnonStruct_8dc97a0a319d4d53) != 4) @compileError("__AnonStruct_8dc97a0a319d4d53 alignment mismatch");
     }
 }
 
@@ -5527,11 +5603,10 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct_7c66fb01c50d182a
-pub const __AnonStruct_7c66fb01c50d182a = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct_5c978c17ba0c990a
+pub const __AnonStruct_5c978c17ba0c990a = if (@sizeOf(usize) == 4) extern struct {
     bytes: u64,
     frames: u64,
-    err: u8,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
@@ -5548,7 +5623,6 @@ pub const __AnonStruct_7c66fb01c50d182a = if (@sizeOf(usize) == 4) extern struct
 } else extern struct {
     bytes: u64,
     frames: u64,
-    err: u8,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
@@ -5566,12 +5640,12 @@ pub const __AnonStruct_7c66fb01c50d182a = if (@sizeOf(usize) == 4) extern struct
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_7c66fb01c50d182a) != 24) @compileError("__AnonStruct_7c66fb01c50d182a size mismatch");
-        if (@alignOf(__AnonStruct_7c66fb01c50d182a) != 8) @compileError("__AnonStruct_7c66fb01c50d182a alignment mismatch");
+        if (@sizeOf(__AnonStruct_5c978c17ba0c990a) != 16) @compileError("__AnonStruct_5c978c17ba0c990a size mismatch");
+        if (@alignOf(__AnonStruct_5c978c17ba0c990a) != 8) @compileError("__AnonStruct_5c978c17ba0c990a alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_7c66fb01c50d182a) != 24) @compileError("__AnonStruct_7c66fb01c50d182a size mismatch");
-        if (@alignOf(__AnonStruct_7c66fb01c50d182a) != 8) @compileError("__AnonStruct_7c66fb01c50d182a alignment mismatch");
+        if (@sizeOf(__AnonStruct_5c978c17ba0c990a) != 16) @compileError("__AnonStruct_5c978c17ba0c990a size mismatch");
+        if (@alignOf(__AnonStruct_5c978c17ba0c990a) != 8) @compileError("__AnonStruct_5c978c17ba0c990a alignment mismatch");
     }
 }
 
@@ -5621,11 +5695,10 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct_50fe0879143e3c18
-pub const __AnonStruct_50fe0879143e3c18 = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct_bda5c9dc6cabe78e
+pub const __AnonStruct_bda5c9dc6cabe78e = if (@sizeOf(usize) == 4) extern struct {
     a: u8,
     b: u8,
-    err: u8,
     g: u8,
     r: u8,
     /// Recursively decrement Roc-owned fields.
@@ -5644,7 +5717,6 @@ pub const __AnonStruct_50fe0879143e3c18 = if (@sizeOf(usize) == 4) extern struct
 } else extern struct {
     a: u8,
     b: u8,
-    err: u8,
     g: u8,
     r: u8,
     /// Recursively decrement Roc-owned fields.
@@ -5664,12 +5736,12 @@ pub const __AnonStruct_50fe0879143e3c18 = if (@sizeOf(usize) == 4) extern struct
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct_50fe0879143e3c18) != 5) @compileError("__AnonStruct_50fe0879143e3c18 size mismatch");
-        if (@alignOf(__AnonStruct_50fe0879143e3c18) != 1) @compileError("__AnonStruct_50fe0879143e3c18 alignment mismatch");
+        if (@sizeOf(__AnonStruct_bda5c9dc6cabe78e) != 4) @compileError("__AnonStruct_bda5c9dc6cabe78e size mismatch");
+        if (@alignOf(__AnonStruct_bda5c9dc6cabe78e) != 1) @compileError("__AnonStruct_bda5c9dc6cabe78e alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct_50fe0879143e3c18) != 5) @compileError("__AnonStruct_50fe0879143e3c18 size mismatch");
-        if (@alignOf(__AnonStruct_50fe0879143e3c18) != 1) @compileError("__AnonStruct_50fe0879143e3c18 alignment mismatch");
+        if (@sizeOf(__AnonStruct_bda5c9dc6cabe78e) != 4) @compileError("__AnonStruct_bda5c9dc6cabe78e size mismatch");
+        if (@alignOf(__AnonStruct_bda5c9dc6cabe78e) != 1) @compileError("__AnonStruct_bda5c9dc6cabe78e alignment mismatch");
     }
 }
 
@@ -7209,7 +7281,7 @@ pub const HostText_prepareResultTag = enum(u8) {
 /// Payload union for Try.
 pub const HostText_prepareResultPayload = extern union {
     err: InvalidResourceOrResourceLimit,
-    ok: __AnonStruct_e1165210b218b76c,
+    ok: __AnonStruct_34e6157b936793f4,
 };
 
 /// Tag union: Try
@@ -7220,8 +7292,8 @@ pub const HostText_prepareResult = if (@sizeOf(usize) == 4) extern struct {
         const ptr: *const InvalidResourceOrResourceLimit = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
-    pub fn payload_ok(self: *const @This()) __AnonStruct_e1165210b218b76c {
-        const ptr: *const __AnonStruct_e1165210b218b76c = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_ok(self: *const @This()) __AnonStruct_34e6157b936793f4 {
+        const ptr: *const __AnonStruct_34e6157b936793f4 = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     /// Recursively decrement Roc-owned payloads.
@@ -7239,7 +7311,7 @@ pub const HostText_prepareResult = if (@sizeOf(usize) == 4) extern struct {
     pub fn payload_err(self: *const @This()) InvalidResourceOrResourceLimit {
         return self.payload.err;
     }
-    pub fn payload_ok(self: *const @This()) __AnonStruct_e1165210b218b76c {
+    pub fn payload_ok(self: *const @This()) __AnonStruct_34e6157b936793f4 {
         return self.payload.ok;
     }
     /// Recursively decrement Roc-owned payloads.
@@ -7494,7 +7566,7 @@ pub const HostStore_openResultTag = enum(u8) {
 /// Payload union for Try.
 pub const HostStore_openResultPayload = extern union {
     err: AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch,
-    ok: *u64,
+    ok: Store,
 };
 
 /// Tag union: Try
@@ -7505,8 +7577,8 @@ pub const HostStore_openResult = if (@sizeOf(usize) == 4) extern struct {
         const ptr: *const AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
-    pub fn payload_ok(self: *const @This()) *u64 {
-        const ptr: *const *u64 = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_ok(self: *const @This()) Store {
+        const ptr: *const Store = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     /// Recursively decrement Roc-owned payloads.
@@ -7524,7 +7596,7 @@ pub const HostStore_openResult = if (@sizeOf(usize) == 4) extern struct {
     pub fn payload_err(self: *const @This()) AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch {
         return self.payload.err;
     }
-    pub fn payload_ok(self: *const @This()) *u64 {
+    pub fn payload_ok(self: *const @This()) Store {
         return self.payload.ok;
     }
     /// Recursively decrement Roc-owned payloads.
@@ -7599,7 +7671,7 @@ pub const HostAudio_gen_toneResultTag = enum(u8) {
 /// Payload union for Try.
 pub const HostAudio_gen_toneResultPayload = extern union {
     err: ResourceLimitOrSoundGenerationFailed,
-    ok: *u64,
+    ok: AudioSound,
 };
 
 /// Tag union: Try
@@ -7610,8 +7682,8 @@ pub const HostAudio_gen_toneResult = if (@sizeOf(usize) == 4) extern struct {
         const ptr: *const ResourceLimitOrSoundGenerationFailed = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
-    pub fn payload_ok(self: *const @This()) *u64 {
-        const ptr: *const *u64 = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_ok(self: *const @This()) AudioSound {
+        const ptr: *const AudioSound = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     /// Recursively decrement Roc-owned payloads.
@@ -7629,7 +7701,7 @@ pub const HostAudio_gen_toneResult = if (@sizeOf(usize) == 4) extern struct {
     pub fn payload_err(self: *const @This()) ResourceLimitOrSoundGenerationFailed {
         return self.payload.err;
     }
-    pub fn payload_ok(self: *const @This()) *u64 {
+    pub fn payload_ok(self: *const @This()) AudioSound {
         return self.payload.ok;
     }
     /// Recursively decrement Roc-owned payloads.
@@ -7693,7 +7765,7 @@ pub const HostAudio_load_soundResultTag = enum(u8) {
 /// Payload union for Try.
 pub const HostAudio_load_soundResultPayload = extern union {
     err: ResourceLimitOrSoundLoadFailed,
-    ok: *u64,
+    ok: AudioSound,
 };
 
 /// Tag union: Try
@@ -7704,8 +7776,8 @@ pub const HostAudio_load_soundResult = if (@sizeOf(usize) == 4) extern struct {
         const ptr: *const ResourceLimitOrSoundLoadFailed = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
-    pub fn payload_ok(self: *const @This()) *u64 {
-        const ptr: *const *u64 = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_ok(self: *const @This()) AudioSound {
+        const ptr: *const AudioSound = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     /// Recursively decrement Roc-owned payloads.
@@ -7723,7 +7795,7 @@ pub const HostAudio_load_soundResult = if (@sizeOf(usize) == 4) extern struct {
     pub fn payload_err(self: *const @This()) ResourceLimitOrSoundLoadFailed {
         return self.payload.err;
     }
-    pub fn payload_ok(self: *const @This()) *u64 {
+    pub fn payload_ok(self: *const @This()) AudioSound {
         return self.payload.ok;
     }
     /// Recursively decrement Roc-owned payloads.
@@ -7787,7 +7859,7 @@ pub const HostAudio_load_musicResultTag = enum(u8) {
 /// Payload union for Try.
 pub const HostAudio_load_musicResultPayload = extern union {
     err: MusicLoadFailedOrResourceLimit,
-    ok: *u64,
+    ok: AudioMusic,
 };
 
 /// Tag union: Try
@@ -7798,8 +7870,8 @@ pub const HostAudio_load_musicResult = if (@sizeOf(usize) == 4) extern struct {
         const ptr: *const MusicLoadFailedOrResourceLimit = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
-    pub fn payload_ok(self: *const @This()) *u64 {
-        const ptr: *const *u64 = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_ok(self: *const @This()) AudioMusic {
+        const ptr: *const AudioMusic = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     /// Recursively decrement Roc-owned payloads.
@@ -7817,7 +7889,7 @@ pub const HostAudio_load_musicResult = if (@sizeOf(usize) == 4) extern struct {
     pub fn payload_err(self: *const @This()) MusicLoadFailedOrResourceLimit {
         return self.payload.err;
     }
-    pub fn payload_ok(self: *const @This()) *u64 {
+    pub fn payload_ok(self: *const @This()) AudioMusic {
         return self.payload.ok;
     }
     /// Recursively decrement Roc-owned payloads.
@@ -7869,6 +7941,855 @@ comptime {
     if (@sizeOf(usize) == 4) {
         if (@sizeOf(MusicLoadFailedOrResourceLimit) != 1) @compileError("MusicLoadFailedOrResourceLimit size mismatch");
         if (@alignOf(MusicLoadFailedOrResourceLimit) != 1) @compileError("MusicLoadFailedOrResourceLimit alignment mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostFiles_read_textResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostFiles_read_textResultPayload = extern union {
+    err: BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable,
+    ok: RocStr,
+};
+
+/// Tag union: Try
+pub const HostFiles_read_textResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [12]u8 align(4),
+    tag: HostFiles_read_textResultTag,
+    pub fn payload_err(self: *const @This()) BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable {
+        const ptr: *const BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    pub fn payload_ok(self: *const @This()) RocStr {
+        const ptr: *const RocStr = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostFiles_read_textResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostFiles_read_textResult(self, amount);
+    }
+} else extern struct {
+    payload: HostFiles_read_textResultPayload,
+    tag: HostFiles_read_textResultTag,
+    pub fn payload_err(self: *const @This()) BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable {
+        return self.payload.err;
+    }
+    pub fn payload_ok(self: *const @This()) RocStr {
+        return self.payload.ok;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostFiles_read_textResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostFiles_read_textResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostFiles_read_textResult) != 32) @compileError("HostFiles_read_textResult size mismatch");
+        if (@alignOf(HostFiles_read_textResult) != 8) @compileError("HostFiles_read_textResult alignment mismatch");
+        if (@offsetOf(HostFiles_read_textResult, "tag") != 24) @compileError("HostFiles_read_textResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostFiles_read_textResult) != 16) @compileError("HostFiles_read_textResult size mismatch");
+        if (@alignOf(HostFiles_read_textResult) != 4) @compileError("HostFiles_read_textResult alignment mismatch");
+        if (@offsetOf(HostFiles_read_textResult, "tag") != 12) @compileError("HostFiles_read_textResult tag offset mismatch");
+    }
+}
+
+/// Tag union: BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable
+pub const BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable = enum(u8) {
+    busy = 0,
+    not_found = 1,
+    not_utf8 = 2,
+    read_failed = 3,
+    too_large = 4,
+    unavailable = 5,
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        _ = self;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        _ = self;
+        _ = amount;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable size mismatch");
+        if (@alignOf(BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable size mismatch");
+        if (@alignOf(BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable alignment mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostFiles_metadataResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostFiles_metadataResultPayload = extern union {
+    err: NotFoundOrPermissionDeniedOrReadFailedOrUnavailable,
+    ok: __AnonStruct_a1f5c33e74b3920b,
+};
+
+/// Tag union: Try
+pub const HostFiles_metadataResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [24]u8 align(8),
+    tag: HostFiles_metadataResultTag,
+    pub fn payload_err(self: *const @This()) NotFoundOrPermissionDeniedOrReadFailedOrUnavailable {
+        const ptr: *const NotFoundOrPermissionDeniedOrReadFailedOrUnavailable = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    pub fn payload_ok(self: *const @This()) __AnonStruct_a1f5c33e74b3920b {
+        const ptr: *const __AnonStruct_a1f5c33e74b3920b = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostFiles_metadataResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostFiles_metadataResult(self, amount);
+    }
+} else extern struct {
+    payload: HostFiles_metadataResultPayload,
+    tag: HostFiles_metadataResultTag,
+    pub fn payload_err(self: *const @This()) NotFoundOrPermissionDeniedOrReadFailedOrUnavailable {
+        return self.payload.err;
+    }
+    pub fn payload_ok(self: *const @This()) __AnonStruct_a1f5c33e74b3920b {
+        return self.payload.ok;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostFiles_metadataResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostFiles_metadataResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostFiles_metadataResult) != 32) @compileError("HostFiles_metadataResult size mismatch");
+        if (@alignOf(HostFiles_metadataResult) != 8) @compileError("HostFiles_metadataResult alignment mismatch");
+        if (@offsetOf(HostFiles_metadataResult, "tag") != 24) @compileError("HostFiles_metadataResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostFiles_metadataResult) != 32) @compileError("HostFiles_metadataResult size mismatch");
+        if (@alignOf(HostFiles_metadataResult) != 8) @compileError("HostFiles_metadataResult alignment mismatch");
+        if (@offsetOf(HostFiles_metadataResult, "tag") != 24) @compileError("HostFiles_metadataResult tag offset mismatch");
+    }
+}
+
+/// Tag union: NotFoundOrPermissionDeniedOrReadFailedOrUnavailable
+pub const NotFoundOrPermissionDeniedOrReadFailedOrUnavailable = enum(u8) {
+    not_found = 0,
+    permission_denied = 1,
+    read_failed = 2,
+    unavailable = 3,
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        _ = self;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        _ = self;
+        _ = amount;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(NotFoundOrPermissionDeniedOrReadFailedOrUnavailable) != 1) @compileError("NotFoundOrPermissionDeniedOrReadFailedOrUnavailable size mismatch");
+        if (@alignOf(NotFoundOrPermissionDeniedOrReadFailedOrUnavailable) != 1) @compileError("NotFoundOrPermissionDeniedOrReadFailedOrUnavailable alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(NotFoundOrPermissionDeniedOrReadFailedOrUnavailable) != 1) @compileError("NotFoundOrPermissionDeniedOrReadFailedOrUnavailable size mismatch");
+        if (@alignOf(NotFoundOrPermissionDeniedOrReadFailedOrUnavailable) != 1) @compileError("NotFoundOrPermissionDeniedOrReadFailedOrUnavailable alignment mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostFiles_read_bytesResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostFiles_read_bytesResultPayload = extern union {
+    err: BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable,
+    ok: RocListWith(u8, false),
+};
+
+/// Tag union: Try
+pub const HostFiles_read_bytesResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [12]u8 align(4),
+    tag: HostFiles_read_bytesResultTag,
+    pub fn payload_err(self: *const @This()) BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable {
+        const ptr: *const BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    pub fn payload_ok(self: *const @This()) RocListWith(u8, false) {
+        const ptr: *const RocListWith(u8, false) = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostFiles_read_bytesResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostFiles_read_bytesResult(self, amount);
+    }
+} else extern struct {
+    payload: HostFiles_read_bytesResultPayload,
+    tag: HostFiles_read_bytesResultTag,
+    pub fn payload_err(self: *const @This()) BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable {
+        return self.payload.err;
+    }
+    pub fn payload_ok(self: *const @This()) RocListWith(u8, false) {
+        return self.payload.ok;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostFiles_read_bytesResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostFiles_read_bytesResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostFiles_read_bytesResult) != 32) @compileError("HostFiles_read_bytesResult size mismatch");
+        if (@alignOf(HostFiles_read_bytesResult) != 8) @compileError("HostFiles_read_bytesResult alignment mismatch");
+        if (@offsetOf(HostFiles_read_bytesResult, "tag") != 24) @compileError("HostFiles_read_bytesResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostFiles_read_bytesResult) != 16) @compileError("HostFiles_read_bytesResult size mismatch");
+        if (@alignOf(HostFiles_read_bytesResult) != 4) @compileError("HostFiles_read_bytesResult alignment mismatch");
+        if (@offsetOf(HostFiles_read_bytesResult, "tag") != 12) @compileError("HostFiles_read_bytesResult tag offset mismatch");
+    }
+}
+
+/// Tag union: BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable
+pub const BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable = enum(u8) {
+    busy = 0,
+    not_found = 1,
+    read_failed = 2,
+    too_large = 3,
+    unavailable = 4,
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        _ = self;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        _ = self;
+        _ = amount;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable size mismatch");
+        if (@alignOf(BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable size mismatch");
+        if (@alignOf(BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable alignment mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostFiles_listResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostFiles_listResultPayload = extern union {
+    err: BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable,
+    ok: RocListWith(u8, false),
+};
+
+/// Tag union: Try
+pub const HostFiles_listResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [12]u8 align(4),
+    tag: HostFiles_listResultTag,
+    pub fn payload_err(self: *const @This()) BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable {
+        const ptr: *const BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    pub fn payload_ok(self: *const @This()) RocListWith(u8, false) {
+        const ptr: *const RocListWith(u8, false) = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostFiles_listResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostFiles_listResult(self, amount);
+    }
+} else extern struct {
+    payload: HostFiles_listResultPayload,
+    tag: HostFiles_listResultTag,
+    pub fn payload_err(self: *const @This()) BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable {
+        return self.payload.err;
+    }
+    pub fn payload_ok(self: *const @This()) RocListWith(u8, false) {
+        return self.payload.ok;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostFiles_listResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostFiles_listResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostFiles_listResult) != 32) @compileError("HostFiles_listResult size mismatch");
+        if (@alignOf(HostFiles_listResult) != 8) @compileError("HostFiles_listResult alignment mismatch");
+        if (@offsetOf(HostFiles_listResult, "tag") != 24) @compileError("HostFiles_listResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostFiles_listResult) != 16) @compileError("HostFiles_listResult size mismatch");
+        if (@alignOf(HostFiles_listResult) != 4) @compileError("HostFiles_listResult alignment mismatch");
+        if (@offsetOf(HostFiles_listResult, "tag") != 12) @compileError("HostFiles_listResult tag offset mismatch");
+    }
+}
+
+/// Tag union: BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable
+pub const BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable = enum(u8) {
+    busy = 0,
+    not_adirectory = 1,
+    not_found = 2,
+    read_failed = 3,
+    too_large = 4,
+    unavailable = 5,
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        _ = self;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        _ = self;
+        _ = amount;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable size mismatch");
+        if (@alignOf(BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable size mismatch");
+        if (@alignOf(BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable alignment mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostHttp_sendResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostHttp_sendResultPayload = extern union {
+    err: MalformedResponseOrNetworkErrorOrOtherOrTimeout,
+    ok: __AnonStruct_a14cd3b7d5755441,
+};
+
+/// Tag union: Try
+pub const HostHttp_sendResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [28]u8 align(4),
+    tag: HostHttp_sendResultTag,
+    pub fn payload_err(self: *const @This()) MalformedResponseOrNetworkErrorOrOtherOrTimeout {
+        const ptr: *const MalformedResponseOrNetworkErrorOrOtherOrTimeout = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    pub fn payload_ok(self: *const @This()) __AnonStruct_a14cd3b7d5755441 {
+        const ptr: *const __AnonStruct_a14cd3b7d5755441 = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostHttp_sendResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostHttp_sendResult(self, amount);
+    }
+} else extern struct {
+    payload: HostHttp_sendResultPayload,
+    tag: HostHttp_sendResultTag,
+    pub fn payload_err(self: *const @This()) MalformedResponseOrNetworkErrorOrOtherOrTimeout {
+        return self.payload.err;
+    }
+    pub fn payload_ok(self: *const @This()) __AnonStruct_a14cd3b7d5755441 {
+        return self.payload.ok;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostHttp_sendResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostHttp_sendResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostHttp_sendResult) != 64) @compileError("HostHttp_sendResult size mismatch");
+        if (@alignOf(HostHttp_sendResult) != 8) @compileError("HostHttp_sendResult alignment mismatch");
+        if (@offsetOf(HostHttp_sendResult, "tag") != 56) @compileError("HostHttp_sendResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostHttp_sendResult) != 32) @compileError("HostHttp_sendResult size mismatch");
+        if (@alignOf(HostHttp_sendResult) != 4) @compileError("HostHttp_sendResult alignment mismatch");
+        if (@offsetOf(HostHttp_sendResult, "tag") != 28) @compileError("HostHttp_sendResult tag offset mismatch");
+    }
+}
+
+/// Tag discriminant for MalformedResponseOrNetworkErrorOrOtherOrTimeout.
+pub const MalformedResponseOrNetworkErrorOrOtherOrTimeoutTag = enum(u8) {
+    MalformedResponse = 0,
+    NetworkError = 1,
+    Other = 2,
+    Timeout = 3,
+};
+
+/// Payload union for MalformedResponseOrNetworkErrorOrOtherOrTimeout.
+pub const MalformedResponseOrNetworkErrorOrOtherOrTimeoutPayload = extern union {
+    malformed_response: [0]u8,
+    network_error: [0]u8,
+    other: RocStr,
+    timeout: [0]u8,
+};
+
+/// Tag union: MalformedResponseOrNetworkErrorOrOtherOrTimeout
+pub const MalformedResponseOrNetworkErrorOrOtherOrTimeout = if (@sizeOf(usize) == 4) extern struct {
+    payload: [12]u8 align(4),
+    tag: MalformedResponseOrNetworkErrorOrOtherOrTimeoutTag,
+    pub fn payload_other(self: *const @This()) RocStr {
+        const ptr: *const RocStr = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefMalformedResponseOrNetworkErrorOrOtherOrTimeout(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfMalformedResponseOrNetworkErrorOrOtherOrTimeout(self, amount);
+    }
+} else extern struct {
+    payload: MalformedResponseOrNetworkErrorOrOtherOrTimeoutPayload,
+    tag: MalformedResponseOrNetworkErrorOrOtherOrTimeoutTag,
+    pub fn payload_other(self: *const @This()) RocStr {
+        return self.payload.other;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefMalformedResponseOrNetworkErrorOrOtherOrTimeout(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfMalformedResponseOrNetworkErrorOrOtherOrTimeout(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(MalformedResponseOrNetworkErrorOrOtherOrTimeout) != 32) @compileError("MalformedResponseOrNetworkErrorOrOtherOrTimeout size mismatch");
+        if (@alignOf(MalformedResponseOrNetworkErrorOrOtherOrTimeout) != 8) @compileError("MalformedResponseOrNetworkErrorOrOtherOrTimeout alignment mismatch");
+        if (@offsetOf(MalformedResponseOrNetworkErrorOrOtherOrTimeout, "tag") != 24) @compileError("MalformedResponseOrNetworkErrorOrOtherOrTimeout tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(MalformedResponseOrNetworkErrorOrOtherOrTimeout) != 16) @compileError("MalformedResponseOrNetworkErrorOrOtherOrTimeout size mismatch");
+        if (@alignOf(MalformedResponseOrNetworkErrorOrOtherOrTimeout) != 4) @compileError("MalformedResponseOrNetworkErrorOrOtherOrTimeout alignment mismatch");
+        if (@offsetOf(MalformedResponseOrNetworkErrorOrOtherOrTimeout, "tag") != 12) @compileError("MalformedResponseOrNetworkErrorOrOtherOrTimeout tag offset mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostCmd_runResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostCmd_runResultPayload = extern union {
+    err: BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable,
+    ok: __AnonStruct_45d496287297bf7f,
+};
+
+/// Tag union: Try
+pub const HostCmd_runResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [40]u8 align(8),
+    tag: HostCmd_runResultTag,
+    pub fn payload_err(self: *const @This()) BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable {
+        const ptr: *const BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    pub fn payload_ok(self: *const @This()) __AnonStruct_45d496287297bf7f {
+        const ptr: *const __AnonStruct_45d496287297bf7f = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostCmd_runResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostCmd_runResult(self, amount);
+    }
+} else extern struct {
+    payload: HostCmd_runResultPayload,
+    tag: HostCmd_runResultTag,
+    pub fn payload_err(self: *const @This()) BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable {
+        return self.payload.err;
+    }
+    pub fn payload_ok(self: *const @This()) __AnonStruct_45d496287297bf7f {
+        return self.payload.ok;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostCmd_runResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostCmd_runResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostCmd_runResult) != 72) @compileError("HostCmd_runResult size mismatch");
+        if (@alignOf(HostCmd_runResult) != 8) @compileError("HostCmd_runResult alignment mismatch");
+        if (@offsetOf(HostCmd_runResult, "tag") != 64) @compileError("HostCmd_runResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostCmd_runResult) != 48) @compileError("HostCmd_runResult size mismatch");
+        if (@alignOf(HostCmd_runResult) != 8) @compileError("HostCmd_runResult alignment mismatch");
+        if (@offsetOf(HostCmd_runResult, "tag") != 40) @compileError("HostCmd_runResult tag offset mismatch");
+    }
+}
+
+/// Tag discriminant for BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable.
+pub const BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailableTag = enum(u8) {
+    Busy = 0,
+    CommandNotFound = 1,
+    PermissionDenied = 2,
+    SpawnFailed = 3,
+    StderrLimitExceeded = 4,
+    StdoutLimitExceeded = 5,
+    Timeout = 6,
+    Unavailable = 7,
+};
+
+/// Payload union for BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable.
+pub const BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailablePayload = extern union {
+    busy: [0]u8,
+    command_not_found: [0]u8,
+    permission_denied: [0]u8,
+    spawn_failed: [0]u8,
+    stderr_limit_exceeded: [0]u8,
+    stdout_limit_exceeded: [0]u8,
+    timeout: __AnonStruct_45d496287297bf7f,
+    unavailable: [0]u8,
+};
+
+/// Tag union: BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable
+pub const BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable = if (@sizeOf(usize) == 4) extern struct {
+    payload: [32]u8 align(8),
+    tag: BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailableTag,
+    pub fn payload_timeout(self: *const @This()) __AnonStruct_45d496287297bf7f {
+        const ptr: *const __AnonStruct_45d496287297bf7f = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefBusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfBusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable(self, amount);
+    }
+} else extern struct {
+    payload: BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailablePayload,
+    tag: BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailableTag,
+    pub fn payload_timeout(self: *const @This()) __AnonStruct_45d496287297bf7f {
+        return self.payload.timeout;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefBusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfBusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable) != 64) @compileError("BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable size mismatch");
+        if (@alignOf(BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable) != 8) @compileError("BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable alignment mismatch");
+        if (@offsetOf(BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable, "tag") != 56) @compileError("BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable) != 40) @compileError("BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable size mismatch");
+        if (@alignOf(BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable) != 8) @compileError("BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable alignment mismatch");
+        if (@offsetOf(BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable, "tag") != 32) @compileError("BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable tag offset mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostUdp_bindResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostUdp_bindResultPayload = extern union {
+    err: AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable,
+    ok: __AnonStruct_77531de58035959,
+};
+
+/// Tag union: Try
+pub const HostUdp_bindResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [12]u8 align(4),
+    tag: HostUdp_bindResultTag,
+    pub fn payload_err(self: *const @This()) AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable {
+        const ptr: *const AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    pub fn payload_ok(self: *const @This()) __AnonStruct_77531de58035959 {
+        const ptr: *const __AnonStruct_77531de58035959 = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostUdp_bindResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostUdp_bindResult(self, amount);
+    }
+} else extern struct {
+    payload: HostUdp_bindResultPayload,
+    tag: HostUdp_bindResultTag,
+    pub fn payload_err(self: *const @This()) AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable {
+        return self.payload.err;
+    }
+    pub fn payload_ok(self: *const @This()) __AnonStruct_77531de58035959 {
+        return self.payload.ok;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostUdp_bindResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostUdp_bindResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostUdp_bindResult) != 24) @compileError("HostUdp_bindResult size mismatch");
+        if (@alignOf(HostUdp_bindResult) != 8) @compileError("HostUdp_bindResult alignment mismatch");
+        if (@offsetOf(HostUdp_bindResult, "tag") != 16) @compileError("HostUdp_bindResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostUdp_bindResult) != 16) @compileError("HostUdp_bindResult size mismatch");
+        if (@alignOf(HostUdp_bindResult) != 4) @compileError("HostUdp_bindResult alignment mismatch");
+        if (@offsetOf(HostUdp_bindResult, "tag") != 12) @compileError("HostUdp_bindResult tag offset mismatch");
+    }
+}
+
+/// Tag union: AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable
+pub const AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable = enum(u8) {
+    address_in_use = 0,
+    address_unavailable = 1,
+    invalid_address = 2,
+    permission_denied = 3,
+    resource_limit = 4,
+    unavailable = 5,
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        _ = self;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        _ = self;
+        _ = amount;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable) != 1) @compileError("AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable size mismatch");
+        if (@alignOf(AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable) != 1) @compileError("AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable) != 1) @compileError("AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable size mismatch");
+        if (@alignOf(AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable) != 1) @compileError("AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable alignment mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostUdp_receiveResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostUdp_receiveResultPayload = extern union {
+    err: AlreadyReceivingOrReceiveFailedOrTimeoutOrUnavailable,
+    ok: __AnonStruct_1772298ecb801858,
+};
+
+/// Tag union: Try
+pub const HostUdp_receiveResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [24]u8 align(4),
+    tag: HostUdp_receiveResultTag,
+    pub fn payload_err(self: *const @This()) AlreadyReceivingOrReceiveFailedOrTimeoutOrUnavailable {
+        const ptr: *const AlreadyReceivingOrReceiveFailedOrTimeoutOrUnavailable = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    pub fn payload_ok(self: *const @This()) __AnonStruct_1772298ecb801858 {
+        const ptr: *const __AnonStruct_1772298ecb801858 = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostUdp_receiveResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostUdp_receiveResult(self, amount);
+    }
+} else extern struct {
+    payload: HostUdp_receiveResultPayload,
+    tag: HostUdp_receiveResultTag,
+    pub fn payload_err(self: *const @This()) AlreadyReceivingOrReceiveFailedOrTimeoutOrUnavailable {
+        return self.payload.err;
+    }
+    pub fn payload_ok(self: *const @This()) __AnonStruct_1772298ecb801858 {
+        return self.payload.ok;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostUdp_receiveResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostUdp_receiveResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostUdp_receiveResult) != 56) @compileError("HostUdp_receiveResult size mismatch");
+        if (@alignOf(HostUdp_receiveResult) != 8) @compileError("HostUdp_receiveResult alignment mismatch");
+        if (@offsetOf(HostUdp_receiveResult, "tag") != 48) @compileError("HostUdp_receiveResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostUdp_receiveResult) != 28) @compileError("HostUdp_receiveResult size mismatch");
+        if (@alignOf(HostUdp_receiveResult) != 4) @compileError("HostUdp_receiveResult alignment mismatch");
+        if (@offsetOf(HostUdp_receiveResult, "tag") != 24) @compileError("HostUdp_receiveResult tag offset mismatch");
+    }
+}
+
+/// Tag union: AlreadyReceivingOrReceiveFailedOrTimeoutOrUnavailable
+pub const AlreadyReceivingOrReceiveFailedOrTimeoutOrUnavailable = enum(u8) {
+    already_receiving = 0,
+    receive_failed = 1,
+    timeout = 2,
+    unavailable = 3,
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        _ = self;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        _ = self;
+        _ = amount;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(AlreadyReceivingOrReceiveFailedOrTimeoutOrUnavailable) != 1) @compileError("AlreadyReceivingOrReceiveFailedOrTimeoutOrUnavailable size mismatch");
+        if (@alignOf(AlreadyReceivingOrReceiveFailedOrTimeoutOrUnavailable) != 1) @compileError("AlreadyReceivingOrReceiveFailedOrTimeoutOrUnavailable alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(AlreadyReceivingOrReceiveFailedOrTimeoutOrUnavailable) != 1) @compileError("AlreadyReceivingOrReceiveFailedOrTimeoutOrUnavailable size mismatch");
+        if (@alignOf(AlreadyReceivingOrReceiveFailedOrTimeoutOrUnavailable) != 1) @compileError("AlreadyReceivingOrReceiveFailedOrTimeoutOrUnavailable alignment mismatch");
     }
 }
 
@@ -8025,6 +8946,101 @@ comptime {
     }
 }
 
+/// Tag discriminant for Try.
+pub const HostWindow_read_clipboardResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostWindow_read_clipboardResultPayload = extern union {
+    err: BusyOrTooLargeOrUnavailable,
+    ok: RocStr,
+};
+
+/// Tag union: Try
+pub const HostWindow_read_clipboardResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [12]u8 align(4),
+    tag: HostWindow_read_clipboardResultTag,
+    pub fn payload_err(self: *const @This()) BusyOrTooLargeOrUnavailable {
+        const ptr: *const BusyOrTooLargeOrUnavailable = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    pub fn payload_ok(self: *const @This()) RocStr {
+        const ptr: *const RocStr = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostWindow_read_clipboardResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostWindow_read_clipboardResult(self, amount);
+    }
+} else extern struct {
+    payload: HostWindow_read_clipboardResultPayload,
+    tag: HostWindow_read_clipboardResultTag,
+    pub fn payload_err(self: *const @This()) BusyOrTooLargeOrUnavailable {
+        return self.payload.err;
+    }
+    pub fn payload_ok(self: *const @This()) RocStr {
+        return self.payload.ok;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostWindow_read_clipboardResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostWindow_read_clipboardResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostWindow_read_clipboardResult) != 32) @compileError("HostWindow_read_clipboardResult size mismatch");
+        if (@alignOf(HostWindow_read_clipboardResult) != 8) @compileError("HostWindow_read_clipboardResult alignment mismatch");
+        if (@offsetOf(HostWindow_read_clipboardResult, "tag") != 24) @compileError("HostWindow_read_clipboardResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostWindow_read_clipboardResult) != 16) @compileError("HostWindow_read_clipboardResult size mismatch");
+        if (@alignOf(HostWindow_read_clipboardResult) != 4) @compileError("HostWindow_read_clipboardResult alignment mismatch");
+        if (@offsetOf(HostWindow_read_clipboardResult, "tag") != 12) @compileError("HostWindow_read_clipboardResult tag offset mismatch");
+    }
+}
+
+/// Tag union: BusyOrTooLargeOrUnavailable
+pub const BusyOrTooLargeOrUnavailable = enum(u8) {
+    busy = 0,
+    too_large = 1,
+    unavailable = 2,
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        _ = self;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        _ = self;
+        _ = amount;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(BusyOrTooLargeOrUnavailable) != 1) @compileError("BusyOrTooLargeOrUnavailable size mismatch");
+        if (@alignOf(BusyOrTooLargeOrUnavailable) != 1) @compileError("BusyOrTooLargeOrUnavailable alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(BusyOrTooLargeOrUnavailable) != 1) @compileError("BusyOrTooLargeOrUnavailable size mismatch");
+        if (@alignOf(BusyOrTooLargeOrUnavailable) != 1) @compileError("BusyOrTooLargeOrUnavailable alignment mismatch");
+    }
+}
+
 /// Tag union: Try
 pub const HostWindow_suggest_sizeResult = enum(u8) {
     err = 0,
@@ -8146,6 +9162,705 @@ comptime {
     if (@sizeOf(usize) == 4) {
         if (@sizeOf(NotFoundOrParseFailedOrReadFailedOrUnsupported) != 1) @compileError("NotFoundOrParseFailedOrReadFailedOrUnsupported size mismatch");
         if (@alignOf(NotFoundOrParseFailedOrReadFailedOrUnsupported) != 1) @compileError("NotFoundOrParseFailedOrReadFailedOrUnsupported alignment mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostSqlite_openResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostSqlite_openResultPayload = extern union {
+    err: SqliteErrOrTooManyConnections,
+    ok: SqliteDb,
+};
+
+/// Tag union: Try
+pub const HostSqlite_openResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [32]u8 align(8),
+    tag: HostSqlite_openResultTag,
+    pub fn payload_err(self: *const @This()) SqliteErrOrTooManyConnections {
+        const ptr: *const SqliteErrOrTooManyConnections = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    pub fn payload_ok(self: *const @This()) SqliteDb {
+        const ptr: *const SqliteDb = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostSqlite_openResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostSqlite_openResult(self, amount);
+    }
+} else extern struct {
+    payload: HostSqlite_openResultPayload,
+    tag: HostSqlite_openResultTag,
+    pub fn payload_err(self: *const @This()) SqliteErrOrTooManyConnections {
+        return self.payload.err;
+    }
+    pub fn payload_ok(self: *const @This()) SqliteDb {
+        return self.payload.ok;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostSqlite_openResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostSqlite_openResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostSqlite_openResult) != 48) @compileError("HostSqlite_openResult size mismatch");
+        if (@alignOf(HostSqlite_openResult) != 8) @compileError("HostSqlite_openResult alignment mismatch");
+        if (@offsetOf(HostSqlite_openResult, "tag") != 40) @compileError("HostSqlite_openResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostSqlite_openResult) != 40) @compileError("HostSqlite_openResult size mismatch");
+        if (@alignOf(HostSqlite_openResult) != 8) @compileError("HostSqlite_openResult alignment mismatch");
+        if (@offsetOf(HostSqlite_openResult, "tag") != 32) @compileError("HostSqlite_openResult tag offset mismatch");
+    }
+}
+
+/// Tag discriminant for SqliteErrOrTooManyConnections.
+pub const SqliteErrOrTooManyConnectionsTag = enum(u8) {
+    SqliteErr = 0,
+    TooManyConnections = 1,
+};
+
+/// Payload union for SqliteErrOrTooManyConnections.
+pub const SqliteErrOrTooManyConnectionsPayload = extern union {
+    sqlite_err: __AnonStruct_22cf486058afc711,
+    too_many_connections: [0]u8,
+};
+
+/// Tag union: SqliteErrOrTooManyConnections
+pub const SqliteErrOrTooManyConnections = if (@sizeOf(usize) == 4) extern struct {
+    payload: [24]u8 align(8),
+    tag: SqliteErrOrTooManyConnectionsTag,
+    pub fn payload_sqlite_err(self: *const @This()) __AnonStruct_22cf486058afc711 {
+        const ptr: *const __AnonStruct_22cf486058afc711 = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefSqliteErrOrTooManyConnections(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfSqliteErrOrTooManyConnections(self, amount);
+    }
+} else extern struct {
+    payload: SqliteErrOrTooManyConnectionsPayload,
+    tag: SqliteErrOrTooManyConnectionsTag,
+    pub fn payload_sqlite_err(self: *const @This()) __AnonStruct_22cf486058afc711 {
+        return self.payload.sqlite_err;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefSqliteErrOrTooManyConnections(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfSqliteErrOrTooManyConnections(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(SqliteErrOrTooManyConnections) != 40) @compileError("SqliteErrOrTooManyConnections size mismatch");
+        if (@alignOf(SqliteErrOrTooManyConnections) != 8) @compileError("SqliteErrOrTooManyConnections alignment mismatch");
+        if (@offsetOf(SqliteErrOrTooManyConnections, "tag") != 32) @compileError("SqliteErrOrTooManyConnections tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(SqliteErrOrTooManyConnections) != 32) @compileError("SqliteErrOrTooManyConnections size mismatch");
+        if (@alignOf(SqliteErrOrTooManyConnections) != 8) @compileError("SqliteErrOrTooManyConnections alignment mismatch");
+        if (@offsetOf(SqliteErrOrTooManyConnections, "tag") != 24) @compileError("SqliteErrOrTooManyConnections tag offset mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostSqlite_closeResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostSqlite_closeResultPayload = extern union {
+    err: __AnonStruct_22cf486058afc711,
+    ok: [0]u8,
+};
+
+/// Tag union: Try
+pub const HostSqlite_closeResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [24]u8 align(8),
+    tag: HostSqlite_closeResultTag,
+    pub fn payload_err(self: *const @This()) __AnonStruct_22cf486058afc711 {
+        const ptr: *const __AnonStruct_22cf486058afc711 = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostSqlite_closeResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostSqlite_closeResult(self, amount);
+    }
+} else extern struct {
+    payload: HostSqlite_closeResultPayload,
+    tag: HostSqlite_closeResultTag,
+    pub fn payload_err(self: *const @This()) __AnonStruct_22cf486058afc711 {
+        return self.payload.err;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostSqlite_closeResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostSqlite_closeResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostSqlite_closeResult) != 40) @compileError("HostSqlite_closeResult size mismatch");
+        if (@alignOf(HostSqlite_closeResult) != 8) @compileError("HostSqlite_closeResult alignment mismatch");
+        if (@offsetOf(HostSqlite_closeResult, "tag") != 32) @compileError("HostSqlite_closeResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostSqlite_closeResult) != 32) @compileError("HostSqlite_closeResult size mismatch");
+        if (@alignOf(HostSqlite_closeResult) != 8) @compileError("HostSqlite_closeResult alignment mismatch");
+        if (@offsetOf(HostSqlite_closeResult, "tag") != 24) @compileError("HostSqlite_closeResult tag offset mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostSqlite_prepareResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostSqlite_prepareResultPayload = extern union {
+    err: MultipleStatementsOrSqliteErrOrTooManyStatements,
+    ok: SqliteStmt,
+};
+
+/// Tag union: Try
+pub const HostSqlite_prepareResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [32]u8 align(8),
+    tag: HostSqlite_prepareResultTag,
+    pub fn payload_err(self: *const @This()) MultipleStatementsOrSqliteErrOrTooManyStatements {
+        const ptr: *const MultipleStatementsOrSqliteErrOrTooManyStatements = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    pub fn payload_ok(self: *const @This()) SqliteStmt {
+        const ptr: *const SqliteStmt = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostSqlite_prepareResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostSqlite_prepareResult(self, amount);
+    }
+} else extern struct {
+    payload: HostSqlite_prepareResultPayload,
+    tag: HostSqlite_prepareResultTag,
+    pub fn payload_err(self: *const @This()) MultipleStatementsOrSqliteErrOrTooManyStatements {
+        return self.payload.err;
+    }
+    pub fn payload_ok(self: *const @This()) SqliteStmt {
+        return self.payload.ok;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostSqlite_prepareResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostSqlite_prepareResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostSqlite_prepareResult) != 48) @compileError("HostSqlite_prepareResult size mismatch");
+        if (@alignOf(HostSqlite_prepareResult) != 8) @compileError("HostSqlite_prepareResult alignment mismatch");
+        if (@offsetOf(HostSqlite_prepareResult, "tag") != 40) @compileError("HostSqlite_prepareResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostSqlite_prepareResult) != 40) @compileError("HostSqlite_prepareResult size mismatch");
+        if (@alignOf(HostSqlite_prepareResult) != 8) @compileError("HostSqlite_prepareResult alignment mismatch");
+        if (@offsetOf(HostSqlite_prepareResult, "tag") != 32) @compileError("HostSqlite_prepareResult tag offset mismatch");
+    }
+}
+
+/// Tag discriminant for MultipleStatementsOrSqliteErrOrTooManyStatements.
+pub const MultipleStatementsOrSqliteErrOrTooManyStatementsTag = enum(u8) {
+    MultipleStatements = 0,
+    SqliteErr = 1,
+    TooManyStatements = 2,
+};
+
+/// Payload union for MultipleStatementsOrSqliteErrOrTooManyStatements.
+pub const MultipleStatementsOrSqliteErrOrTooManyStatementsPayload = extern union {
+    multiple_statements: [0]u8,
+    sqlite_err: __AnonStruct_22cf486058afc711,
+    too_many_statements: [0]u8,
+};
+
+/// Tag union: MultipleStatementsOrSqliteErrOrTooManyStatements
+pub const MultipleStatementsOrSqliteErrOrTooManyStatements = if (@sizeOf(usize) == 4) extern struct {
+    payload: [24]u8 align(8),
+    tag: MultipleStatementsOrSqliteErrOrTooManyStatementsTag,
+    pub fn payload_sqlite_err(self: *const @This()) __AnonStruct_22cf486058afc711 {
+        const ptr: *const __AnonStruct_22cf486058afc711 = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefMultipleStatementsOrSqliteErrOrTooManyStatements(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfMultipleStatementsOrSqliteErrOrTooManyStatements(self, amount);
+    }
+} else extern struct {
+    payload: MultipleStatementsOrSqliteErrOrTooManyStatementsPayload,
+    tag: MultipleStatementsOrSqliteErrOrTooManyStatementsTag,
+    pub fn payload_sqlite_err(self: *const @This()) __AnonStruct_22cf486058afc711 {
+        return self.payload.sqlite_err;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefMultipleStatementsOrSqliteErrOrTooManyStatements(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfMultipleStatementsOrSqliteErrOrTooManyStatements(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(MultipleStatementsOrSqliteErrOrTooManyStatements) != 40) @compileError("MultipleStatementsOrSqliteErrOrTooManyStatements size mismatch");
+        if (@alignOf(MultipleStatementsOrSqliteErrOrTooManyStatements) != 8) @compileError("MultipleStatementsOrSqliteErrOrTooManyStatements alignment mismatch");
+        if (@offsetOf(MultipleStatementsOrSqliteErrOrTooManyStatements, "tag") != 32) @compileError("MultipleStatementsOrSqliteErrOrTooManyStatements tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(MultipleStatementsOrSqliteErrOrTooManyStatements) != 32) @compileError("MultipleStatementsOrSqliteErrOrTooManyStatements size mismatch");
+        if (@alignOf(MultipleStatementsOrSqliteErrOrTooManyStatements) != 8) @compileError("MultipleStatementsOrSqliteErrOrTooManyStatements alignment mismatch");
+        if (@offsetOf(MultipleStatementsOrSqliteErrOrTooManyStatements, "tag") != 24) @compileError("MultipleStatementsOrSqliteErrOrTooManyStatements tag offset mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostSqlite_run_stmtResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostSqlite_run_stmtResultPayload = extern union {
+    err: MultipleStatementsOrResultTooLargeOrSqliteErr,
+    ok: __AnonStruct_566a76c01f44ee92,
+};
+
+/// Tag union: Try
+pub const HostSqlite_run_stmtResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [72]u8 align(8),
+    tag: HostSqlite_run_stmtResultTag,
+    pub fn payload_err(self: *const @This()) MultipleStatementsOrResultTooLargeOrSqliteErr {
+        const ptr: *const MultipleStatementsOrResultTooLargeOrSqliteErr = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    pub fn payload_ok(self: *const @This()) __AnonStruct_566a76c01f44ee92 {
+        const ptr: *const __AnonStruct_566a76c01f44ee92 = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostSqlite_run_stmtResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostSqlite_run_stmtResult(self, amount);
+    }
+} else extern struct {
+    payload: HostSqlite_run_stmtResultPayload,
+    tag: HostSqlite_run_stmtResultTag,
+    pub fn payload_err(self: *const @This()) MultipleStatementsOrResultTooLargeOrSqliteErr {
+        return self.payload.err;
+    }
+    pub fn payload_ok(self: *const @This()) __AnonStruct_566a76c01f44ee92 {
+        return self.payload.ok;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostSqlite_run_stmtResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostSqlite_run_stmtResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostSqlite_run_stmtResult) != 112) @compileError("HostSqlite_run_stmtResult size mismatch");
+        if (@alignOf(HostSqlite_run_stmtResult) != 8) @compileError("HostSqlite_run_stmtResult alignment mismatch");
+        if (@offsetOf(HostSqlite_run_stmtResult, "tag") != 104) @compileError("HostSqlite_run_stmtResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostSqlite_run_stmtResult) != 80) @compileError("HostSqlite_run_stmtResult size mismatch");
+        if (@alignOf(HostSqlite_run_stmtResult) != 8) @compileError("HostSqlite_run_stmtResult alignment mismatch");
+        if (@offsetOf(HostSqlite_run_stmtResult, "tag") != 72) @compileError("HostSqlite_run_stmtResult tag offset mismatch");
+    }
+}
+
+/// Tag discriminant for MultipleStatementsOrResultTooLargeOrSqliteErr.
+pub const MultipleStatementsOrResultTooLargeOrSqliteErrTag = enum(u8) {
+    MultipleStatements = 0,
+    ResultTooLarge = 1,
+    SqliteErr = 2,
+};
+
+/// Payload union for MultipleStatementsOrResultTooLargeOrSqliteErr.
+pub const MultipleStatementsOrResultTooLargeOrSqliteErrPayload = extern union {
+    multiple_statements: [0]u8,
+    result_too_large: [0]u8,
+    sqlite_err: __AnonStruct_22cf486058afc711,
+};
+
+/// Tag union: MultipleStatementsOrResultTooLargeOrSqliteErr
+pub const MultipleStatementsOrResultTooLargeOrSqliteErr = if (@sizeOf(usize) == 4) extern struct {
+    payload: [24]u8 align(8),
+    tag: MultipleStatementsOrResultTooLargeOrSqliteErrTag,
+    pub fn payload_sqlite_err(self: *const @This()) __AnonStruct_22cf486058afc711 {
+        const ptr: *const __AnonStruct_22cf486058afc711 = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefMultipleStatementsOrResultTooLargeOrSqliteErr(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfMultipleStatementsOrResultTooLargeOrSqliteErr(self, amount);
+    }
+} else extern struct {
+    payload: MultipleStatementsOrResultTooLargeOrSqliteErrPayload,
+    tag: MultipleStatementsOrResultTooLargeOrSqliteErrTag,
+    pub fn payload_sqlite_err(self: *const @This()) __AnonStruct_22cf486058afc711 {
+        return self.payload.sqlite_err;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefMultipleStatementsOrResultTooLargeOrSqliteErr(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfMultipleStatementsOrResultTooLargeOrSqliteErr(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(MultipleStatementsOrResultTooLargeOrSqliteErr) != 40) @compileError("MultipleStatementsOrResultTooLargeOrSqliteErr size mismatch");
+        if (@alignOf(MultipleStatementsOrResultTooLargeOrSqliteErr) != 8) @compileError("MultipleStatementsOrResultTooLargeOrSqliteErr alignment mismatch");
+        if (@offsetOf(MultipleStatementsOrResultTooLargeOrSqliteErr, "tag") != 32) @compileError("MultipleStatementsOrResultTooLargeOrSqliteErr tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(MultipleStatementsOrResultTooLargeOrSqliteErr) != 32) @compileError("MultipleStatementsOrResultTooLargeOrSqliteErr size mismatch");
+        if (@alignOf(MultipleStatementsOrResultTooLargeOrSqliteErr) != 8) @compileError("MultipleStatementsOrResultTooLargeOrSqliteErr alignment mismatch");
+        if (@offsetOf(MultipleStatementsOrResultTooLargeOrSqliteErr, "tag") != 24) @compileError("MultipleStatementsOrResultTooLargeOrSqliteErr tag offset mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostCapture_stop_recordingResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostCapture_stop_recordingResultPayload = extern union {
+    err: BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable,
+    ok: __AnonStruct_5c978c17ba0c990a,
+};
+
+/// Tag union: Try
+pub const HostCapture_stop_recordingResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [16]u8 align(8),
+    tag: HostCapture_stop_recordingResultTag,
+    pub fn payload_err(self: *const @This()) BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable {
+        const ptr: *const BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    pub fn payload_ok(self: *const @This()) __AnonStruct_5c978c17ba0c990a {
+        const ptr: *const __AnonStruct_5c978c17ba0c990a = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostCapture_stop_recordingResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostCapture_stop_recordingResult(self, amount);
+    }
+} else extern struct {
+    payload: HostCapture_stop_recordingResultPayload,
+    tag: HostCapture_stop_recordingResultTag,
+    pub fn payload_err(self: *const @This()) BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable {
+        return self.payload.err;
+    }
+    pub fn payload_ok(self: *const @This()) __AnonStruct_5c978c17ba0c990a {
+        return self.payload.ok;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostCapture_stop_recordingResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostCapture_stop_recordingResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostCapture_stop_recordingResult) != 24) @compileError("HostCapture_stop_recordingResult size mismatch");
+        if (@alignOf(HostCapture_stop_recordingResult) != 8) @compileError("HostCapture_stop_recordingResult alignment mismatch");
+        if (@offsetOf(HostCapture_stop_recordingResult, "tag") != 16) @compileError("HostCapture_stop_recordingResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostCapture_stop_recordingResult) != 24) @compileError("HostCapture_stop_recordingResult size mismatch");
+        if (@alignOf(HostCapture_stop_recordingResult) != 8) @compileError("HostCapture_stop_recordingResult alignment mismatch");
+        if (@offsetOf(HostCapture_stop_recordingResult, "tag") != 16) @compileError("HostCapture_stop_recordingResult tag offset mismatch");
+    }
+}
+
+/// Tag union: BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable
+pub const BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable = enum(u8) {
+    budget_exceeded = 0,
+    busy = 1,
+    not_recording = 2,
+    readback_failed = 3,
+    target_unavailable = 4,
+    unavailable = 5,
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        _ = self;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        _ = self;
+        _ = amount;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable) != 1) @compileError("BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable size mismatch");
+        if (@alignOf(BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable) != 1) @compileError("BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable) != 1) @compileError("BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable size mismatch");
+        if (@alignOf(BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable) != 1) @compileError("BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable alignment mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostCapture_pixel_atResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostCapture_pixel_atResultPayload = extern union {
+    err: BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable,
+    ok: __AnonStruct_bda5c9dc6cabe78e,
+};
+
+/// Tag union: Try
+pub const HostCapture_pixel_atResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [4]u8 align(1),
+    tag: HostCapture_pixel_atResultTag,
+    pub fn payload_err(self: *const @This()) BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable {
+        const ptr: *const BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    pub fn payload_ok(self: *const @This()) __AnonStruct_bda5c9dc6cabe78e {
+        const ptr: *const __AnonStruct_bda5c9dc6cabe78e = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostCapture_pixel_atResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostCapture_pixel_atResult(self, amount);
+    }
+} else extern struct {
+    payload: HostCapture_pixel_atResultPayload,
+    tag: HostCapture_pixel_atResultTag,
+    pub fn payload_err(self: *const @This()) BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable {
+        return self.payload.err;
+    }
+    pub fn payload_ok(self: *const @This()) __AnonStruct_bda5c9dc6cabe78e {
+        return self.payload.ok;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostCapture_pixel_atResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostCapture_pixel_atResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostCapture_pixel_atResult) != 5) @compileError("HostCapture_pixel_atResult size mismatch");
+        if (@alignOf(HostCapture_pixel_atResult) != 1) @compileError("HostCapture_pixel_atResult alignment mismatch");
+        if (@offsetOf(HostCapture_pixel_atResult, "tag") != 4) @compileError("HostCapture_pixel_atResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostCapture_pixel_atResult) != 5) @compileError("HostCapture_pixel_atResult size mismatch");
+        if (@alignOf(HostCapture_pixel_atResult) != 1) @compileError("HostCapture_pixel_atResult alignment mismatch");
+        if (@offsetOf(HostCapture_pixel_atResult, "tag") != 4) @compileError("HostCapture_pixel_atResult tag offset mismatch");
+    }
+}
+
+/// Tag union: BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable
+pub const BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable = enum(u8) {
+    busy = 0,
+    readback_failed = 1,
+    region_out_of_bounds = 2,
+    target_unavailable = 3,
+    unavailable = 4,
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        _ = self;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        _ = self;
+        _ = amount;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable) != 1) @compileError("BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable size mismatch");
+        if (@alignOf(BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable) != 1) @compileError("BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable) != 1) @compileError("BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable size mismatch");
+        if (@alignOf(BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable) != 1) @compileError("BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable alignment mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const HostCapture_read_regionResultTag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const HostCapture_read_regionResultPayload = extern union {
+    err: BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable,
+    ok: RocListWith(u8, false),
+};
+
+/// Tag union: Try
+pub const HostCapture_read_regionResult = if (@sizeOf(usize) == 4) extern struct {
+    payload: [12]u8 align(4),
+    tag: HostCapture_read_regionResultTag,
+    pub fn payload_err(self: *const @This()) BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable {
+        const ptr: *const BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    pub fn payload_ok(self: *const @This()) RocListWith(u8, false) {
+        const ptr: *const RocListWith(u8, false) = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostCapture_read_regionResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostCapture_read_regionResult(self, amount);
+    }
+} else extern struct {
+    payload: HostCapture_read_regionResultPayload,
+    tag: HostCapture_read_regionResultTag,
+    pub fn payload_err(self: *const @This()) BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable {
+        return self.payload.err;
+    }
+    pub fn payload_ok(self: *const @This()) RocListWith(u8, false) {
+        return self.payload.ok;
+    }
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        decrefHostCapture_read_regionResult(self, roc_host);
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        increfHostCapture_read_regionResult(self, amount);
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostCapture_read_regionResult) != 32) @compileError("HostCapture_read_regionResult size mismatch");
+        if (@alignOf(HostCapture_read_regionResult) != 8) @compileError("HostCapture_read_regionResult alignment mismatch");
+        if (@offsetOf(HostCapture_read_regionResult, "tag") != 24) @compileError("HostCapture_read_regionResult tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostCapture_read_regionResult) != 16) @compileError("HostCapture_read_regionResult size mismatch");
+        if (@alignOf(HostCapture_read_regionResult) != 4) @compileError("HostCapture_read_regionResult alignment mismatch");
+        if (@offsetOf(HostCapture_read_regionResult, "tag") != 12) @compileError("HostCapture_read_regionResult tag offset mismatch");
     }
 }
 
@@ -8389,188 +10104,6 @@ comptime {
     }
 }
 
-/// Return type record for Host.files_read_text!
-/// Fields ordered by compiler-emitted ABI offsets.
-pub const HostFiles_read_textRetRecord = if (@sizeOf(usize) == 4) extern struct {
-    contents: RocStr,
-    err: u8,
-} else extern struct {
-    contents: RocStr,
-    err: u8,
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostFiles_read_textRetRecord) != 32) @compileError("HostFiles_read_textRetRecord size mismatch");
-        if (@alignOf(HostFiles_read_textRetRecord) != 8) @compileError("HostFiles_read_textRetRecord alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostFiles_read_textRetRecord) != 16) @compileError("HostFiles_read_textRetRecord size mismatch");
-        if (@alignOf(HostFiles_read_textRetRecord) != 4) @compileError("HostFiles_read_textRetRecord alignment mismatch");
-    }
-}
-
-/// Return type record for Host.files_read_bytes!
-/// Fields ordered by compiler-emitted ABI offsets.
-pub const HostFiles_read_bytesRetRecord = if (@sizeOf(usize) == 4) extern struct {
-    bytes: RocListWith(u8, false),
-    err: u8,
-} else extern struct {
-    bytes: RocListWith(u8, false),
-    err: u8,
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostFiles_read_bytesRetRecord) != 32) @compileError("HostFiles_read_bytesRetRecord size mismatch");
-        if (@alignOf(HostFiles_read_bytesRetRecord) != 8) @compileError("HostFiles_read_bytesRetRecord alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostFiles_read_bytesRetRecord) != 16) @compileError("HostFiles_read_bytesRetRecord size mismatch");
-        if (@alignOf(HostFiles_read_bytesRetRecord) != 4) @compileError("HostFiles_read_bytesRetRecord alignment mismatch");
-    }
-}
-
-/// Return type record for Host.files_list!
-/// Fields ordered by compiler-emitted ABI offsets.
-pub const HostFiles_listRetRecord = if (@sizeOf(usize) == 4) extern struct {
-    bytes: RocListWith(u8, false),
-    err: u8,
-} else extern struct {
-    bytes: RocListWith(u8, false),
-    err: u8,
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostFiles_listRetRecord) != 32) @compileError("HostFiles_listRetRecord size mismatch");
-        if (@alignOf(HostFiles_listRetRecord) != 8) @compileError("HostFiles_listRetRecord alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostFiles_listRetRecord) != 16) @compileError("HostFiles_listRetRecord size mismatch");
-        if (@alignOf(HostFiles_listRetRecord) != 4) @compileError("HostFiles_listRetRecord alignment mismatch");
-    }
-}
-
-/// Return type record for Host.files_metadata!
-/// Fields ordered by compiler-emitted ABI offsets.
-pub const HostFiles_metadataRetRecord = if (@sizeOf(usize) == 4) extern struct {
-    modified_seconds: i64,
-    size_bytes: u64,
-    modified_nanosecond: u32,
-    err: u8,
-    kind: u8,
-} else extern struct {
-    modified_seconds: i64,
-    size_bytes: u64,
-    modified_nanosecond: u32,
-    err: u8,
-    kind: u8,
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostFiles_metadataRetRecord) != 24) @compileError("HostFiles_metadataRetRecord size mismatch");
-        if (@alignOf(HostFiles_metadataRetRecord) != 8) @compileError("HostFiles_metadataRetRecord alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostFiles_metadataRetRecord) != 24) @compileError("HostFiles_metadataRetRecord size mismatch");
-        if (@alignOf(HostFiles_metadataRetRecord) != 8) @compileError("HostFiles_metadataRetRecord alignment mismatch");
-    }
-}
-
-/// Return type record for Host.capture_stop_recording!
-/// Fields ordered by compiler-emitted ABI offsets.
-pub const HostCapture_stop_recordingRetRecord = if (@sizeOf(usize) == 4) extern struct {
-    bytes: u64,
-    frames: u64,
-    err: u8,
-} else extern struct {
-    bytes: u64,
-    frames: u64,
-    err: u8,
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostCapture_stop_recordingRetRecord) != 24) @compileError("HostCapture_stop_recordingRetRecord size mismatch");
-        if (@alignOf(HostCapture_stop_recordingRetRecord) != 8) @compileError("HostCapture_stop_recordingRetRecord alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostCapture_stop_recordingRetRecord) != 24) @compileError("HostCapture_stop_recordingRetRecord size mismatch");
-        if (@alignOf(HostCapture_stop_recordingRetRecord) != 8) @compileError("HostCapture_stop_recordingRetRecord alignment mismatch");
-    }
-}
-
-/// Return type record for Host.capture_pixel_at!
-/// Fields ordered by compiler-emitted ABI offsets.
-pub const HostCapture_pixel_atRetRecord = if (@sizeOf(usize) == 4) extern struct {
-    a: u8,
-    b: u8,
-    err: u8,
-    g: u8,
-    r: u8,
-} else extern struct {
-    a: u8,
-    b: u8,
-    err: u8,
-    g: u8,
-    r: u8,
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostCapture_pixel_atRetRecord) != 5) @compileError("HostCapture_pixel_atRetRecord size mismatch");
-        if (@alignOf(HostCapture_pixel_atRetRecord) != 1) @compileError("HostCapture_pixel_atRetRecord alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostCapture_pixel_atRetRecord) != 5) @compileError("HostCapture_pixel_atRetRecord size mismatch");
-        if (@alignOf(HostCapture_pixel_atRetRecord) != 1) @compileError("HostCapture_pixel_atRetRecord alignment mismatch");
-    }
-}
-
-/// Return type record for Host.capture_read_region!
-/// Fields ordered by compiler-emitted ABI offsets.
-pub const HostCapture_read_regionRetRecord = if (@sizeOf(usize) == 4) extern struct {
-    bytes: RocListWith(u8, false),
-    err: u8,
-} else extern struct {
-    bytes: RocListWith(u8, false),
-    err: u8,
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostCapture_read_regionRetRecord) != 32) @compileError("HostCapture_read_regionRetRecord size mismatch");
-        if (@alignOf(HostCapture_read_regionRetRecord) != 8) @compileError("HostCapture_read_regionRetRecord alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostCapture_read_regionRetRecord) != 16) @compileError("HostCapture_read_regionRetRecord size mismatch");
-        if (@alignOf(HostCapture_read_regionRetRecord) != 4) @compileError("HostCapture_read_regionRetRecord alignment mismatch");
-    }
-}
-
-/// Return type record for Host.window_read_clipboard!
-/// Fields ordered by compiler-emitted ABI offsets.
-pub const HostWindow_read_clipboardRetRecord = if (@sizeOf(usize) == 4) extern struct {
-    contents: RocStr,
-    err: u8,
-} else extern struct {
-    contents: RocStr,
-    err: u8,
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostWindow_read_clipboardRetRecord) != 32) @compileError("HostWindow_read_clipboardRetRecord size mismatch");
-        if (@alignOf(HostWindow_read_clipboardRetRecord) != 8) @compileError("HostWindow_read_clipboardRetRecord alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostWindow_read_clipboardRetRecord) != 16) @compileError("HostWindow_read_clipboardRetRecord size mismatch");
-        if (@alignOf(HostWindow_read_clipboardRetRecord) != 4) @compileError("HostWindow_read_clipboardRetRecord alignment mismatch");
-    }
-}
-
 /// Return type record for Host.window_scale_dpi!
 /// Fields ordered by compiler-emitted ABI offsets.
 pub const HostWindow_scale_dpiRetRecord = if (@sizeOf(usize) == 4) extern struct {
@@ -8589,33 +10122,6 @@ comptime {
     if (@sizeOf(usize) == 4) {
         if (@sizeOf(HostWindow_scale_dpiRetRecord) != 8) @compileError("HostWindow_scale_dpiRetRecord size mismatch");
         if (@alignOf(HostWindow_scale_dpiRetRecord) != 4) @compileError("HostWindow_scale_dpiRetRecord alignment mismatch");
-    }
-}
-
-/// Return type record for Host.http_send!
-/// Fields ordered by compiler-emitted ABI offsets.
-pub const HostHttp_sendRetRecord = if (@sizeOf(usize) == 4) extern struct {
-    body: RocListWith(u8, false),
-    err_message: RocStr,
-    headers: RocList(__AnonStruct_82a96c5d55d63488),
-    status: u16,
-    err: u8,
-} else extern struct {
-    body: RocListWith(u8, false),
-    err_message: RocStr,
-    headers: RocList(__AnonStruct_82a96c5d55d63488),
-    status: u16,
-    err: u8,
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostHttp_sendRetRecord) != 80) @compileError("HostHttp_sendRetRecord size mismatch");
-        if (@alignOf(HostHttp_sendRetRecord) != 8) @compileError("HostHttp_sendRetRecord alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostHttp_sendRetRecord) != 40) @compileError("HostHttp_sendRetRecord size mismatch");
-        if (@alignOf(HostHttp_sendRetRecord) != 4) @compileError("HostHttp_sendRetRecord alignment mismatch");
     }
 }
 
@@ -8640,239 +10146,8 @@ comptime {
     }
 }
 
-/// Return type record for Host.udp_bind!
-/// Fields ordered by compiler-emitted ABI offsets.
-pub const HostUdp_bindRetRecord = if (@sizeOf(usize) == 4) extern struct {
-    handle: *u64,
-    ip: u32,
-    port: u16,
-    err: u8,
-} else extern struct {
-    handle: *u64,
-    ip: u32,
-    port: u16,
-    err: u8,
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostUdp_bindRetRecord) != 16) @compileError("HostUdp_bindRetRecord size mismatch");
-        if (@alignOf(HostUdp_bindRetRecord) != 8) @compileError("HostUdp_bindRetRecord alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostUdp_bindRetRecord) != 12) @compileError("HostUdp_bindRetRecord size mismatch");
-        if (@alignOf(HostUdp_bindRetRecord) != 4) @compileError("HostUdp_bindRetRecord alignment mismatch");
-    }
-}
-
-/// Return type record for Host.udp_receive!
-/// Fields ordered by compiler-emitted ABI offsets.
-pub const HostUdp_receiveRetRecord = if (@sizeOf(usize) == 4) extern struct {
-    payload: RocListWith(u8, false),
-    slices: RocListWith(__AnonStruct_4dd3180405b3f44f, false),
-    err: u8,
-} else extern struct {
-    payload: RocListWith(u8, false),
-    slices: RocListWith(__AnonStruct_4dd3180405b3f44f, false),
-    err: u8,
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostUdp_receiveRetRecord) != 56) @compileError("HostUdp_receiveRetRecord size mismatch");
-        if (@alignOf(HostUdp_receiveRetRecord) != 8) @compileError("HostUdp_receiveRetRecord alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostUdp_receiveRetRecord) != 28) @compileError("HostUdp_receiveRetRecord size mismatch");
-        if (@alignOf(HostUdp_receiveRetRecord) != 4) @compileError("HostUdp_receiveRetRecord alignment mismatch");
-    }
-}
-
-/// Return type record for Host.sqlite_open!
-/// Fields ordered by compiler-emitted ABI offsets.
-pub const HostSqlite_openRetRecord = if (@sizeOf(usize) == 4) extern struct {
-    err: i64,
-    db: *u64,
-    message: RocStr,
-} else extern struct {
-    err: i64,
-    db: *u64,
-    message: RocStr,
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostSqlite_openRetRecord) != 40) @compileError("HostSqlite_openRetRecord size mismatch");
-        if (@alignOf(HostSqlite_openRetRecord) != 8) @compileError("HostSqlite_openRetRecord alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostSqlite_openRetRecord) != 24) @compileError("HostSqlite_openRetRecord size mismatch");
-        if (@alignOf(HostSqlite_openRetRecord) != 8) @compileError("HostSqlite_openRetRecord alignment mismatch");
-    }
-}
-
-/// Return type record for Host.sqlite_close!
-/// Fields ordered by compiler-emitted ABI offsets.
-pub const HostSqlite_closeRetRecord = if (@sizeOf(usize) == 4) extern struct {
-    err: i64,
-    message: RocStr,
-} else extern struct {
-    err: i64,
-    message: RocStr,
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostSqlite_closeRetRecord) != 32) @compileError("HostSqlite_closeRetRecord size mismatch");
-        if (@alignOf(HostSqlite_closeRetRecord) != 8) @compileError("HostSqlite_closeRetRecord alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostSqlite_closeRetRecord) != 24) @compileError("HostSqlite_closeRetRecord size mismatch");
-        if (@alignOf(HostSqlite_closeRetRecord) != 8) @compileError("HostSqlite_closeRetRecord alignment mismatch");
-    }
-}
-
-/// Return type record for Host.sqlite_prepare!
-/// Fields ordered by compiler-emitted ABI offsets.
-pub const HostSqlite_prepareRetRecord = if (@sizeOf(usize) == 4) extern struct {
-    err: i64,
-    message: RocStr,
-    stmt: *u64,
-} else extern struct {
-    err: i64,
-    message: RocStr,
-    stmt: *u64,
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostSqlite_prepareRetRecord) != 40) @compileError("HostSqlite_prepareRetRecord size mismatch");
-        if (@alignOf(HostSqlite_prepareRetRecord) != 8) @compileError("HostSqlite_prepareRetRecord alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostSqlite_prepareRetRecord) != 24) @compileError("HostSqlite_prepareRetRecord size mismatch");
-        if (@alignOf(HostSqlite_prepareRetRecord) != 8) @compileError("HostSqlite_prepareRetRecord alignment mismatch");
-    }
-}
-
-/// Return type record for Host.sqlite_run_stmt!
-/// Fields ordered by compiler-emitted ABI offsets.
-pub const HostSqlite_run_stmtRetRecord = if (@sizeOf(usize) == 4) extern struct {
-    changes: i64,
-    err: i64,
-    last_insert_rowid: i64,
-    ncols: u64,
-    row_count: u64,
-    cells: RocListWith(__AnonStruct_3a90da783672cf8d, false),
-    message: RocStr,
-    names: RocListWith(u8, false),
-    payload: RocListWith(u8, false),
-} else extern struct {
-    changes: i64,
-    err: i64,
-    last_insert_rowid: i64,
-    ncols: u64,
-    row_count: u64,
-    cells: RocListWith(__AnonStruct_3a90da783672cf8d, false),
-    message: RocStr,
-    names: RocListWith(u8, false),
-    payload: RocListWith(u8, false),
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostSqlite_run_stmtRetRecord) != 136) @compileError("HostSqlite_run_stmtRetRecord size mismatch");
-        if (@alignOf(HostSqlite_run_stmtRetRecord) != 8) @compileError("HostSqlite_run_stmtRetRecord alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostSqlite_run_stmtRetRecord) != 88) @compileError("HostSqlite_run_stmtRetRecord size mismatch");
-        if (@alignOf(HostSqlite_run_stmtRetRecord) != 8) @compileError("HostSqlite_run_stmtRetRecord alignment mismatch");
-    }
-}
-
-/// Return type record for Host.sqlite_run_once!
-/// Fields ordered by compiler-emitted ABI offsets.
-pub const HostSqlite_run_onceRetRecord = if (@sizeOf(usize) == 4) extern struct {
-    changes: i64,
-    err: i64,
-    last_insert_rowid: i64,
-    ncols: u64,
-    row_count: u64,
-    cells: RocListWith(__AnonStruct_3a90da783672cf8d, false),
-    message: RocStr,
-    names: RocListWith(u8, false),
-    payload: RocListWith(u8, false),
-} else extern struct {
-    changes: i64,
-    err: i64,
-    last_insert_rowid: i64,
-    ncols: u64,
-    row_count: u64,
-    cells: RocListWith(__AnonStruct_3a90da783672cf8d, false),
-    message: RocStr,
-    names: RocListWith(u8, false),
-    payload: RocListWith(u8, false),
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostSqlite_run_onceRetRecord) != 136) @compileError("HostSqlite_run_onceRetRecord size mismatch");
-        if (@alignOf(HostSqlite_run_onceRetRecord) != 8) @compileError("HostSqlite_run_onceRetRecord alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostSqlite_run_onceRetRecord) != 88) @compileError("HostSqlite_run_onceRetRecord size mismatch");
-        if (@alignOf(HostSqlite_run_onceRetRecord) != 8) @compileError("HostSqlite_run_onceRetRecord alignment mismatch");
-    }
-}
-
-/// Return type record for Host.sqlite_exec_script!
-/// Fields ordered by compiler-emitted ABI offsets.
-pub const HostSqlite_exec_scriptRetRecord = if (@sizeOf(usize) == 4) extern struct {
-    err: i64,
-    message: RocStr,
-} else extern struct {
-    err: i64,
-    message: RocStr,
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostSqlite_exec_scriptRetRecord) != 32) @compileError("HostSqlite_exec_scriptRetRecord size mismatch");
-        if (@alignOf(HostSqlite_exec_scriptRetRecord) != 8) @compileError("HostSqlite_exec_scriptRetRecord alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostSqlite_exec_scriptRetRecord) != 24) @compileError("HostSqlite_exec_scriptRetRecord size mismatch");
-        if (@alignOf(HostSqlite_exec_scriptRetRecord) != 8) @compileError("HostSqlite_exec_scriptRetRecord alignment mismatch");
-    }
-}
-
-/// Return type record for Host.cmd_run!
-/// Fields ordered by compiler-emitted ABI offsets.
-pub const HostCmd_runRetRecord = if (@sizeOf(usize) == 4) extern struct {
-    exit_code: i64,
-    stderr: RocListWith(u8, false),
-    stdout: RocListWith(u8, false),
-    err: u8,
-} else extern struct {
-    exit_code: i64,
-    stderr: RocListWith(u8, false),
-    stdout: RocListWith(u8, false),
-    err: u8,
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostCmd_runRetRecord) != 64) @compileError("HostCmd_runRetRecord size mismatch");
-        if (@alignOf(HostCmd_runRetRecord) != 8) @compileError("HostCmd_runRetRecord alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostCmd_runRetRecord) != 40) @compileError("HostCmd_runRetRecord size mismatch");
-        if (@alignOf(HostCmd_runRetRecord) != 8) @compileError("HostCmd_runRetRecord alignment mismatch");
-    }
-}
-
 /// Arguments for Host.store_open!
-/// Roc signature: { asset_set : Str, content_hash : Str, content_hash_mode : U8, content_version : U32, location_kind : U8, manifest_required : Bool, root : Str, schema : U32 } => Try(Handle(Host.StoreResource), [AssetSetMismatch, ContentHashMismatch, ContentVersionMismatch, InvalidExpectedContentHash, InvalidRootPath, ManifestMalformed, ManifestMissing, ManifestUnreadable, ResourceLimit, RootNotDirectory, RootNotFound, RootUnreadable, SchemaMismatch])
+/// Roc signature: { asset_set : Str, content_hash : Str, content_hash_mode : U8, content_version : U32, location_kind : U8, manifest_required : Bool, root : Str, schema : U32 } => Try(Store, [AssetSetMismatch, ContentHashMismatch, ContentVersionMismatch, InvalidExpectedContentHash, InvalidRootPath, ManifestMalformed, ManifestMissing, ManifestUnreadable, ResourceLimit, RootNotDirectory, RootNotFound, RootUnreadable, SchemaMismatch])
 /// Refcounted fields are owned by the hosted function.
 pub const HostStore_openArgs = if (@sizeOf(usize) == 4) extern struct {
     asset_set: RocStr,
@@ -8936,39 +10211,39 @@ comptime {
 }
 
 /// Arguments for Host.texture_load_store!
-/// Roc signature: { path : Str, store : Handle(Host.StoreResource) } => Try(Texture, [NotFound, PathInvalid, ReadFailed, ResourceLimit, TextureLoadFailed])
+/// Roc signature: { path : Str, store : Store } => Try(Texture, [NotFound, PathInvalid, ReadFailed, ResourceLimit, TextureLoadFailed])
 /// Refcounted fields are owned by the hosted function.
 pub const HostTexture_load_storeArgs = if (@sizeOf(usize) == 4) extern struct {
     path: RocStr,
-    store: *u64,
+    store: Store,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
         value.path.decref(roc_host);
-        decrefBoxWith(@ptrCast(value.store), @alignOf(u64), false, null, roc_host);
+        value.store.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
         value.path.incref(amount);
-        increfBox(@ptrCast(value.store), amount);
+        value.store.incref(amount);
     }
 } else extern struct {
     path: RocStr,
-    store: *u64,
+    store: Store,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
         value.path.decref(roc_host);
-        decrefBoxWith(@ptrCast(value.store), @alignOf(u64), false, null, roc_host);
+        value.store.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
         value.path.incref(amount);
-        increfBox(@ptrCast(value.store), amount);
+        value.store.incref(amount);
     }
 };
 
@@ -9250,7 +10525,7 @@ pub const HostTexture_set_wrapArgs = extern struct {
 };
 
 /// Arguments for Host.audio_gen_tone!
-/// Roc signature: { freq : F32, ms : I32 } => Try(Handle(Host.SoundResource), [ResourceLimit, SoundGenerationFailed])
+/// Roc signature: { freq : F32, ms : I32 } => Try(AudioSound, [ResourceLimit, SoundGenerationFailed])
 /// Refcounted fields are owned by the hosted function.
 pub const HostAudio_gen_toneArgs = if (@sizeOf(usize) == 4) extern struct {
     freq: f32,
@@ -9298,7 +10573,7 @@ comptime {
 }
 
 /// Arguments for Host.audio_gen_sound!
-/// Roc signature: { attack_ms : I32, decay_ms : I32, freq_end : F32, freq_start : F32, ms : I32, release_ms : I32, sustain : F32, volume : F32, waveform : U8 } => Try(Handle(Host.SoundResource), [ResourceLimit, SoundGenerationFailed])
+/// Roc signature: { attack_ms : I32, decay_ms : I32, freq_end : F32, freq_start : F32, ms : I32, release_ms : I32, sustain : F32, volume : F32, waveform : U8 } => Try(AudioSound, [ResourceLimit, SoundGenerationFailed])
 /// Refcounted fields are owned by the hosted function.
 pub const HostAudio_gen_soundArgs = if (@sizeOf(usize) == 4) extern struct {
     attack_ms: i32,
@@ -9360,166 +10635,586 @@ comptime {
 }
 
 /// Arguments for Host.audio_load_sound!
-/// Roc signature: Str => Try(Handle(Host.SoundResource), [ResourceLimit, SoundLoadFailed])
+/// Roc signature: Str => Try(AudioSound, [ResourceLimit, SoundLoadFailed])
 /// Refcounted fields are owned by the hosted function.
 pub const HostAudio_load_soundArgs = extern struct {
     arg0: RocStr,
 };
 
 /// Arguments for Host.audio_load_music!
-/// Roc signature: Str => Try(Handle(Host.MusicResource), [MusicLoadFailed, ResourceLimit])
+/// Roc signature: Str => Try(AudioMusic, [MusicLoadFailed, ResourceLimit])
 /// Refcounted fields are owned by the hosted function.
 pub const HostAudio_load_musicArgs = extern struct {
     arg0: RocStr,
 };
 
 /// Arguments for Host.audio_play_sound!
-/// Roc signature: Handle(Host.SoundResource) => {}
+/// Roc signature: AudioSound => {}
 /// Refcounted fields are owned by the hosted function.
-pub const HostAudio_play_soundArgs = extern struct {
-    arg0: *u64,
+pub const HostAudio_play_soundArgs = if (@sizeOf(usize) == 4) extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+} else extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
 };
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostAudio_play_soundArgs) != 8) @compileError("HostAudio_play_soundArgs size mismatch");
+        if (@alignOf(HostAudio_play_soundArgs) != 8) @compileError("HostAudio_play_soundArgs alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostAudio_play_soundArgs) != 4) @compileError("HostAudio_play_soundArgs size mismatch");
+        if (@alignOf(HostAudio_play_soundArgs) != 4) @compileError("HostAudio_play_soundArgs alignment mismatch");
+    }
+}
 
 /// Arguments for Host.audio_stop_sound!
-/// Roc signature: Handle(Host.SoundResource) => {}
+/// Roc signature: AudioSound => {}
 /// Refcounted fields are owned by the hosted function.
-pub const HostAudio_stop_soundArgs = extern struct {
-    arg0: *u64,
+pub const HostAudio_stop_soundArgs = if (@sizeOf(usize) == 4) extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+} else extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
 };
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostAudio_stop_soundArgs) != 8) @compileError("HostAudio_stop_soundArgs size mismatch");
+        if (@alignOf(HostAudio_stop_soundArgs) != 8) @compileError("HostAudio_stop_soundArgs alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostAudio_stop_soundArgs) != 4) @compileError("HostAudio_stop_soundArgs size mismatch");
+        if (@alignOf(HostAudio_stop_soundArgs) != 4) @compileError("HostAudio_stop_soundArgs alignment mismatch");
+    }
+}
 
 /// Arguments for Host.audio_pause_sound!
-/// Roc signature: Handle(Host.SoundResource) => {}
+/// Roc signature: AudioSound => {}
 /// Refcounted fields are owned by the hosted function.
-pub const HostAudio_pause_soundArgs = extern struct {
-    arg0: *u64,
+pub const HostAudio_pause_soundArgs = if (@sizeOf(usize) == 4) extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+} else extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
 };
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostAudio_pause_soundArgs) != 8) @compileError("HostAudio_pause_soundArgs size mismatch");
+        if (@alignOf(HostAudio_pause_soundArgs) != 8) @compileError("HostAudio_pause_soundArgs alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostAudio_pause_soundArgs) != 4) @compileError("HostAudio_pause_soundArgs size mismatch");
+        if (@alignOf(HostAudio_pause_soundArgs) != 4) @compileError("HostAudio_pause_soundArgs alignment mismatch");
+    }
+}
 
 /// Arguments for Host.audio_resume_sound!
-/// Roc signature: Handle(Host.SoundResource) => {}
+/// Roc signature: AudioSound => {}
 /// Refcounted fields are owned by the hosted function.
-pub const HostAudio_resume_soundArgs = extern struct {
-    arg0: *u64,
+pub const HostAudio_resume_soundArgs = if (@sizeOf(usize) == 4) extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+} else extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
 };
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostAudio_resume_soundArgs) != 8) @compileError("HostAudio_resume_soundArgs size mismatch");
+        if (@alignOf(HostAudio_resume_soundArgs) != 8) @compileError("HostAudio_resume_soundArgs alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostAudio_resume_soundArgs) != 4) @compileError("HostAudio_resume_soundArgs size mismatch");
+        if (@alignOf(HostAudio_resume_soundArgs) != 4) @compileError("HostAudio_resume_soundArgs alignment mismatch");
+    }
+}
 
 /// Arguments for Host.audio_is_sound_playing!
-/// Roc signature: Handle(Host.SoundResource) => Bool
+/// Roc signature: AudioSound => Bool
 /// Refcounted fields are owned by the hosted function.
-pub const HostAudio_is_sound_playingArgs = extern struct {
-    arg0: *u64,
+pub const HostAudio_is_sound_playingArgs = if (@sizeOf(usize) == 4) extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+} else extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
 };
 
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostAudio_is_sound_playingArgs) != 8) @compileError("HostAudio_is_sound_playingArgs size mismatch");
+        if (@alignOf(HostAudio_is_sound_playingArgs) != 8) @compileError("HostAudio_is_sound_playingArgs alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostAudio_is_sound_playingArgs) != 4) @compileError("HostAudio_is_sound_playingArgs size mismatch");
+        if (@alignOf(HostAudio_is_sound_playingArgs) != 4) @compileError("HostAudio_is_sound_playingArgs alignment mismatch");
+    }
+}
+
 /// Arguments for Host.audio_set_sound_volume!
-/// Roc signature: Handle(Host.SoundResource), F32 => {}
+/// Roc signature: AudioSound, F32 => {}
 /// Refcounted fields are owned by the hosted function.
 pub const HostAudio_set_sound_volumeArgs = extern struct {
-    arg0: *u64,
+    arg0: AudioSound,
     arg1: f32,
 };
 
 /// Arguments for Host.audio_set_sound_pitch!
-/// Roc signature: Handle(Host.SoundResource), F32 => {}
+/// Roc signature: AudioSound, F32 => {}
 /// Refcounted fields are owned by the hosted function.
 pub const HostAudio_set_sound_pitchArgs = extern struct {
-    arg0: *u64,
+    arg0: AudioSound,
     arg1: f32,
 };
 
 /// Arguments for Host.audio_set_sound_pan!
-/// Roc signature: Handle(Host.SoundResource), F32 => {}
+/// Roc signature: AudioSound, F32 => {}
 /// Refcounted fields are owned by the hosted function.
 pub const HostAudio_set_sound_panArgs = extern struct {
-    arg0: *u64,
+    arg0: AudioSound,
     arg1: f32,
 };
 
 /// Arguments for Host.audio_play_music!
-/// Roc signature: Handle(Host.MusicResource) => {}
+/// Roc signature: AudioMusic => {}
 /// Refcounted fields are owned by the hosted function.
-pub const HostAudio_play_musicArgs = extern struct {
-    arg0: *u64,
+pub const HostAudio_play_musicArgs = if (@sizeOf(usize) == 4) extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+} else extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
 };
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostAudio_play_musicArgs) != 8) @compileError("HostAudio_play_musicArgs size mismatch");
+        if (@alignOf(HostAudio_play_musicArgs) != 8) @compileError("HostAudio_play_musicArgs alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostAudio_play_musicArgs) != 4) @compileError("HostAudio_play_musicArgs size mismatch");
+        if (@alignOf(HostAudio_play_musicArgs) != 4) @compileError("HostAudio_play_musicArgs alignment mismatch");
+    }
+}
 
 /// Arguments for Host.audio_stop_music!
-/// Roc signature: Handle(Host.MusicResource) => {}
+/// Roc signature: AudioMusic => {}
 /// Refcounted fields are owned by the hosted function.
-pub const HostAudio_stop_musicArgs = extern struct {
-    arg0: *u64,
+pub const HostAudio_stop_musicArgs = if (@sizeOf(usize) == 4) extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+} else extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
 };
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostAudio_stop_musicArgs) != 8) @compileError("HostAudio_stop_musicArgs size mismatch");
+        if (@alignOf(HostAudio_stop_musicArgs) != 8) @compileError("HostAudio_stop_musicArgs alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostAudio_stop_musicArgs) != 4) @compileError("HostAudio_stop_musicArgs size mismatch");
+        if (@alignOf(HostAudio_stop_musicArgs) != 4) @compileError("HostAudio_stop_musicArgs alignment mismatch");
+    }
+}
 
 /// Arguments for Host.audio_pause_music!
-/// Roc signature: Handle(Host.MusicResource) => {}
+/// Roc signature: AudioMusic => {}
 /// Refcounted fields are owned by the hosted function.
-pub const HostAudio_pause_musicArgs = extern struct {
-    arg0: *u64,
+pub const HostAudio_pause_musicArgs = if (@sizeOf(usize) == 4) extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+} else extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
 };
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostAudio_pause_musicArgs) != 8) @compileError("HostAudio_pause_musicArgs size mismatch");
+        if (@alignOf(HostAudio_pause_musicArgs) != 8) @compileError("HostAudio_pause_musicArgs alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostAudio_pause_musicArgs) != 4) @compileError("HostAudio_pause_musicArgs size mismatch");
+        if (@alignOf(HostAudio_pause_musicArgs) != 4) @compileError("HostAudio_pause_musicArgs alignment mismatch");
+    }
+}
 
 /// Arguments for Host.audio_resume_music!
-/// Roc signature: Handle(Host.MusicResource) => {}
+/// Roc signature: AudioMusic => {}
 /// Refcounted fields are owned by the hosted function.
-pub const HostAudio_resume_musicArgs = extern struct {
-    arg0: *u64,
+pub const HostAudio_resume_musicArgs = if (@sizeOf(usize) == 4) extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+} else extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
 };
 
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostAudio_resume_musicArgs) != 8) @compileError("HostAudio_resume_musicArgs size mismatch");
+        if (@alignOf(HostAudio_resume_musicArgs) != 8) @compileError("HostAudio_resume_musicArgs alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostAudio_resume_musicArgs) != 4) @compileError("HostAudio_resume_musicArgs size mismatch");
+        if (@alignOf(HostAudio_resume_musicArgs) != 4) @compileError("HostAudio_resume_musicArgs alignment mismatch");
+    }
+}
+
 /// Arguments for Host.audio_set_music_volume!
-/// Roc signature: Handle(Host.MusicResource), F32 => {}
+/// Roc signature: AudioMusic, F32 => {}
 /// Refcounted fields are owned by the hosted function.
 pub const HostAudio_set_music_volumeArgs = extern struct {
-    arg0: *u64,
+    arg0: AudioMusic,
     arg1: f32,
 };
 
 /// Arguments for Host.audio_set_music_pitch!
-/// Roc signature: Handle(Host.MusicResource), F32 => {}
+/// Roc signature: AudioMusic, F32 => {}
 /// Refcounted fields are owned by the hosted function.
 pub const HostAudio_set_music_pitchArgs = extern struct {
-    arg0: *u64,
+    arg0: AudioMusic,
     arg1: f32,
 };
 
 /// Arguments for Host.audio_set_music_pan!
-/// Roc signature: Handle(Host.MusicResource), F32 => {}
+/// Roc signature: AudioMusic, F32 => {}
 /// Refcounted fields are owned by the hosted function.
 pub const HostAudio_set_music_panArgs = extern struct {
-    arg0: *u64,
+    arg0: AudioMusic,
     arg1: f32,
 };
 
 /// Arguments for Host.audio_set_music_looping!
-/// Roc signature: Handle(Host.MusicResource), Bool => {}
+/// Roc signature: AudioMusic, Bool => {}
 /// Refcounted fields are owned by the hosted function.
 pub const HostAudio_set_music_loopingArgs = extern struct {
-    arg0: *u64,
+    arg0: AudioMusic,
     arg1: bool,
 };
 
 /// Arguments for Host.audio_is_music_playing!
-/// Roc signature: Handle(Host.MusicResource) => Bool
+/// Roc signature: AudioMusic => Bool
 /// Refcounted fields are owned by the hosted function.
-pub const HostAudio_is_music_playingArgs = extern struct {
-    arg0: *u64,
+pub const HostAudio_is_music_playingArgs = if (@sizeOf(usize) == 4) extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+} else extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
 };
 
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostAudio_is_music_playingArgs) != 8) @compileError("HostAudio_is_music_playingArgs size mismatch");
+        if (@alignOf(HostAudio_is_music_playingArgs) != 8) @compileError("HostAudio_is_music_playingArgs alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostAudio_is_music_playingArgs) != 4) @compileError("HostAudio_is_music_playingArgs size mismatch");
+        if (@alignOf(HostAudio_is_music_playingArgs) != 4) @compileError("HostAudio_is_music_playingArgs alignment mismatch");
+    }
+}
+
 /// Arguments for Host.audio_seek_music!
-/// Roc signature: Handle(Host.MusicResource), F32 => {}
+/// Roc signature: AudioMusic, F32 => {}
 /// Refcounted fields are owned by the hosted function.
 pub const HostAudio_seek_musicArgs = extern struct {
-    arg0: *u64,
+    arg0: AudioMusic,
     arg1: f32,
 };
 
 /// Arguments for Host.audio_music_length!
-/// Roc signature: Handle(Host.MusicResource) => F32
+/// Roc signature: AudioMusic => F32
 /// Refcounted fields are owned by the hosted function.
-pub const HostAudio_music_lengthArgs = extern struct {
-    arg0: *u64,
+pub const HostAudio_music_lengthArgs = if (@sizeOf(usize) == 4) extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+} else extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
 };
 
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostAudio_music_lengthArgs) != 8) @compileError("HostAudio_music_lengthArgs size mismatch");
+        if (@alignOf(HostAudio_music_lengthArgs) != 8) @compileError("HostAudio_music_lengthArgs alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostAudio_music_lengthArgs) != 4) @compileError("HostAudio_music_lengthArgs size mismatch");
+        if (@alignOf(HostAudio_music_lengthArgs) != 4) @compileError("HostAudio_music_lengthArgs alignment mismatch");
+    }
+}
+
 /// Arguments for Host.audio_music_time_played!
-/// Roc signature: Handle(Host.MusicResource) => F32
+/// Roc signature: AudioMusic => F32
 /// Refcounted fields are owned by the hosted function.
-pub const HostAudio_music_time_playedArgs = extern struct {
-    arg0: *u64,
+pub const HostAudio_music_time_playedArgs = if (@sizeOf(usize) == 4) extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+} else extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
 };
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostAudio_music_time_playedArgs) != 8) @compileError("HostAudio_music_time_playedArgs size mismatch");
+        if (@alignOf(HostAudio_music_time_playedArgs) != 8) @compileError("HostAudio_music_time_playedArgs alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostAudio_music_time_playedArgs) != 4) @compileError("HostAudio_music_time_playedArgs size mismatch");
+        if (@alignOf(HostAudio_music_time_playedArgs) != 4) @compileError("HostAudio_music_time_playedArgs alignment mismatch");
+    }
+}
 
 /// Arguments for Host.audio_set_master_volume!
 /// Roc signature: F32 => {}
@@ -10145,41 +11840,41 @@ comptime {
 }
 
 /// Arguments for Host.text_load_store_font!
-/// Roc signature: { path : Str, size : I32, store : Handle(Host.StoreResource) } => Try(Font, [FontLoadFailed, NotFound, PathInvalid, ReadFailed, ResourceLimit])
+/// Roc signature: { path : Str, size : I32, store : Store } => Try(Font, [FontLoadFailed, NotFound, PathInvalid, ReadFailed, ResourceLimit])
 /// Refcounted fields are owned by the hosted function.
 pub const HostText_load_store_fontArgs = if (@sizeOf(usize) == 4) extern struct {
     path: RocStr,
-    store: *u64,
+    store: Store,
     size: i32,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
         value.path.decref(roc_host);
-        decrefBoxWith(@ptrCast(value.store), @alignOf(u64), false, null, roc_host);
+        value.store.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
         value.path.incref(amount);
-        increfBox(@ptrCast(value.store), amount);
+        value.store.incref(amount);
     }
 } else extern struct {
     path: RocStr,
-    store: *u64,
+    store: Store,
     size: i32,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
         value.path.decref(roc_host);
-        decrefBoxWith(@ptrCast(value.store), @alignOf(u64), false, null, roc_host);
+        value.store.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
         value.path.incref(amount);
-        increfBox(@ptrCast(value.store), amount);
+        value.store.incref(amount);
     }
 };
 
@@ -10195,7 +11890,7 @@ comptime {
 }
 
 /// Arguments for Host.text_prepare!
-/// Roc signature: { font : Handle([FontResource]), size : F32, spacing : F32, text : Str } => Try({ height : F32, prepared : Handle(Host.PreparedTextResource), width : F32 }, [InvalidResource, ResourceLimit])
+/// Roc signature: { font : Handle([FontResource]), size : F32, spacing : F32, text : Str } => Try({ height : F32, prepared : TextPrepared, width : F32 }, [InvalidResource, ResourceLimit])
 /// Refcounted fields are owned by the hosted function.
 pub const HostText_prepareArgs = if (@sizeOf(usize) == 4) extern struct {
     font: *u64,
@@ -10247,16 +11942,16 @@ comptime {
 }
 
 /// Arguments for Host.draw_draw_prepared_text!
-/// Roc signature: { color : Color.Rgba, pos : Math.Vec2, prepared : Handle(Host.PreparedTextResource) } => {}
+/// Roc signature: { color : Color.Rgba, pos : Math.Vec2, prepared : TextPrepared } => {}
 /// Refcounted fields are owned by the hosted function.
 pub const HostDraw_draw_prepared_textArgs = if (@sizeOf(usize) == 4) extern struct {
-    prepared: *u64,
+    prepared: TextPrepared,
     pos: MathVec2,
     color: ColorRgba,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        decrefBoxWith(@ptrCast(value.prepared), @alignOf(u64), false, null, roc_host);
+        value.prepared.decref(roc_host);
         value.pos.decref(roc_host);
         value.color.decref(roc_host);
     }
@@ -10264,18 +11959,18 @@ pub const HostDraw_draw_prepared_textArgs = if (@sizeOf(usize) == 4) extern stru
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        increfBox(@ptrCast(value.prepared), amount);
+        value.prepared.incref(amount);
         value.pos.incref(amount);
         value.color.incref(amount);
     }
 } else extern struct {
-    prepared: *u64,
+    prepared: TextPrepared,
     pos: MathVec2,
     color: ColorRgba,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        decrefBoxWith(@ptrCast(value.prepared), @alignOf(u64), false, null, roc_host);
+        value.prepared.decref(roc_host);
         value.pos.decref(roc_host);
         value.color.decref(roc_host);
     }
@@ -10283,7 +11978,7 @@ pub const HostDraw_draw_prepared_textArgs = if (@sizeOf(usize) == 4) extern stru
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        increfBox(@ptrCast(value.prepared), amount);
+        value.prepared.incref(amount);
         value.pos.incref(amount);
         value.color.incref(amount);
     }
@@ -10909,28 +12604,28 @@ comptime {
 }
 
 /// Arguments for Host.files_read_text!
-/// Roc signature: Str => { contents : Str, err : U8 }
+/// Roc signature: Str => Try(Str, [Busy, NotFound, NotUtf8, ReadFailed, TooLarge, Unavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostFiles_read_textArgs = extern struct {
     arg0: RocStr,
 };
 
 /// Arguments for Host.files_read_bytes!
-/// Roc signature: Str => { bytes : List(U8), err : U8 }
+/// Roc signature: Str => Try(List(U8), [Busy, NotFound, ReadFailed, TooLarge, Unavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostFiles_read_bytesArgs = extern struct {
     arg0: RocStr,
 };
 
 /// Arguments for Host.files_list!
-/// Roc signature: Str => { bytes : List(U8), err : U8 }
+/// Roc signature: Str => Try(List(U8), [Busy, NotADirectory, NotFound, ReadFailed, TooLarge, Unavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostFiles_listArgs = extern struct {
     arg0: RocStr,
 };
 
 /// Arguments for Host.files_metadata!
-/// Roc signature: Str => { err : U8, kind : U8, modified_nanosecond : U32, modified_seconds : I64, size_bytes : U64 }
+/// Roc signature: Str => Try({ kind : U8, modified_nanosecond : U32, modified_seconds : I64, size_bytes : U64 }, [NotFound, PermissionDenied, ReadFailed, Unavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostFiles_metadataArgs = extern struct {
     arg0: RocStr,
@@ -11177,7 +12872,7 @@ comptime {
 }
 
 /// Arguments for Host.capture_pixel_at!
-/// Roc signature: { source : { screen : Bool, target : Texture }, x : I32, y : I32 } => { a : U8, b : U8, err : U8, g : U8, r : U8 }
+/// Roc signature: { source : { screen : Bool, target : Texture }, x : I32, y : I32 } => Try({ a : U8, b : U8, g : U8, r : U8 }, [Busy, ReadbackFailed, RegionOutOfBounds, TargetUnavailable, Unavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostCapture_pixel_atArgs = if (@sizeOf(usize) == 4) extern struct {
     source: __AnonStruct_29524f9bb2f9574c,
@@ -11223,7 +12918,7 @@ comptime {
 }
 
 /// Arguments for Host.capture_read_region!
-/// Roc signature: { height : I32, source : { screen : Bool, target : Texture }, width : I32, x : I32, y : I32 } => { bytes : List(U8), err : U8 }
+/// Roc signature: { height : I32, source : { screen : Bool, target : Texture }, width : I32, x : I32, y : I32 } => Try(List(U8), [Busy, ReadbackFailed, RegionOutOfBounds, TargetUnavailable, Unavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostCapture_read_regionArgs = if (@sizeOf(usize) == 4) extern struct {
     source: __AnonStruct_29524f9bb2f9574c,
@@ -11828,17 +13523,17 @@ comptime {
 }
 
 /// Arguments for Host.shader_load_store!
-/// Roc signature: { fragment_path : Str, store : Handle(Host.StoreResource), vertex_path : Str } => Try(Shader, [NotFound, PathInvalid, ReadFailed, ResourceLimit, ShaderLoadFailed])
+/// Roc signature: { fragment_path : Str, store : Store, vertex_path : Str } => Try(Shader, [NotFound, PathInvalid, ReadFailed, ResourceLimit, ShaderLoadFailed])
 /// Refcounted fields are owned by the hosted function.
 pub const HostShader_load_storeArgs = if (@sizeOf(usize) == 4) extern struct {
     fragment_path: RocStr,
-    store: *u64,
+    store: Store,
     vertex_path: RocStr,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
         value.fragment_path.decref(roc_host);
-        decrefBoxWith(@ptrCast(value.store), @alignOf(u64), false, null, roc_host);
+        value.store.decref(roc_host);
         value.vertex_path.decref(roc_host);
     }
 
@@ -11846,18 +13541,18 @@ pub const HostShader_load_storeArgs = if (@sizeOf(usize) == 4) extern struct {
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
         value.fragment_path.incref(amount);
-        increfBox(@ptrCast(value.store), amount);
+        value.store.incref(amount);
         value.vertex_path.incref(amount);
     }
 } else extern struct {
     fragment_path: RocStr,
-    store: *u64,
+    store: Store,
     vertex_path: RocStr,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
         value.fragment_path.decref(roc_host);
-        decrefBoxWith(@ptrCast(value.store), @alignOf(u64), false, null, roc_host);
+        value.store.decref(roc_host);
         value.vertex_path.decref(roc_host);
     }
 
@@ -11865,7 +13560,7 @@ pub const HostShader_load_storeArgs = if (@sizeOf(usize) == 4) extern struct {
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
         value.fragment_path.incref(amount);
-        increfBox(@ptrCast(value.store), amount);
+        value.store.incref(amount);
         value.vertex_path.incref(amount);
     }
 };
@@ -12210,7 +13905,7 @@ comptime {
 }
 
 /// Arguments for Host.http_send!
-/// Roc signature: { body : List(U8), headers : List({ name : Str, value : Str }), max_response_bytes : U64, method : U8, method_ext : Str, timeout_ms : U64, uri : Str } => { body : List(U8), err : U8, err_message : Str, headers : List({ name : Str, value : Str }), status : U16 }
+/// Roc signature: { body : List(U8), headers : List({ name : Str, value : Str }), max_response_bytes : U64, method : U8, method_ext : Str, timeout_ms : U64, uri : Str } => Try({ body : List(U8), headers : List({ name : Str, value : Str }), status : U16 }, [MalformedResponse, NetworkError, Other(Str), Timeout])
 /// Refcounted fields are owned by the hosted function.
 pub const HostHttp_sendArgs = if (@sizeOf(usize) == 4) extern struct {
     max_response_bytes: u64,
@@ -12300,7 +13995,7 @@ pub const HostStdio_write_bytesArgs = extern struct {
 };
 
 /// Arguments for Host.udp_bind!
-/// Roc signature: { ip : Str, port : U16 } => { err : U8, handle : Handle(Host.UdpSocketResource), ip : U32, port : U16 }
+/// Roc signature: { ip : Str, port : U16 } => Try({ handle : UdpSocket, ip : U32, port : U16 }, [AddressInUse, AddressUnavailable, InvalidAddress, PermissionDenied, ResourceLimit, Unavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostUdp_bindArgs = if (@sizeOf(usize) == 4) extern struct {
     ip: RocStr,
@@ -12344,19 +14039,19 @@ comptime {
 }
 
 /// Arguments for Host.udp_send!
-/// Roc signature: { bytes : List(U8), ip : Str, port : U16, socket : Handle(Host.UdpSocketResource) } => U8
+/// Roc signature: { bytes : List(U8), ip : Str, port : U16, socket : UdpSocket } => U8
 /// Refcounted fields are owned by the hosted function.
 pub const HostUdp_sendArgs = if (@sizeOf(usize) == 4) extern struct {
     bytes: RocListWith(u8, false),
     ip: RocStr,
-    socket: *u64,
+    socket: UdpSocket,
     port: u16,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
         value.bytes.decref(roc_host);
         value.ip.decref(roc_host);
-        decrefBoxWith(@ptrCast(value.socket), @alignOf(u64), false, null, roc_host);
+        value.socket.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
@@ -12364,19 +14059,19 @@ pub const HostUdp_sendArgs = if (@sizeOf(usize) == 4) extern struct {
         const value = self;
         value.bytes.incref(amount);
         value.ip.incref(amount);
-        increfBox(@ptrCast(value.socket), amount);
+        value.socket.incref(amount);
     }
 } else extern struct {
     bytes: RocListWith(u8, false),
     ip: RocStr,
-    socket: *u64,
+    socket: UdpSocket,
     port: u16,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
         value.bytes.decref(roc_host);
         value.ip.decref(roc_host);
-        decrefBoxWith(@ptrCast(value.socket), @alignOf(u64), false, null, roc_host);
+        value.socket.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
@@ -12384,7 +14079,7 @@ pub const HostUdp_sendArgs = if (@sizeOf(usize) == 4) extern struct {
         const value = self;
         value.bytes.incref(amount);
         value.ip.incref(amount);
-        increfBox(@ptrCast(value.socket), amount);
+        value.socket.incref(amount);
     }
 };
 
@@ -12400,37 +14095,37 @@ comptime {
 }
 
 /// Arguments for Host.udp_receive!
-/// Roc signature: { max_datagrams : U32, socket : Handle(Host.UdpSocketResource), timeout_ms : U64 } => { err : U8, payload : List(U8), slices : List({ ip : U32, len : U64, port : U16, start : U64 }) }
+/// Roc signature: { max_datagrams : U32, socket : UdpSocket, timeout_ms : U64 } => Try({ payload : List(U8), slices : List({ ip : U32, len : U64, port : U16, start : U64 }) }, [AlreadyReceiving, ReceiveFailed, Timeout, Unavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostUdp_receiveArgs = if (@sizeOf(usize) == 4) extern struct {
     timeout_ms: u64,
-    socket: *u64,
+    socket: UdpSocket,
     max_datagrams: u32,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        decrefBoxWith(@ptrCast(value.socket), @alignOf(u64), false, null, roc_host);
+        value.socket.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        increfBox(@ptrCast(value.socket), amount);
+        value.socket.incref(amount);
     }
 } else extern struct {
     timeout_ms: u64,
-    socket: *u64,
+    socket: UdpSocket,
     max_datagrams: u32,
     /// Recursively decrement Roc-owned fields.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         const value = self;
-        decrefBoxWith(@ptrCast(value.socket), @alignOf(u64), false, null, roc_host);
+        value.socket.decref(roc_host);
     }
 
     /// Increment Roc-owned fields.
     pub fn incref(self: @This(), amount: isize) void {
         const value = self;
-        increfBox(@ptrCast(value.socket), amount);
+        value.socket.incref(amount);
     }
 };
 
@@ -12446,7 +14141,7 @@ comptime {
 }
 
 /// Arguments for Host.sqlite_open!
-/// Roc signature: Str, U8, U64, U64 => { db : Handle(Host.SqliteDbResource), err : I64, message : Str }
+/// Roc signature: Str, U8, U64, U64 => Try(SqliteDb, [SqliteErr({ code : I64, message : Str }), TooManyConnections])
 /// Refcounted fields are owned by the hosted function.
 pub const HostSqlite_openArgs = extern struct {
     arg0: RocStr,
@@ -12456,47 +14151,82 @@ pub const HostSqlite_openArgs = extern struct {
 };
 
 /// Arguments for Host.sqlite_close!
-/// Roc signature: Handle(Host.SqliteDbResource) => { err : I64, message : Str }
+/// Roc signature: SqliteDb => Try({}, [SqliteErr({ code : I64, message : Str })])
 /// Refcounted fields are owned by the hosted function.
-pub const HostSqlite_closeArgs = extern struct {
-    arg0: *u64,
+pub const HostSqlite_closeArgs = if (@sizeOf(usize) == 4) extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
+} else extern struct {
+    handle: *u64,
+    /// Recursively decrement Roc-owned fields.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        const value = self;
+        decrefBoxWith(@ptrCast(value.handle), @alignOf(u64), false, null, roc_host);
+    }
+
+    /// Increment Roc-owned fields.
+    pub fn incref(self: @This(), amount: isize) void {
+        const value = self;
+        increfBox(@ptrCast(value.handle), amount);
+    }
 };
 
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostSqlite_closeArgs) != 8) @compileError("HostSqlite_closeArgs size mismatch");
+        if (@alignOf(HostSqlite_closeArgs) != 8) @compileError("HostSqlite_closeArgs alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostSqlite_closeArgs) != 4) @compileError("HostSqlite_closeArgs size mismatch");
+        if (@alignOf(HostSqlite_closeArgs) != 4) @compileError("HostSqlite_closeArgs alignment mismatch");
+    }
+}
+
 /// Arguments for Host.sqlite_prepare!
-/// Roc signature: Handle(Host.SqliteDbResource), Str => { err : I64, message : Str, stmt : Handle(Host.SqliteStmtResource) }
+/// Roc signature: SqliteDb, Str => Try(SqliteStmt, [MultipleStatements, SqliteErr({ code : I64, message : Str }), TooManyStatements])
 /// Refcounted fields are owned by the hosted function.
 pub const HostSqlite_prepareArgs = extern struct {
-    arg0: *u64,
+    arg0: SqliteDb,
     arg1: RocStr,
 };
 
 /// Arguments for Host.sqlite_run_stmt!
-/// Roc signature: Handle(Host.SqliteStmtResource), List({ blob : List(U8), integer : I64, kind : U8, name : Str, real : F64, text : Str }) => { cells : List({ integer : I64, kind : U8, len : U64, real : F64, start : U64 }), changes : I64, err : I64, last_insert_rowid : I64, message : Str, names : List(U8), ncols : U64, payload : List(U8), row_count : U64 }
+/// Roc signature: SqliteStmt, List({ blob : List(U8), integer : I64, kind : U8, name : Str, real : F64, text : Str }) => Try({ cells : List({ integer : I64, kind : U8, len : U64, real : F64, start : U64 }), changes : I64, last_insert_rowid : I64, names : List(U8), ncols : U64, payload : List(U8), row_count : U64 }, [MultipleStatements, ResultTooLarge, SqliteErr({ code : I64, message : Str })])
 /// Refcounted fields are owned by the hosted function.
 pub const HostSqlite_run_stmtArgs = extern struct {
-    arg0: *u64,
+    arg0: SqliteStmt,
     arg1: RocList(__AnonStruct_90c9f98ccd96f8ce),
 };
 
 /// Arguments for Host.sqlite_run_once!
-/// Roc signature: Handle(Host.SqliteDbResource), Str, List({ blob : List(U8), integer : I64, kind : U8, name : Str, real : F64, text : Str }) => { cells : List({ integer : I64, kind : U8, len : U64, real : F64, start : U64 }), changes : I64, err : I64, last_insert_rowid : I64, message : Str, names : List(U8), ncols : U64, payload : List(U8), row_count : U64 }
+/// Roc signature: SqliteDb, Str, List({ blob : List(U8), integer : I64, kind : U8, name : Str, real : F64, text : Str }) => Try({ cells : List({ integer : I64, kind : U8, len : U64, real : F64, start : U64 }), changes : I64, last_insert_rowid : I64, names : List(U8), ncols : U64, payload : List(U8), row_count : U64 }, [MultipleStatements, ResultTooLarge, SqliteErr({ code : I64, message : Str })])
 /// Refcounted fields are owned by the hosted function.
 pub const HostSqlite_run_onceArgs = extern struct {
-    arg0: *u64,
+    arg0: SqliteDb,
     arg1: RocStr,
     arg2: RocList(__AnonStruct_90c9f98ccd96f8ce),
 };
 
 /// Arguments for Host.sqlite_exec_script!
-/// Roc signature: Handle(Host.SqliteDbResource), Str => { err : I64, message : Str }
+/// Roc signature: SqliteDb, Str => Try({}, [SqliteErr({ code : I64, message : Str })])
 /// Refcounted fields are owned by the hosted function.
 pub const HostSqlite_exec_scriptArgs = extern struct {
-    arg0: *u64,
+    arg0: SqliteDb,
     arg1: RocStr,
 };
 
 /// Arguments for Host.cmd_run!
-/// Roc signature: { args : List(Str), clear_envs : Bool, envs : List({ name : Str, value : Str }), program : Str, stderr_limit_bytes : U64, stdout_limit_bytes : U64, timeout_ms : U64, working_dir : Str } => { err : U8, exit_code : I64, stderr : List(U8), stdout : List(U8) }
+/// Roc signature: { args : List(Str), clear_envs : Bool, envs : List({ name : Str, value : Str }), program : Str, stderr_limit_bytes : U64, stdout_limit_bytes : U64, timeout_ms : U64, working_dir : Str } => Try({ exit_code : I64, stderr : List(U8), stdout : List(U8) }, [Busy, CommandNotFound, PermissionDenied, SpawnFailed, StderrLimitExceeded, StdoutLimitExceeded, Timeout({ exit_code : I64, stderr : List(U8), stdout : List(U8) }), Unavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostCmd_runArgs = if (@sizeOf(usize) == 4) extern struct {
     stderr_limit_bytes: u64,
@@ -12606,7 +14336,8 @@ pub const HostTrace_sample_f64Args = extern struct {
 
 pub const HostStore_openArg0 = __AnonStruct_8f4b2816fd84fce2;
 pub const HostStore_openErr = AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch;
-pub const HostTexture_load_storeArg0 = __AnonStruct_e6634fb4c190c214;
+pub const HostStore_openOk = Store;
+pub const HostTexture_load_storeArg0 = __AnonStruct_fcb9c18e638f68bc;
 pub const HostTexture_load_storeErr = NotFoundOrPathInvalidOrReadFailedOrResourceLimitOrTextureLoadFailed;
 pub const HostTexture_load_storeOk = Texture;
 pub const HostTexture_load_bytesArg0 = __AnonStruct_ff17f03b4409100d;
@@ -12627,13 +14358,17 @@ pub const HostTexture_update_regionArg0 = __AnonStruct_307d51efe2380633;
 pub const HostTexture_update_regionArg0Pixels = ColorRgba;
 pub const HostAudio_gen_toneArg0 = __AnonStruct_74e1febaa758f087;
 pub const HostAudio_gen_toneErr = ResourceLimitOrSoundGenerationFailed;
+pub const HostAudio_gen_toneOk = AudioSound;
 pub const HostAudio_gen_soundArg0 = __AnonStruct_37b6eb678c2c2ca2;
 pub const HostAudio_gen_soundResult = HostAudio_gen_toneResult;
 pub const HostAudio_gen_soundResultPayload = HostAudio_gen_toneResultPayload;
 pub const HostAudio_gen_soundResultTag = HostAudio_gen_toneResultTag;
 pub const HostAudio_gen_soundErr = ResourceLimitOrSoundGenerationFailed;
+pub const HostAudio_gen_soundOk = AudioSound;
 pub const HostAudio_load_soundErr = ResourceLimitOrSoundLoadFailed;
+pub const HostAudio_load_soundOk = AudioSound;
 pub const HostAudio_load_musicErr = MusicLoadFailedOrResourceLimit;
+pub const HostAudio_load_musicOk = AudioMusic;
 pub const HostDraw_begin_scissorArg0 = __AnonStruct_5d393593a1f032cb;
 pub const HostDraw_circle_gradientArg0 = __AnonStruct_f8a458371716c148;
 pub const HostDraw_circle_linesArg0 = __AnonStruct_8b18bd818a3a6ac2;
@@ -12652,13 +14387,13 @@ pub const HostDraw_lineArg0 = __AnonStruct_a3fdb7fbf4ae00b8;
 pub const HostText_load_fontArg0 = __AnonStruct_5cba559c3a07b56a;
 pub const HostText_load_fontErr = FontLoadFailedOrResourceLimit;
 pub const HostText_load_fontOk = Font;
-pub const HostText_load_store_fontArg0 = __AnonStruct_80c864420ea33e1e;
+pub const HostText_load_store_fontArg0 = __AnonStruct_aba52beeae923776;
 pub const HostText_load_store_fontErr = FontLoadFailedOrNotFoundOrPathInvalidOrReadFailedOrResourceLimit;
 pub const HostText_load_store_fontOk = Font;
 pub const HostText_prepareArg0 = __AnonStruct_7f4d6dac6c3eef5e;
 pub const HostText_prepareErr = InvalidResourceOrResourceLimit;
-pub const HostText_prepareOk = __AnonStruct_e1165210b218b76c;
-pub const HostDraw_draw_prepared_textArg0 = __AnonStruct_6bff15fb6a4cb85a;
+pub const HostText_prepareOk = __AnonStruct_34e6157b936793f4;
+pub const HostDraw_draw_prepared_textArg0 = __AnonStruct_8dc97a0a319d4d53;
 pub const HostDraw_polygon_linesArg0 = __AnonStruct_2dcd38bc772d0799;
 pub const HostDraw_polygon_linesArg0Points = MathVec2;
 pub const HostDraw_polygonArg0 = __AnonStruct_16cb9af61afe2d08;
@@ -12672,23 +14407,26 @@ pub const HostDraw_rounded_rectangleArg0 = __AnonStruct_2b98c437f1796b13;
 pub const HostDraw_textArg0 = __AnonStruct_a794ed9ee3bc5d8d;
 pub const HostDraw_triangle_linesArg0 = __AnonStruct_563f890a3b4ea7a0;
 pub const HostDraw_triangleArg0 = __AnonStruct_d48cb861dff2afaa;
-pub const HostFiles_read_text = __AnonStruct_e98c7d72bcd7a610;
-pub const HostFiles_read_bytes = __AnonStruct_5b08b74ffdd2f118;
-pub const HostFiles_list = __AnonStruct_5b08b74ffdd2f118;
-pub const HostFiles_metadata = __AnonStruct_ee584b0815816939;
+pub const HostFiles_read_textErr = BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable;
+pub const HostFiles_read_bytesErr = BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable;
+pub const HostFiles_listErr = BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable;
+pub const HostFiles_metadataErr = NotFoundOrPermissionDeniedOrReadFailedOrUnavailable;
+pub const HostFiles_metadataOk = __AnonStruct_a1f5c33e74b3920b;
 pub const HostCapture_set_virtual_mouseArg0 = __AnonStruct_e20342da83229f51;
 pub const HostCapture_set_virtual_keysArg0 = __AnonStruct_c3425bb1e3730c6e;
 pub const HostCapture_start_recordingArg0 = __AnonStruct_96bd4e483c462501;
-pub const HostCapture_stop_recording = __AnonStruct_7c66fb01c50d182a;
+pub const HostCapture_stop_recordingErr = BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable;
+pub const HostCapture_stop_recordingOk = __AnonStruct_5c978c17ba0c990a;
 pub const HostCapture_screenshot_textureArg0 = __AnonStruct_aa2779af0bb79965;
 pub const HostCapture_pixel_atArg0 = __AnonStruct_30827bd86e7a53b3;
 pub const HostCapture_pixel_atArg0Source = __AnonStruct_29524f9bb2f9574c;
-pub const HostCapture_pixel_at = __AnonStruct_50fe0879143e3c18;
+pub const HostCapture_pixel_atErr = BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable;
+pub const HostCapture_pixel_atOk = __AnonStruct_bda5c9dc6cabe78e;
 pub const HostCapture_read_regionArg0 = __AnonStruct_7ea2de5aa3c18166;
 pub const HostCapture_read_regionArg0Source = __AnonStruct_29524f9bb2f9574c;
-pub const HostCapture_read_region = __AnonStruct_5b08b74ffdd2f118;
+pub const HostCapture_read_regionErr = BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable;
 pub const HostApp_read_textErr = NotFoundOrReadFailed;
-pub const HostWindow_read_clipboard = __AnonStruct_e98c7d72bcd7a610;
+pub const HostWindow_read_clipboardErr = BusyOrTooLargeOrUnavailable;
 pub const HostWindow_suggest_sizeArg0 = __AnonStruct_bc8fa73ca49a5ac0;
 pub const HostWindow_suggest_min_sizeArg0 = __AnonStruct_bc8fa73ca49a5ac0;
 pub const HostWindow_scale_dpi = __AnonStruct_2818a50bdccefb1e;
@@ -12711,7 +14449,7 @@ pub const HostTexture_load_render_targetOk = Texture;
 pub const HostShader_load_sourceArg0 = __AnonStruct_c813cb81fdeac2dc;
 pub const HostShader_load_sourceErr = ResourceLimitOrShaderLoadFailed;
 pub const HostShader_load_sourceOk = Shader;
-pub const HostShader_load_storeArg0 = __AnonStruct_3e85b4e878c74d96;
+pub const HostShader_load_storeArg0 = __AnonStruct_87e8defa2945b71d;
 pub const HostShader_load_storeErr = NotFoundOrPathInvalidOrReadFailedOrResourceLimitOrShaderLoadFailed;
 pub const HostShader_load_storeOk = Shader;
 pub const HostShader_locationArg0 = __AnonStruct_45ec9dff41865827;
@@ -12731,28 +14469,65 @@ pub const HostShader_set_vec4Arg0Uniform = __AnonStruct_e9411c6c8286af86;
 pub const HostShader_set_vec4Arg0Value = __AnonStruct_8ea1de206d7d534d;
 pub const HostHttp_sendArg0 = __AnonStruct_85380e02323174c5;
 pub const HostHttp_sendArg0Headers = __AnonStruct_82a96c5d55d63488;
-pub const HostHttp_send = __AnonStruct_da7cbd33c88fa20a;
-pub const HostHttp_sendHeaders = __AnonStruct_82a96c5d55d63488;
+pub const HostHttp_sendErr = MalformedResponseOrNetworkErrorOrOtherOrTimeout;
+pub const HostHttp_sendErrPayload = MalformedResponseOrNetworkErrorOrOtherOrTimeoutPayload;
+pub const HostHttp_sendErrTag = MalformedResponseOrNetworkErrorOrOtherOrTimeoutTag;
+pub const HostHttp_sendOk = __AnonStruct_a14cd3b7d5755441;
+pub const HostHttp_sendOkHeaders = __AnonStruct_82a96c5d55d63488;
 pub const HostTime_now = __AnonStruct_bbf5049c4fa71893;
 pub const HostUdp_bindArg0 = __AnonStruct_63b1422749dba501;
-pub const HostUdp_bind = __AnonStruct_c53c193ad2a36104;
-pub const HostUdp_sendArg0 = __AnonStruct_686570ce13fde405;
-pub const HostUdp_receiveArg0 = __AnonStruct_3d573c3bcb10a375;
-pub const HostUdp_receive = __AnonStruct_c44117854a91f9a7;
-pub const HostUdp_receiveSlices = __AnonStruct_4dd3180405b3f44f;
-pub const HostSqlite_open = __AnonStruct_d1ff90659ed42132;
-pub const HostSqlite_close = __AnonStruct_e7ff50a9dfab1a8d;
-pub const HostSqlite_prepare = __AnonStruct_cff0e6766f0cb5bf;
+pub const HostUdp_bindErr = AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable;
+pub const HostUdp_bindOk = __AnonStruct_77531de58035959;
+pub const HostUdp_sendArg0 = __AnonStruct_53d84a4d5bb34dcd;
+pub const HostUdp_receiveArg0 = __AnonStruct_c0489e409fcc99cd;
+pub const HostUdp_receiveErr = AlreadyReceivingOrReceiveFailedOrTimeoutOrUnavailable;
+pub const HostUdp_receiveOk = __AnonStruct_1772298ecb801858;
+pub const HostUdp_receiveOkSlices = __AnonStruct_4dd3180405b3f44f;
+pub const HostSqlite_openErr = SqliteErrOrTooManyConnections;
+pub const HostSqlite_openErrPayload = SqliteErrOrTooManyConnectionsPayload;
+pub const HostSqlite_openErrTag = SqliteErrOrTooManyConnectionsTag;
+pub const HostSqlite_openErrSqliteErr = __AnonStruct_22cf486058afc711;
+pub const HostSqlite_openOk = SqliteDb;
+pub const SqliteErrOrTooManyConnectionsSqliteErr = __AnonStruct_22cf486058afc711;
+pub const HostSqlite_closeErr = __AnonStruct_22cf486058afc711;
+pub const SqliteErr = __AnonStruct_22cf486058afc711;
+pub const SqliteErrSqliteErr = __AnonStruct_22cf486058afc711;
+pub const HostSqlite_prepareErr = MultipleStatementsOrSqliteErrOrTooManyStatements;
+pub const HostSqlite_prepareErrPayload = MultipleStatementsOrSqliteErrOrTooManyStatementsPayload;
+pub const HostSqlite_prepareErrTag = MultipleStatementsOrSqliteErrOrTooManyStatementsTag;
+pub const HostSqlite_prepareErrSqliteErr = __AnonStruct_22cf486058afc711;
+pub const HostSqlite_prepareOk = SqliteStmt;
+pub const MultipleStatementsOrSqliteErrOrTooManyStatementsSqliteErr = __AnonStruct_22cf486058afc711;
 pub const HostSqlite_run_stmtArg1 = __AnonStruct_90c9f98ccd96f8ce;
-pub const HostSqlite_run_stmt = __AnonStruct_4bc5d3695423e2f1;
-pub const HostSqlite_run_stmtCells = __AnonStruct_3a90da783672cf8d;
+pub const HostSqlite_run_stmtErr = MultipleStatementsOrResultTooLargeOrSqliteErr;
+pub const HostSqlite_run_stmtErrPayload = MultipleStatementsOrResultTooLargeOrSqliteErrPayload;
+pub const HostSqlite_run_stmtErrTag = MultipleStatementsOrResultTooLargeOrSqliteErrTag;
+pub const HostSqlite_run_stmtErrSqliteErr = __AnonStruct_22cf486058afc711;
+pub const HostSqlite_run_stmtOk = __AnonStruct_566a76c01f44ee92;
+pub const MultipleStatementsOrResultTooLargeOrSqliteErrSqliteErr = __AnonStruct_22cf486058afc711;
+pub const HostSqlite_run_stmtOkCells = __AnonStruct_3a90da783672cf8d;
 pub const HostSqlite_run_onceArg2 = __AnonStruct_90c9f98ccd96f8ce;
-pub const HostSqlite_run_once = __AnonStruct_4bc5d3695423e2f1;
-pub const HostSqlite_run_onceCells = __AnonStruct_3a90da783672cf8d;
-pub const HostSqlite_exec_script = __AnonStruct_e7ff50a9dfab1a8d;
+pub const HostSqlite_run_onceResult = HostSqlite_run_stmtResult;
+pub const HostSqlite_run_onceResultPayload = HostSqlite_run_stmtResultPayload;
+pub const HostSqlite_run_onceResultTag = HostSqlite_run_stmtResultTag;
+pub const HostSqlite_run_onceErr = MultipleStatementsOrResultTooLargeOrSqliteErr;
+pub const HostSqlite_run_onceErrPayload = MultipleStatementsOrResultTooLargeOrSqliteErrPayload;
+pub const HostSqlite_run_onceErrTag = MultipleStatementsOrResultTooLargeOrSqliteErrTag;
+pub const HostSqlite_run_onceErrSqliteErr = __AnonStruct_22cf486058afc711;
+pub const HostSqlite_run_onceOk = __AnonStruct_566a76c01f44ee92;
+pub const HostSqlite_run_onceOkCells = __AnonStruct_3a90da783672cf8d;
+pub const HostSqlite_exec_scriptResult = HostSqlite_closeResult;
+pub const HostSqlite_exec_scriptResultPayload = HostSqlite_closeResultPayload;
+pub const HostSqlite_exec_scriptResultTag = HostSqlite_closeResultTag;
+pub const HostSqlite_exec_scriptErr = __AnonStruct_22cf486058afc711;
 pub const HostCmd_runArg0 = __AnonStruct_3fe396bc5ba0c31c;
 pub const HostCmd_runArg0Envs = __AnonStruct_82a96c5d55d63488;
-pub const HostCmd_run = __AnonStruct_fa110e8829dc221b;
+pub const HostCmd_runErr = BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable;
+pub const HostCmd_runErrPayload = BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailablePayload;
+pub const HostCmd_runErrTag = BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailableTag;
+pub const HostCmd_runErrTimeout = __AnonStruct_45d496287297bf7f;
+pub const HostCmd_runOk = __AnonStruct_45d496287297bf7f;
+pub const BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailableTimeout = __AnonStruct_45d496287297bf7f;
 pub const App_config_for_host = __AnonStruct_a868748fcc059834;
 pub const Update_for_hostArg1 = __AnonStruct_cf3def8e4b7f351;
 pub const Update_for_hostArg1Capture = __AnonStruct_681b090756070ab0;
@@ -12802,8 +14577,14 @@ pub const TextureRelease = struct {
     }
 };
 
-pub const __AnonStruct_e6634fb4c190c214Release = struct {
-    pub fn release(value: __AnonStruct_e6634fb4c190c214, roc_host: *RocHost) void {
+pub const __AnonStruct_fcb9c18e638f68bcRelease = struct {
+    pub fn release(value: __AnonStruct_fcb9c18e638f68bc, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+pub const StoreRelease = struct {
+    pub fn release(value: Store, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -13042,8 +14823,8 @@ pub const HostText_load_store_fontResultRelease = struct {
     }
 };
 
-pub const __AnonStruct_80c864420ea33e1eRelease = struct {
-    pub fn release(value: __AnonStruct_80c864420ea33e1e, roc_host: *RocHost) void {
+pub const __AnonStruct_aba52beeae923776Release = struct {
+    pub fn release(value: __AnonStruct_aba52beeae923776, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -13076,8 +14857,14 @@ pub const HostText_prepareResultRelease = struct {
     }
 };
 
-pub const __AnonStruct_e1165210b218b76cRelease = struct {
-    pub fn release(value: __AnonStruct_e1165210b218b76c, roc_host: *RocHost) void {
+pub const __AnonStruct_34e6157b936793f4Release = struct {
+    pub fn release(value: __AnonStruct_34e6157b936793f4, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+pub const TextPreparedRelease = struct {
+    pub fn release(value: TextPrepared, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -13156,8 +14943,8 @@ pub const HostShader_load_storeResultRelease = struct {
     }
 };
 
-pub const __AnonStruct_3e85b4e878c74d96Release = struct {
-    pub fn release(value: __AnonStruct_3e85b4e878c74d96, roc_host: *RocHost) void {
+pub const __AnonStruct_87e8defa2945b71dRelease = struct {
+    pub fn release(value: __AnonStruct_87e8defa2945b71d, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -13234,7 +15021,7 @@ fn decrefHostStore_openResult(value: HostStore_openResult, roc_host: *RocHost) v
             value.payload_err().decref(roc_host);
         },
         .Ok => {
-            decrefBoxWith(@ptrCast(value.payload_ok()), @alignOf(u64), false, null, roc_host);
+            value.payload_ok().decref(roc_host);
         },
     }
 }
@@ -13245,7 +15032,7 @@ fn increfHostStore_openResult(value: HostStore_openResult, amount: isize) void {
             value.payload_err().incref(amount);
         },
         .Ok => {
-            increfBox(@ptrCast(value.payload_ok()), amount);
+            value.payload_ok().incref(amount);
         },
     }
 }
@@ -13274,7 +15061,7 @@ fn decrefHostAudio_gen_toneResult(value: HostAudio_gen_toneResult, roc_host: *Ro
             value.payload_err().decref(roc_host);
         },
         .Ok => {
-            decrefBoxWith(@ptrCast(value.payload_ok()), @alignOf(u64), false, null, roc_host);
+            value.payload_ok().decref(roc_host);
         },
     }
 }
@@ -13285,13 +15072,19 @@ fn increfHostAudio_gen_toneResult(value: HostAudio_gen_toneResult, amount: isize
             value.payload_err().incref(amount);
         },
         .Ok => {
-            increfBox(@ptrCast(value.payload_ok()), amount);
+            value.payload_ok().incref(amount);
         },
     }
 }
 
 pub const HostAudio_gen_toneResultRelease = struct {
     pub fn release(value: HostAudio_gen_toneResult, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+pub const AudioSoundRelease = struct {
+    pub fn release(value: AudioSound, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -13314,7 +15107,7 @@ fn decrefHostAudio_load_soundResult(value: HostAudio_load_soundResult, roc_host:
             value.payload_err().decref(roc_host);
         },
         .Ok => {
-            decrefBoxWith(@ptrCast(value.payload_ok()), @alignOf(u64), false, null, roc_host);
+            value.payload_ok().decref(roc_host);
         },
     }
 }
@@ -13325,7 +15118,7 @@ fn increfHostAudio_load_soundResult(value: HostAudio_load_soundResult, amount: i
             value.payload_err().incref(amount);
         },
         .Ok => {
-            increfBox(@ptrCast(value.payload_ok()), amount);
+            value.payload_ok().incref(amount);
         },
     }
 }
@@ -13342,7 +15135,7 @@ fn decrefHostAudio_load_musicResult(value: HostAudio_load_musicResult, roc_host:
             value.payload_err().decref(roc_host);
         },
         .Ok => {
-            decrefBoxWith(@ptrCast(value.payload_ok()), @alignOf(u64), false, null, roc_host);
+            value.payload_ok().decref(roc_host);
         },
     }
 }
@@ -13353,7 +15146,7 @@ fn increfHostAudio_load_musicResult(value: HostAudio_load_musicResult, amount: i
             value.payload_err().incref(amount);
         },
         .Ok => {
-            increfBox(@ptrCast(value.payload_ok()), amount);
+            value.payload_ok().incref(amount);
         },
     }
 }
@@ -13364,26 +15157,188 @@ pub const HostAudio_load_musicResultRelease = struct {
     }
 };
 
-pub const __AnonStruct_e98c7d72bcd7a610Release = struct {
-    pub fn release(value: __AnonStruct_e98c7d72bcd7a610, roc_host: *RocHost) void {
+pub const AudioMusicRelease = struct {
+    pub fn release(value: AudioMusic, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
 
-pub const __AnonStruct_ee584b0815816939Release = struct {
-    pub fn release(value: __AnonStruct_ee584b0815816939, roc_host: *RocHost) void {
+fn decrefHostFiles_read_textResult(value: HostFiles_read_textResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {
+            value.payload_ok().decref(roc_host);
+        },
+    }
+}
+
+fn increfHostFiles_read_textResult(value: HostFiles_read_textResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {
+            value.payload_ok().incref(amount);
+        },
+    }
+}
+
+pub const HostFiles_read_textResultRelease = struct {
+    pub fn release(value: HostFiles_read_textResult, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
 
-pub const __AnonStruct_5b08b74ffdd2f118Release = struct {
-    pub fn release(value: __AnonStruct_5b08b74ffdd2f118, roc_host: *RocHost) void {
+fn decrefHostFiles_metadataResult(value: HostFiles_metadataResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {
+            value.payload_ok().decref(roc_host);
+        },
+    }
+}
+
+fn increfHostFiles_metadataResult(value: HostFiles_metadataResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {
+            value.payload_ok().incref(amount);
+        },
+    }
+}
+
+pub const HostFiles_metadataResultRelease = struct {
+    pub fn release(value: HostFiles_metadataResult, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
 
-pub const __AnonStruct_da7cbd33c88fa20aRelease = struct {
-    pub fn release(value: __AnonStruct_da7cbd33c88fa20a, roc_host: *RocHost) void {
+pub const __AnonStruct_a1f5c33e74b3920bRelease = struct {
+    pub fn release(value: __AnonStruct_a1f5c33e74b3920b, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+fn decrefHostFiles_read_bytesResult(value: HostFiles_read_bytesResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {
+            value.payload_ok().decref(roc_host);
+        },
+    }
+}
+
+fn increfHostFiles_read_bytesResult(value: HostFiles_read_bytesResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {
+            value.payload_ok().incref(amount);
+        },
+    }
+}
+
+pub const HostFiles_read_bytesResultRelease = struct {
+    pub fn release(value: HostFiles_read_bytesResult, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+fn decrefHostFiles_listResult(value: HostFiles_listResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {
+            value.payload_ok().decref(roc_host);
+        },
+    }
+}
+
+fn increfHostFiles_listResult(value: HostFiles_listResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {
+            value.payload_ok().incref(amount);
+        },
+    }
+}
+
+pub const HostFiles_listResultRelease = struct {
+    pub fn release(value: HostFiles_listResult, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+fn decrefHostHttp_sendResult(value: HostHttp_sendResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {
+            value.payload_ok().decref(roc_host);
+        },
+    }
+}
+
+fn increfHostHttp_sendResult(value: HostHttp_sendResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {
+            value.payload_ok().incref(amount);
+        },
+    }
+}
+
+pub const HostHttp_sendResultRelease = struct {
+    pub fn release(value: HostHttp_sendResult, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+fn decrefMalformedResponseOrNetworkErrorOrOtherOrTimeout(value: MalformedResponseOrNetworkErrorOrOtherOrTimeout, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .MalformedResponse => {},
+        .NetworkError => {},
+        .Other => {
+            value.payload_other().decref(roc_host);
+        },
+        .Timeout => {},
+    }
+}
+
+fn increfMalformedResponseOrNetworkErrorOrOtherOrTimeout(value: MalformedResponseOrNetworkErrorOrOtherOrTimeout, amount: isize) void {
+    switch (value.tag) {
+        .MalformedResponse => {},
+        .NetworkError => {},
+        .Other => {
+            value.payload_other().incref(amount);
+        },
+        .Timeout => {},
+    }
+}
+
+pub const MalformedResponseOrNetworkErrorOrOtherOrTimeoutRelease = struct {
+    pub fn release(value: MalformedResponseOrNetworkErrorOrOtherOrTimeout, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+pub const __AnonStruct_a14cd3b7d5755441Release = struct {
+    pub fn release(value: __AnonStruct_a14cd3b7d5755441, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -13400,8 +15355,72 @@ pub const __AnonStruct_85380e02323174c5Release = struct {
     }
 };
 
-pub const __AnonStruct_fa110e8829dc221bRelease = struct {
-    pub fn release(value: __AnonStruct_fa110e8829dc221b, roc_host: *RocHost) void {
+fn decrefHostCmd_runResult(value: HostCmd_runResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {
+            value.payload_ok().decref(roc_host);
+        },
+    }
+}
+
+fn increfHostCmd_runResult(value: HostCmd_runResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {
+            value.payload_ok().incref(amount);
+        },
+    }
+}
+
+pub const HostCmd_runResultRelease = struct {
+    pub fn release(value: HostCmd_runResult, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+fn decrefBusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable(value: BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Busy => {},
+        .CommandNotFound => {},
+        .PermissionDenied => {},
+        .SpawnFailed => {},
+        .StderrLimitExceeded => {},
+        .StdoutLimitExceeded => {},
+        .Timeout => {
+            value.payload_timeout().decref(roc_host);
+        },
+        .Unavailable => {},
+    }
+}
+
+fn increfBusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable(value: BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable, amount: isize) void {
+    switch (value.tag) {
+        .Busy => {},
+        .CommandNotFound => {},
+        .PermissionDenied => {},
+        .SpawnFailed => {},
+        .StderrLimitExceeded => {},
+        .StdoutLimitExceeded => {},
+        .Timeout => {
+            value.payload_timeout().incref(amount);
+        },
+        .Unavailable => {},
+    }
+}
+
+pub const BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailableRelease = struct {
+    pub fn release(value: BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+pub const __AnonStruct_45d496287297bf7fRelease = struct {
+    pub fn release(value: __AnonStruct_45d496287297bf7f, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -13412,8 +15431,42 @@ pub const __AnonStruct_3fe396bc5ba0c31cRelease = struct {
     }
 };
 
-pub const __AnonStruct_c53c193ad2a36104Release = struct {
-    pub fn release(value: __AnonStruct_c53c193ad2a36104, roc_host: *RocHost) void {
+fn decrefHostUdp_bindResult(value: HostUdp_bindResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {
+            value.payload_ok().decref(roc_host);
+        },
+    }
+}
+
+fn increfHostUdp_bindResult(value: HostUdp_bindResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {
+            value.payload_ok().incref(amount);
+        },
+    }
+}
+
+pub const HostUdp_bindResultRelease = struct {
+    pub fn release(value: HostUdp_bindResult, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+pub const __AnonStruct_77531de58035959Release = struct {
+    pub fn release(value: __AnonStruct_77531de58035959, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+pub const UdpSocketRelease = struct {
+    pub fn release(value: UdpSocket, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -13424,14 +15477,42 @@ pub const __AnonStruct_63b1422749dba501Release = struct {
     }
 };
 
-pub const __AnonStruct_686570ce13fde405Release = struct {
-    pub fn release(value: __AnonStruct_686570ce13fde405, roc_host: *RocHost) void {
+pub const __AnonStruct_53d84a4d5bb34dcdRelease = struct {
+    pub fn release(value: __AnonStruct_53d84a4d5bb34dcd, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
 
-pub const __AnonStruct_c44117854a91f9a7Release = struct {
-    pub fn release(value: __AnonStruct_c44117854a91f9a7, roc_host: *RocHost) void {
+fn decrefHostUdp_receiveResult(value: HostUdp_receiveResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {
+            value.payload_ok().decref(roc_host);
+        },
+    }
+}
+
+fn increfHostUdp_receiveResult(value: HostUdp_receiveResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {
+            value.payload_ok().incref(amount);
+        },
+    }
+}
+
+pub const HostUdp_receiveResultRelease = struct {
+    pub fn release(value: HostUdp_receiveResult, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+pub const __AnonStruct_1772298ecb801858Release = struct {
+    pub fn release(value: __AnonStruct_1772298ecb801858, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -13442,8 +15523,8 @@ pub const __AnonStruct_4dd3180405b3f44fRelease = struct {
     }
 };
 
-pub const __AnonStruct_3d573c3bcb10a375Release = struct {
-    pub fn release(value: __AnonStruct_3d573c3bcb10a375, roc_host: *RocHost) void {
+pub const __AnonStruct_c0489e409fcc99cdRelease = struct {
+    pub fn release(value: __AnonStruct_c0489e409fcc99cd, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -13496,6 +15577,34 @@ fn increfHostApp_read_textResult(value: HostApp_read_textResult, amount: isize) 
 
 pub const HostApp_read_textResultRelease = struct {
     pub fn release(value: HostApp_read_textResult, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+fn decrefHostWindow_read_clipboardResult(value: HostWindow_read_clipboardResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {
+            value.payload_ok().decref(roc_host);
+        },
+    }
+}
+
+fn increfHostWindow_read_clipboardResult(value: HostWindow_read_clipboardResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {
+            value.payload_ok().incref(amount);
+        },
+    }
+}
+
+pub const HostWindow_read_clipboardResultRelease = struct {
+    pub fn release(value: HostWindow_read_clipboardResult, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -13622,26 +15731,210 @@ pub const __AnonStruct_9f9f7e660a5e922bRelease = struct {
     }
 };
 
-pub const __AnonStruct_d1ff90659ed42132Release = struct {
-    pub fn release(value: __AnonStruct_d1ff90659ed42132, roc_host: *RocHost) void {
+fn decrefHostSqlite_openResult(value: HostSqlite_openResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {
+            value.payload_ok().decref(roc_host);
+        },
+    }
+}
+
+fn increfHostSqlite_openResult(value: HostSqlite_openResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {
+            value.payload_ok().incref(amount);
+        },
+    }
+}
+
+pub const HostSqlite_openResultRelease = struct {
+    pub fn release(value: HostSqlite_openResult, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
 
-pub const __AnonStruct_e7ff50a9dfab1a8dRelease = struct {
-    pub fn release(value: __AnonStruct_e7ff50a9dfab1a8d, roc_host: *RocHost) void {
+fn decrefSqliteErrOrTooManyConnections(value: SqliteErrOrTooManyConnections, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .SqliteErr => {
+            value.payload_sqlite_err().decref(roc_host);
+        },
+        .TooManyConnections => {},
+    }
+}
+
+fn increfSqliteErrOrTooManyConnections(value: SqliteErrOrTooManyConnections, amount: isize) void {
+    switch (value.tag) {
+        .SqliteErr => {
+            value.payload_sqlite_err().incref(amount);
+        },
+        .TooManyConnections => {},
+    }
+}
+
+pub const SqliteErrOrTooManyConnectionsRelease = struct {
+    pub fn release(value: SqliteErrOrTooManyConnections, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
 
-pub const __AnonStruct_cff0e6766f0cb5bfRelease = struct {
-    pub fn release(value: __AnonStruct_cff0e6766f0cb5bf, roc_host: *RocHost) void {
+pub const __AnonStruct_22cf486058afc711Release = struct {
+    pub fn release(value: __AnonStruct_22cf486058afc711, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
 
-pub const __AnonStruct_4bc5d3695423e2f1Release = struct {
-    pub fn release(value: __AnonStruct_4bc5d3695423e2f1, roc_host: *RocHost) void {
+pub const SqliteDbRelease = struct {
+    pub fn release(value: SqliteDb, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+fn decrefHostSqlite_closeResult(value: HostSqlite_closeResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {},
+    }
+}
+
+fn increfHostSqlite_closeResult(value: HostSqlite_closeResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {},
+    }
+}
+
+pub const HostSqlite_closeResultRelease = struct {
+    pub fn release(value: HostSqlite_closeResult, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+fn decrefHostSqlite_prepareResult(value: HostSqlite_prepareResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {
+            value.payload_ok().decref(roc_host);
+        },
+    }
+}
+
+fn increfHostSqlite_prepareResult(value: HostSqlite_prepareResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {
+            value.payload_ok().incref(amount);
+        },
+    }
+}
+
+pub const HostSqlite_prepareResultRelease = struct {
+    pub fn release(value: HostSqlite_prepareResult, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+fn decrefMultipleStatementsOrSqliteErrOrTooManyStatements(value: MultipleStatementsOrSqliteErrOrTooManyStatements, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .MultipleStatements => {},
+        .SqliteErr => {
+            value.payload_sqlite_err().decref(roc_host);
+        },
+        .TooManyStatements => {},
+    }
+}
+
+fn increfMultipleStatementsOrSqliteErrOrTooManyStatements(value: MultipleStatementsOrSqliteErrOrTooManyStatements, amount: isize) void {
+    switch (value.tag) {
+        .MultipleStatements => {},
+        .SqliteErr => {
+            value.payload_sqlite_err().incref(amount);
+        },
+        .TooManyStatements => {},
+    }
+}
+
+pub const MultipleStatementsOrSqliteErrOrTooManyStatementsRelease = struct {
+    pub fn release(value: MultipleStatementsOrSqliteErrOrTooManyStatements, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+pub const SqliteStmtRelease = struct {
+    pub fn release(value: SqliteStmt, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+fn decrefHostSqlite_run_stmtResult(value: HostSqlite_run_stmtResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {
+            value.payload_ok().decref(roc_host);
+        },
+    }
+}
+
+fn increfHostSqlite_run_stmtResult(value: HostSqlite_run_stmtResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {
+            value.payload_ok().incref(amount);
+        },
+    }
+}
+
+pub const HostSqlite_run_stmtResultRelease = struct {
+    pub fn release(value: HostSqlite_run_stmtResult, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+fn decrefMultipleStatementsOrResultTooLargeOrSqliteErr(value: MultipleStatementsOrResultTooLargeOrSqliteErr, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .MultipleStatements => {},
+        .ResultTooLarge => {},
+        .SqliteErr => {
+            value.payload_sqlite_err().decref(roc_host);
+        },
+    }
+}
+
+fn increfMultipleStatementsOrResultTooLargeOrSqliteErr(value: MultipleStatementsOrResultTooLargeOrSqliteErr, amount: isize) void {
+    switch (value.tag) {
+        .MultipleStatements => {},
+        .ResultTooLarge => {},
+        .SqliteErr => {
+            value.payload_sqlite_err().incref(amount);
+        },
+    }
+}
+
+pub const MultipleStatementsOrResultTooLargeOrSqliteErrRelease = struct {
+    pub fn release(value: MultipleStatementsOrResultTooLargeOrSqliteErr, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+pub const __AnonStruct_566a76c01f44ee92Release = struct {
+    pub fn release(value: __AnonStruct_566a76c01f44ee92, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -13700,8 +15993,8 @@ pub const __AnonStruct_a3fdb7fbf4ae00b8Release = struct {
     }
 };
 
-pub const __AnonStruct_6bff15fb6a4cb85aRelease = struct {
-    pub fn release(value: __AnonStruct_6bff15fb6a4cb85a, roc_host: *RocHost) void {
+pub const __AnonStruct_8dc97a0a319d4d53Release = struct {
+    pub fn release(value: __AnonStruct_8dc97a0a319d4d53, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -13826,8 +16119,36 @@ pub const __AnonStruct_96bd4e483c462501Release = struct {
     }
 };
 
-pub const __AnonStruct_7c66fb01c50d182aRelease = struct {
-    pub fn release(value: __AnonStruct_7c66fb01c50d182a, roc_host: *RocHost) void {
+fn decrefHostCapture_stop_recordingResult(value: HostCapture_stop_recordingResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {
+            value.payload_ok().decref(roc_host);
+        },
+    }
+}
+
+fn increfHostCapture_stop_recordingResult(value: HostCapture_stop_recordingResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {
+            value.payload_ok().incref(amount);
+        },
+    }
+}
+
+pub const HostCapture_stop_recordingResultRelease = struct {
+    pub fn release(value: HostCapture_stop_recordingResult, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+pub const __AnonStruct_5c978c17ba0c990aRelease = struct {
+    pub fn release(value: __AnonStruct_5c978c17ba0c990a, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -13838,8 +16159,36 @@ pub const __AnonStruct_aa2779af0bb79965Release = struct {
     }
 };
 
-pub const __AnonStruct_50fe0879143e3c18Release = struct {
-    pub fn release(value: __AnonStruct_50fe0879143e3c18, roc_host: *RocHost) void {
+fn decrefHostCapture_pixel_atResult(value: HostCapture_pixel_atResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {
+            value.payload_ok().decref(roc_host);
+        },
+    }
+}
+
+fn increfHostCapture_pixel_atResult(value: HostCapture_pixel_atResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {
+            value.payload_ok().incref(amount);
+        },
+    }
+}
+
+pub const HostCapture_pixel_atResultRelease = struct {
+    pub fn release(value: HostCapture_pixel_atResult, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+pub const __AnonStruct_bda5c9dc6cabe78eRelease = struct {
+    pub fn release(value: __AnonStruct_bda5c9dc6cabe78e, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -13852,6 +16201,34 @@ pub const __AnonStruct_30827bd86e7a53b3Release = struct {
 
 pub const __AnonStruct_29524f9bb2f9574cRelease = struct {
     pub fn release(value: __AnonStruct_29524f9bb2f9574c, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+fn decrefHostCapture_read_regionResult(value: HostCapture_read_regionResult, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().decref(roc_host);
+        },
+        .Ok => {
+            value.payload_ok().decref(roc_host);
+        },
+    }
+}
+
+fn increfHostCapture_read_regionResult(value: HostCapture_read_regionResult, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+            value.payload_err().incref(amount);
+        },
+        .Ok => {
+            value.payload_ok().incref(amount);
+        },
+    }
+}
+
+pub const HostCapture_read_regionResultRelease = struct {
+    pub fn release(value: HostCapture_read_regionResult, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -14105,7 +16482,8 @@ fn rocReleasePolicy(comptime T: type) type {
     if (T == HostTexture_load_storeResult) return HostTexture_load_storeResultRelease;
     if (T == Texture) return TextureRelease;
     if (T == *u64) return RocBoxSpineRelease(*u64, u64);
-    if (T == __AnonStruct_e6634fb4c190c214) return __AnonStruct_e6634fb4c190c214Release;
+    if (T == __AnonStruct_fcb9c18e638f68bc) return __AnonStruct_fcb9c18e638f68bcRelease;
+    if (T == Store) return StoreRelease;
     if (T == HostTexture_load_bytesResult) return HostTexture_load_bytesResultRelease;
     if (T == __AnonStruct_ff17f03b4409100d) return __AnonStruct_ff17f03b4409100dRelease;
     if (T == RocListWith(u8, false)) return RocListSpineRelease(RocListWith(u8, false));
@@ -14121,15 +16499,16 @@ fn rocReleasePolicy(comptime T: type) type {
     if (T == HostText_load_fontResult) return HostText_load_fontResultRelease;
     if (T == __AnonStruct_5cba559c3a07b56a) return __AnonStruct_5cba559c3a07b56aRelease;
     if (T == HostText_load_store_fontResult) return HostText_load_store_fontResultRelease;
-    if (T == __AnonStruct_80c864420ea33e1e) return __AnonStruct_80c864420ea33e1eRelease;
+    if (T == __AnonStruct_aba52beeae923776) return __AnonStruct_aba52beeae923776Release;
     if (T == HostText_prepareResult) return HostText_prepareResultRelease;
-    if (T == __AnonStruct_e1165210b218b76c) return __AnonStruct_e1165210b218b76cRelease;
+    if (T == __AnonStruct_34e6157b936793f4) return __AnonStruct_34e6157b936793f4Release;
+    if (T == TextPrepared) return TextPreparedRelease;
     if (T == __AnonStruct_7f4d6dac6c3eef5e) return __AnonStruct_7f4d6dac6c3eef5eRelease;
     if (T == HostShader_load_sourceResult) return HostShader_load_sourceResultRelease;
     if (T == Shader) return ShaderRelease;
     if (T == __AnonStruct_c813cb81fdeac2dc) return __AnonStruct_c813cb81fdeac2dcRelease;
     if (T == HostShader_load_storeResult) return HostShader_load_storeResultRelease;
-    if (T == __AnonStruct_3e85b4e878c74d96) return __AnonStruct_3e85b4e878c74d96Release;
+    if (T == __AnonStruct_87e8defa2945b71d) return __AnonStruct_87e8defa2945b71dRelease;
     if (T == __AnonStruct_45ec9dff41865827) return __AnonStruct_45ec9dff41865827Release;
     if (T == __AnonStruct_f7e0ea2377a157c8) return __AnonStruct_f7e0ea2377a157c8Release;
     if (T == __AnonStruct_e9411c6c8286af86) return __AnonStruct_e9411c6c8286af86Release;
@@ -14142,25 +16521,36 @@ fn rocReleasePolicy(comptime T: type) type {
     if (T == __AnonStruct_8f4b2816fd84fce2) return __AnonStruct_8f4b2816fd84fce2Release;
     if (T == RocErasedCallable) return RocErasedCallableRelease;
     if (T == HostAudio_gen_toneResult) return HostAudio_gen_toneResultRelease;
+    if (T == AudioSound) return AudioSoundRelease;
     if (T == HostAudio_load_soundResult) return HostAudio_load_soundResultRelease;
     if (T == HostAudio_load_musicResult) return HostAudio_load_musicResultRelease;
-    if (T == __AnonStruct_e98c7d72bcd7a610) return __AnonStruct_e98c7d72bcd7a610Release;
-    if (T == __AnonStruct_5b08b74ffdd2f118) return __AnonStruct_5b08b74ffdd2f118Release;
-    if (T == __AnonStruct_da7cbd33c88fa20a) return __AnonStruct_da7cbd33c88fa20aRelease;
+    if (T == AudioMusic) return AudioMusicRelease;
+    if (T == HostFiles_read_textResult) return HostFiles_read_textResultRelease;
+    if (T == HostFiles_read_bytesResult) return HostFiles_read_bytesResultRelease;
+    if (T == HostFiles_listResult) return HostFiles_listResultRelease;
+    if (T == HostHttp_sendResult) return HostHttp_sendResultRelease;
+    if (T == MalformedResponseOrNetworkErrorOrOtherOrTimeout) return MalformedResponseOrNetworkErrorOrOtherOrTimeoutRelease;
+    if (T == __AnonStruct_a14cd3b7d5755441) return __AnonStruct_a14cd3b7d5755441Release;
     if (T == RocList(__AnonStruct_82a96c5d55d63488)) return RocListRelease(RocList(__AnonStruct_82a96c5d55d63488), __AnonStruct_82a96c5d55d63488Release);
     if (T == __AnonStruct_82a96c5d55d63488) return __AnonStruct_82a96c5d55d63488Release;
     if (T == __AnonStruct_85380e02323174c5) return __AnonStruct_85380e02323174c5Release;
-    if (T == __AnonStruct_fa110e8829dc221b) return __AnonStruct_fa110e8829dc221bRelease;
+    if (T == HostCmd_runResult) return HostCmd_runResultRelease;
+    if (T == BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable) return BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailableRelease;
+    if (T == __AnonStruct_45d496287297bf7f) return __AnonStruct_45d496287297bf7fRelease;
     if (T == __AnonStruct_3fe396bc5ba0c31c) return __AnonStruct_3fe396bc5ba0c31cRelease;
     if (T == RocList(RocStr)) return RocListRelease(RocList(RocStr), RocStrRelease);
-    if (T == __AnonStruct_c53c193ad2a36104) return __AnonStruct_c53c193ad2a36104Release;
+    if (T == HostUdp_bindResult) return HostUdp_bindResultRelease;
+    if (T == __AnonStruct_77531de58035959) return __AnonStruct_77531de58035959Release;
+    if (T == UdpSocket) return UdpSocketRelease;
     if (T == __AnonStruct_63b1422749dba501) return __AnonStruct_63b1422749dba501Release;
-    if (T == __AnonStruct_686570ce13fde405) return __AnonStruct_686570ce13fde405Release;
-    if (T == __AnonStruct_c44117854a91f9a7) return __AnonStruct_c44117854a91f9a7Release;
+    if (T == __AnonStruct_53d84a4d5bb34dcd) return __AnonStruct_53d84a4d5bb34dcdRelease;
+    if (T == HostUdp_receiveResult) return HostUdp_receiveResultRelease;
+    if (T == __AnonStruct_1772298ecb801858) return __AnonStruct_1772298ecb801858Release;
     if (T == RocListWith(__AnonStruct_4dd3180405b3f44f, false)) return RocListSpineRelease(RocListWith(__AnonStruct_4dd3180405b3f44f, false));
-    if (T == __AnonStruct_3d573c3bcb10a375) return __AnonStruct_3d573c3bcb10a375Release;
+    if (T == __AnonStruct_c0489e409fcc99cd) return __AnonStruct_c0489e409fcc99cdRelease;
     if (T == HostApp_read_envResult) return HostApp_read_envResultRelease;
     if (T == HostApp_read_textResult) return HostApp_read_textResultRelease;
+    if (T == HostWindow_read_clipboardResult) return HostWindow_read_clipboardResultRelease;
     if (T == RocList(__AnonStruct_dae0ce24e748c0cf)) return RocListRelease(RocList(__AnonStruct_dae0ce24e748c0cf), __AnonStruct_dae0ce24e748c0cfRelease);
     if (T == __AnonStruct_dae0ce24e748c0cf) return __AnonStruct_dae0ce24e748c0cfRelease;
     if (T == HostTilemap_load_tmxResult) return HostTilemap_load_tmxResultRelease;
@@ -14180,14 +16570,21 @@ fn rocReleasePolicy(comptime T: type) type {
     if (T == RocListWith(__AnonStruct_66e2af4e09d9cfd8, false)) return RocListSpineRelease(RocListWith(__AnonStruct_66e2af4e09d9cfd8, false));
     if (T == RocList(__AnonStruct_9f9f7e660a5e922b)) return RocListRelease(RocList(__AnonStruct_9f9f7e660a5e922b), __AnonStruct_9f9f7e660a5e922bRelease);
     if (T == __AnonStruct_9f9f7e660a5e922b) return __AnonStruct_9f9f7e660a5e922bRelease;
-    if (T == __AnonStruct_d1ff90659ed42132) return __AnonStruct_d1ff90659ed42132Release;
-    if (T == __AnonStruct_e7ff50a9dfab1a8d) return __AnonStruct_e7ff50a9dfab1a8dRelease;
-    if (T == __AnonStruct_cff0e6766f0cb5bf) return __AnonStruct_cff0e6766f0cb5bfRelease;
-    if (T == __AnonStruct_4bc5d3695423e2f1) return __AnonStruct_4bc5d3695423e2f1Release;
+    if (T == HostSqlite_openResult) return HostSqlite_openResultRelease;
+    if (T == SqliteErrOrTooManyConnections) return SqliteErrOrTooManyConnectionsRelease;
+    if (T == __AnonStruct_22cf486058afc711) return __AnonStruct_22cf486058afc711Release;
+    if (T == SqliteDb) return SqliteDbRelease;
+    if (T == HostSqlite_closeResult) return HostSqlite_closeResultRelease;
+    if (T == HostSqlite_prepareResult) return HostSqlite_prepareResultRelease;
+    if (T == MultipleStatementsOrSqliteErrOrTooManyStatements) return MultipleStatementsOrSqliteErrOrTooManyStatementsRelease;
+    if (T == SqliteStmt) return SqliteStmtRelease;
+    if (T == HostSqlite_run_stmtResult) return HostSqlite_run_stmtResultRelease;
+    if (T == MultipleStatementsOrResultTooLargeOrSqliteErr) return MultipleStatementsOrResultTooLargeOrSqliteErrRelease;
+    if (T == __AnonStruct_566a76c01f44ee92) return __AnonStruct_566a76c01f44ee92Release;
     if (T == RocListWith(__AnonStruct_3a90da783672cf8d, false)) return RocListSpineRelease(RocListWith(__AnonStruct_3a90da783672cf8d, false));
     if (T == RocList(__AnonStruct_90c9f98ccd96f8ce)) return RocListRelease(RocList(__AnonStruct_90c9f98ccd96f8ce), __AnonStruct_90c9f98ccd96f8ceRelease);
     if (T == __AnonStruct_90c9f98ccd96f8ce) return __AnonStruct_90c9f98ccd96f8ceRelease;
-    if (T == __AnonStruct_6bff15fb6a4cb85a) return __AnonStruct_6bff15fb6a4cb85aRelease;
+    if (T == __AnonStruct_8dc97a0a319d4d53) return __AnonStruct_8dc97a0a319d4d53Release;
     if (T == __AnonStruct_16cb9af61afe2d08) return __AnonStruct_16cb9af61afe2d08Release;
     if (T == RocListWith(MathVec2, false)) return RocListSpineRelease(RocListWith(MathVec2, false));
     if (T == __AnonStruct_2dcd38bc772d0799) return __AnonStruct_2dcd38bc772d0799Release;
@@ -14202,6 +16599,7 @@ fn rocReleasePolicy(comptime T: type) type {
     if (T == __AnonStruct_aa2779af0bb79965) return __AnonStruct_aa2779af0bb79965Release;
     if (T == __AnonStruct_30827bd86e7a53b3) return __AnonStruct_30827bd86e7a53b3Release;
     if (T == __AnonStruct_29524f9bb2f9574c) return __AnonStruct_29524f9bb2f9574cRelease;
+    if (T == HostCapture_read_regionResult) return HostCapture_read_regionResultRelease;
     if (T == __AnonStruct_7ea2de5aa3c18166) return __AnonStruct_7ea2de5aa3c18166Release;
     if (T == __AnonStruct_def8e181e644dca4) return __AnonStruct_def8e181e644dca4Release;
     if (T == __AnonStruct_8fd71e3705bdb8b5) return __AnonStruct_8fd71e3705bdb8b5Release;
@@ -14236,7 +16634,7 @@ pub extern fn roc_crashed(bytes: [*]const u8, len: usize) callconv(.c) void;
 // Refcounted arguments are owned by the hosted function.
 
 /// Hosted symbol for Host.store_open!
-/// Roc signature: { asset_set : Str, content_hash : Str, content_hash_mode : U8, content_version : U32, location_kind : U8, manifest_required : Bool, root : Str, schema : U32 } => Try(Handle(Host.StoreResource), [AssetSetMismatch, ContentHashMismatch, ContentVersionMismatch, InvalidExpectedContentHash, InvalidRootPath, ManifestMalformed, ManifestMissing, ManifestUnreadable, ResourceLimit, RootNotDirectory, RootNotFound, RootUnreadable, SchemaMismatch])
+/// Roc signature: { asset_set : Str, content_hash : Str, content_hash_mode : U8, content_version : U32, location_kind : U8, manifest_required : Bool, root : Str, schema : U32 } => Try(Store, [AssetSetMismatch, ContentHashMismatch, ContentVersionMismatch, InvalidExpectedContentHash, InvalidRootPath, ManifestMalformed, ManifestMissing, ManifestUnreadable, ResourceLimit, RootNotDirectory, RootNotFound, RootUnreadable, SchemaMismatch])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
@@ -14244,7 +16642,7 @@ pub extern fn roc_crashed(bytes: [*]const u8, len: usize) callconv(.c) void;
 pub extern fn roc_store_open_raw(arg0: HostStore_openArgs) callconv(.c) HostStore_openResult;
 
 /// Hosted symbol for Host.texture_load_store!
-/// Roc signature: { path : Str, store : Handle(Host.StoreResource) } => Try(Texture, [NotFound, PathInvalid, ReadFailed, ResourceLimit, TextureLoadFailed])
+/// Roc signature: { path : Str, store : Store } => Try(Texture, [NotFound, PathInvalid, ReadFailed, ResourceLimit, TextureLoadFailed])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
@@ -14298,17 +16696,17 @@ pub extern fn roc_texture_set_filter_raw(arg0: Texture, arg1: u8) callconv(.c) v
 pub extern fn roc_texture_set_wrap_raw(arg0: Texture, arg1: u8) callconv(.c) void;
 
 /// Hosted symbol for Host.audio_gen_tone!
-/// Roc signature: { freq : F32, ms : I32 } => Try(Handle(Host.SoundResource), [ResourceLimit, SoundGenerationFailed])
+/// Roc signature: { freq : F32, ms : I32 } => Try(AudioSound, [ResourceLimit, SoundGenerationFailed])
 /// The result is owned by Roc: return exactly one owned reference.
 pub extern fn roc_audio_gen_tone_raw(arg0: HostAudio_gen_toneArgs) callconv(.c) HostAudio_gen_toneResult;
 
 /// Hosted symbol for Host.audio_gen_sound!
-/// Roc signature: { attack_ms : I32, decay_ms : I32, freq_end : F32, freq_start : F32, ms : I32, release_ms : I32, sustain : F32, volume : F32, waveform : U8 } => Try(Handle(Host.SoundResource), [ResourceLimit, SoundGenerationFailed])
+/// Roc signature: { attack_ms : I32, decay_ms : I32, freq_end : F32, freq_start : F32, ms : I32, release_ms : I32, sustain : F32, volume : F32, waveform : U8 } => Try(AudioSound, [ResourceLimit, SoundGenerationFailed])
 /// The result is owned by Roc: return exactly one owned reference.
 pub extern fn roc_audio_gen_sound_raw(arg0: HostAudio_gen_soundArgs) callconv(.c) HostAudio_gen_toneResult;
 
 /// Hosted symbol for Host.audio_load_sound!
-/// Roc signature: Str => Try(Handle(Host.SoundResource), [ResourceLimit, SoundLoadFailed])
+/// Roc signature: Str => Try(AudioSound, [ResourceLimit, SoundLoadFailed])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
@@ -14316,7 +16714,7 @@ pub extern fn roc_audio_gen_sound_raw(arg0: HostAudio_gen_soundArgs) callconv(.c
 pub extern fn roc_audio_load_sound_raw(arg0: RocStr) callconv(.c) HostAudio_load_soundResult;
 
 /// Hosted symbol for Host.audio_load_music!
-/// Roc signature: Str => Try(Handle(Host.MusicResource), [MusicLoadFailed, ResourceLimit])
+/// Roc signature: Str => Try(AudioMusic, [MusicLoadFailed, ResourceLimit])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
@@ -14324,144 +16722,144 @@ pub extern fn roc_audio_load_sound_raw(arg0: RocStr) callconv(.c) HostAudio_load
 pub extern fn roc_audio_load_music_raw(arg0: RocStr) callconv(.c) HostAudio_load_musicResult;
 
 /// Hosted symbol for Host.audio_play_sound!
-/// Roc signature: Handle(Host.SoundResource) => {}
+/// Roc signature: AudioSound => {}
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
-pub extern fn roc_audio_play_raw(arg0: *u64) callconv(.c) void;
+///     arg0.decref(roc_host);
+pub extern fn roc_audio_play_raw(arg0: AudioSound) callconv(.c) void;
 
 /// Hosted symbol for Host.audio_stop_sound!
-/// Roc signature: Handle(Host.SoundResource) => {}
+/// Roc signature: AudioSound => {}
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
-pub extern fn roc_audio_stop_raw(arg0: *u64) callconv(.c) void;
+///     arg0.decref(roc_host);
+pub extern fn roc_audio_stop_raw(arg0: AudioSound) callconv(.c) void;
 
 /// Hosted symbol for Host.audio_pause_sound!
-/// Roc signature: Handle(Host.SoundResource) => {}
+/// Roc signature: AudioSound => {}
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
-pub extern fn roc_audio_pause_raw(arg0: *u64) callconv(.c) void;
+///     arg0.decref(roc_host);
+pub extern fn roc_audio_pause_raw(arg0: AudioSound) callconv(.c) void;
 
 /// Hosted symbol for Host.audio_resume_sound!
-/// Roc signature: Handle(Host.SoundResource) => {}
+/// Roc signature: AudioSound => {}
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
-pub extern fn roc_audio_resume_raw(arg0: *u64) callconv(.c) void;
+///     arg0.decref(roc_host);
+pub extern fn roc_audio_resume_raw(arg0: AudioSound) callconv(.c) void;
 
 /// Hosted symbol for Host.audio_is_sound_playing!
-/// Roc signature: Handle(Host.SoundResource) => Bool
+/// Roc signature: AudioSound => Bool
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
-pub extern fn roc_audio_is_playing_raw(arg0: *u64) callconv(.c) bool;
+///     arg0.decref(roc_host);
+pub extern fn roc_audio_is_playing_raw(arg0: AudioSound) callconv(.c) bool;
 
 /// Hosted symbol for Host.audio_set_sound_volume!
-/// Roc signature: Handle(Host.SoundResource), F32 => {}
+/// Roc signature: AudioSound, F32 => {}
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
-pub extern fn roc_audio_set_volume_raw(arg0: *u64, arg1: f32) callconv(.c) void;
+///     arg0.decref(roc_host);
+pub extern fn roc_audio_set_volume_raw(arg0: AudioSound, arg1: f32) callconv(.c) void;
 
 /// Hosted symbol for Host.audio_set_sound_pitch!
-/// Roc signature: Handle(Host.SoundResource), F32 => {}
+/// Roc signature: AudioSound, F32 => {}
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
-pub extern fn roc_audio_set_pitch_raw(arg0: *u64, arg1: f32) callconv(.c) void;
+///     arg0.decref(roc_host);
+pub extern fn roc_audio_set_pitch_raw(arg0: AudioSound, arg1: f32) callconv(.c) void;
 
 /// Hosted symbol for Host.audio_set_sound_pan!
-/// Roc signature: Handle(Host.SoundResource), F32 => {}
+/// Roc signature: AudioSound, F32 => {}
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
-pub extern fn roc_audio_set_pan_raw(arg0: *u64, arg1: f32) callconv(.c) void;
+///     arg0.decref(roc_host);
+pub extern fn roc_audio_set_pan_raw(arg0: AudioSound, arg1: f32) callconv(.c) void;
 
 /// Hosted symbol for Host.audio_play_music!
-/// Roc signature: Handle(Host.MusicResource) => {}
+/// Roc signature: AudioMusic => {}
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
-pub extern fn roc_audio_play_music_raw(arg0: *u64) callconv(.c) void;
+///     arg0.decref(roc_host);
+pub extern fn roc_audio_play_music_raw(arg0: AudioMusic) callconv(.c) void;
 
 /// Hosted symbol for Host.audio_stop_music!
-/// Roc signature: Handle(Host.MusicResource) => {}
+/// Roc signature: AudioMusic => {}
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
-pub extern fn roc_audio_stop_music_raw(arg0: *u64) callconv(.c) void;
+///     arg0.decref(roc_host);
+pub extern fn roc_audio_stop_music_raw(arg0: AudioMusic) callconv(.c) void;
 
 /// Hosted symbol for Host.audio_pause_music!
-/// Roc signature: Handle(Host.MusicResource) => {}
+/// Roc signature: AudioMusic => {}
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
-pub extern fn roc_audio_pause_music_raw(arg0: *u64) callconv(.c) void;
+///     arg0.decref(roc_host);
+pub extern fn roc_audio_pause_music_raw(arg0: AudioMusic) callconv(.c) void;
 
 /// Hosted symbol for Host.audio_resume_music!
-/// Roc signature: Handle(Host.MusicResource) => {}
+/// Roc signature: AudioMusic => {}
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
-pub extern fn roc_audio_resume_music_raw(arg0: *u64) callconv(.c) void;
+///     arg0.decref(roc_host);
+pub extern fn roc_audio_resume_music_raw(arg0: AudioMusic) callconv(.c) void;
 
 /// Hosted symbol for Host.audio_set_music_volume!
-/// Roc signature: Handle(Host.MusicResource), F32 => {}
+/// Roc signature: AudioMusic, F32 => {}
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
-pub extern fn roc_audio_set_music_volume_raw(arg0: *u64, arg1: f32) callconv(.c) void;
+///     arg0.decref(roc_host);
+pub extern fn roc_audio_set_music_volume_raw(arg0: AudioMusic, arg1: f32) callconv(.c) void;
 
 /// Hosted symbol for Host.audio_set_music_pitch!
-/// Roc signature: Handle(Host.MusicResource), F32 => {}
+/// Roc signature: AudioMusic, F32 => {}
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
-pub extern fn roc_audio_set_music_pitch_raw(arg0: *u64, arg1: f32) callconv(.c) void;
+///     arg0.decref(roc_host);
+pub extern fn roc_audio_set_music_pitch_raw(arg0: AudioMusic, arg1: f32) callconv(.c) void;
 
 /// Hosted symbol for Host.audio_set_music_pan!
-/// Roc signature: Handle(Host.MusicResource), F32 => {}
+/// Roc signature: AudioMusic, F32 => {}
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
-pub extern fn roc_audio_set_music_pan_raw(arg0: *u64, arg1: f32) callconv(.c) void;
+///     arg0.decref(roc_host);
+pub extern fn roc_audio_set_music_pan_raw(arg0: AudioMusic, arg1: f32) callconv(.c) void;
 
 /// Hosted symbol for Host.audio_set_music_looping!
-/// Roc signature: Handle(Host.MusicResource), Bool => {}
+/// Roc signature: AudioMusic, Bool => {}
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
-pub extern fn roc_audio_set_music_looping_raw(arg0: *u64, arg1: bool) callconv(.c) void;
+///     arg0.decref(roc_host);
+pub extern fn roc_audio_set_music_looping_raw(arg0: AudioMusic, arg1: bool) callconv(.c) void;
 
 /// Hosted symbol for Host.audio_is_music_playing!
-/// Roc signature: Handle(Host.MusicResource) => Bool
+/// Roc signature: AudioMusic => Bool
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
-pub extern fn roc_audio_is_music_playing_raw(arg0: *u64) callconv(.c) bool;
+///     arg0.decref(roc_host);
+pub extern fn roc_audio_is_music_playing_raw(arg0: AudioMusic) callconv(.c) bool;
 
 /// Hosted symbol for Host.audio_seek_music!
-/// Roc signature: Handle(Host.MusicResource), F32 => {}
+/// Roc signature: AudioMusic, F32 => {}
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
-pub extern fn roc_audio_seek_music_raw(arg0: *u64, arg1: f32) callconv(.c) void;
+///     arg0.decref(roc_host);
+pub extern fn roc_audio_seek_music_raw(arg0: AudioMusic, arg1: f32) callconv(.c) void;
 
 /// Hosted symbol for Host.audio_music_length!
-/// Roc signature: Handle(Host.MusicResource) => F32
+/// Roc signature: AudioMusic => F32
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
-pub extern fn roc_audio_music_length_raw(arg0: *u64) callconv(.c) f32;
+///     arg0.decref(roc_host);
+pub extern fn roc_audio_music_length_raw(arg0: AudioMusic) callconv(.c) f32;
 
 /// Hosted symbol for Host.audio_music_time_played!
-/// Roc signature: Handle(Host.MusicResource) => F32
+/// Roc signature: AudioMusic => F32
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
-pub extern fn roc_audio_music_time_played_raw(arg0: *u64) callconv(.c) f32;
+///     arg0.decref(roc_host);
+pub extern fn roc_audio_music_time_played_raw(arg0: AudioMusic) callconv(.c) f32;
 
 /// Hosted symbol for Host.audio_set_master_volume!
 /// Roc signature: F32 => {}
@@ -14546,7 +16944,7 @@ pub extern fn roc_draw_line_raw(arg0: HostDraw_lineArgs) callconv(.c) void;
 pub extern fn roc_text_load_font_raw(arg0: HostText_load_fontArgs) callconv(.c) HostText_load_fontResult;
 
 /// Hosted symbol for Host.text_load_store_font!
-/// Roc signature: { path : Str, size : I32, store : Handle(Host.StoreResource) } => Try(Font, [FontLoadFailed, NotFound, PathInvalid, ReadFailed, ResourceLimit])
+/// Roc signature: { path : Str, size : I32, store : Store } => Try(Font, [FontLoadFailed, NotFound, PathInvalid, ReadFailed, ResourceLimit])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
@@ -14554,7 +16952,7 @@ pub extern fn roc_text_load_font_raw(arg0: HostText_load_fontArgs) callconv(.c) 
 pub extern fn roc_text_load_store_font_raw(arg0: HostText_load_store_fontArgs) callconv(.c) HostText_load_store_fontResult;
 
 /// Hosted symbol for Host.text_prepare!
-/// Roc signature: { font : Handle([FontResource]), size : F32, spacing : F32, text : Str } => Try({ height : F32, prepared : Handle(Host.PreparedTextResource), width : F32 }, [InvalidResource, ResourceLimit])
+/// Roc signature: { font : Handle([FontResource]), size : F32, spacing : F32, text : Str } => Try({ height : F32, prepared : TextPrepared, width : F32 }, [InvalidResource, ResourceLimit])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
@@ -14562,7 +16960,7 @@ pub extern fn roc_text_load_store_font_raw(arg0: HostText_load_store_fontArgs) c
 pub extern fn roc_text_prepare_raw(arg0: HostText_prepareArgs) callconv(.c) HostText_prepareResult;
 
 /// Hosted symbol for Host.draw_draw_prepared_text!
-/// Roc signature: { color : Color.Rgba, pos : Math.Vec2, prepared : Handle(Host.PreparedTextResource) } => {}
+/// Roc signature: { color : Color.Rgba, pos : Math.Vec2, prepared : TextPrepared } => {}
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
@@ -14622,35 +17020,35 @@ pub extern fn roc_draw_triangle_lines_raw(arg0: HostDraw_triangle_linesArgs) cal
 pub extern fn roc_draw_triangle_raw(arg0: HostDraw_triangleArgs) callconv(.c) void;
 
 /// Hosted symbol for Host.files_read_text!
-/// Roc signature: Str => { contents : Str, err : U8 }
+/// Roc signature: Str => Try(Str, [Busy, NotFound, NotUtf8, ReadFailed, TooLarge, Unavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_files_read_text(arg0: RocStr) callconv(.c) __AnonStruct_e98c7d72bcd7a610;
+pub extern fn roc_files_read_text(arg0: RocStr) callconv(.c) HostFiles_read_textResult;
 
 /// Hosted symbol for Host.files_read_bytes!
-/// Roc signature: Str => { bytes : List(U8), err : U8 }
+/// Roc signature: Str => Try(List(U8), [Busy, NotFound, ReadFailed, TooLarge, Unavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_files_read_bytes(arg0: RocStr) callconv(.c) __AnonStruct_5b08b74ffdd2f118;
+pub extern fn roc_files_read_bytes(arg0: RocStr) callconv(.c) HostFiles_read_bytesResult;
 
 /// Hosted symbol for Host.files_list!
-/// Roc signature: Str => { bytes : List(U8), err : U8 }
+/// Roc signature: Str => Try(List(U8), [Busy, NotADirectory, NotFound, ReadFailed, TooLarge, Unavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_files_list(arg0: RocStr) callconv(.c) __AnonStruct_5b08b74ffdd2f118;
+pub extern fn roc_files_list(arg0: RocStr) callconv(.c) HostFiles_listResult;
 
 /// Hosted symbol for Host.files_metadata!
-/// Roc signature: Str => { err : U8, kind : U8, modified_nanosecond : U32, modified_seconds : I64, size_bytes : U64 }
+/// Roc signature: Str => Try({ kind : U8, modified_nanosecond : U32, modified_seconds : I64, size_bytes : U64 }, [NotFound, PermissionDenied, ReadFailed, Unavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
-pub extern fn roc_files_metadata(arg0: RocStr) callconv(.c) __AnonStruct_ee584b0815816939;
+pub extern fn roc_files_metadata(arg0: RocStr) callconv(.c) HostFiles_metadataResult;
 
 /// Hosted symbol for Host.files_write_text!
 /// Roc signature: Str, Str => U8
@@ -14694,8 +17092,8 @@ pub extern fn roc_capture_set_virtual_text(arg0: RocListWith(u32, false)) callco
 pub extern fn roc_capture_start_recording(arg0: HostCapture_start_recordingArgs) callconv(.c) u8;
 
 /// Hosted symbol for Host.capture_stop_recording!
-/// Roc signature: {} => { bytes : U64, err : U8, frames : U64 }
-pub extern fn roc_capture_stop_recording() callconv(.c) __AnonStruct_7c66fb01c50d182a;
+/// Roc signature: {} => Try({ bytes : U64, frames : U64 }, [BudgetExceeded, Busy, NotRecording, ReadbackFailed, TargetUnavailable, Unavailable])
+pub extern fn roc_capture_stop_recording() callconv(.c) HostCapture_stop_recordingResult;
 
 /// Hosted symbol for Host.capture_screenshot!
 /// Roc signature: Str => U8
@@ -14712,19 +17110,19 @@ pub extern fn roc_capture_screenshot(arg0: RocStr) callconv(.c) u8;
 pub extern fn roc_capture_screenshot_texture(arg0: HostCapture_screenshot_textureArgs) callconv(.c) u8;
 
 /// Hosted symbol for Host.capture_pixel_at!
-/// Roc signature: { source : { screen : Bool, target : Texture }, x : I32, y : I32 } => { a : U8, b : U8, err : U8, g : U8, r : U8 }
+/// Roc signature: { source : { screen : Bool, target : Texture }, x : I32, y : I32 } => Try({ a : U8, b : U8, g : U8, r : U8 }, [Busy, ReadbackFailed, RegionOutOfBounds, TargetUnavailable, Unavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
-pub extern fn roc_capture_pixel_at(arg0: HostCapture_pixel_atArgs) callconv(.c) __AnonStruct_50fe0879143e3c18;
+pub extern fn roc_capture_pixel_at(arg0: HostCapture_pixel_atArgs) callconv(.c) HostCapture_pixel_atResult;
 
 /// Hosted symbol for Host.capture_read_region!
-/// Roc signature: { height : I32, source : { screen : Bool, target : Texture }, width : I32, x : I32, y : I32 } => { bytes : List(U8), err : U8 }
+/// Roc signature: { height : I32, source : { screen : Bool, target : Texture }, width : I32, x : I32, y : I32 } => Try(List(U8), [Busy, ReadbackFailed, RegionOutOfBounds, TargetUnavailable, Unavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_capture_read_region(arg0: HostCapture_read_regionArgs) callconv(.c) __AnonStruct_5b08b74ffdd2f118;
+pub extern fn roc_capture_read_region(arg0: HostCapture_read_regionArgs) callconv(.c) HostCapture_read_regionResult;
 
 /// Hosted symbol for Host.app_exit!
 /// Roc signature: I32 => {}
@@ -14764,9 +17162,9 @@ pub extern fn roc_random_i32(arg0: i32, arg1: i32) callconv(.c) i32;
 pub extern fn roc_keys_set_exit_key(arg0: i32) callconv(.c) void;
 
 /// Hosted symbol for Host.window_read_clipboard!
-/// Roc signature: {} => { contents : Str, err : U8 }
+/// Roc signature: {} => Try(Str, [Busy, TooLarge, Unavailable])
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_window_read_clipboard() callconv(.c) __AnonStruct_e98c7d72bcd7a610;
+pub extern fn roc_window_read_clipboard() callconv(.c) HostWindow_read_clipboardResult;
 
 /// Hosted symbol for Host.window_set_clipboard_text!
 /// Roc signature: Str => {}
@@ -14893,7 +17291,7 @@ pub extern fn roc_texture_load_render_target_raw(arg0: HostTexture_load_render_t
 pub extern fn roc_shader_load_source_raw(arg0: HostShader_load_sourceArgs) callconv(.c) HostShader_load_sourceResult;
 
 /// Hosted symbol for Host.shader_load_store!
-/// Roc signature: { fragment_path : Str, store : Handle(Host.StoreResource), vertex_path : Str } => Try(Shader, [NotFound, PathInvalid, ReadFailed, ResourceLimit, ShaderLoadFailed])
+/// Roc signature: { fragment_path : Str, store : Store, vertex_path : Str } => Try(Shader, [NotFound, PathInvalid, ReadFailed, ResourceLimit, ShaderLoadFailed])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
@@ -14950,12 +17348,12 @@ pub extern fn roc_shader_set_vec3_raw(arg0: HostShader_set_vec3Args) callconv(.c
 pub extern fn roc_shader_set_vec4_raw(arg0: HostShader_set_vec4Args) callconv(.c) void;
 
 /// Hosted symbol for Host.http_send!
-/// Roc signature: { body : List(U8), headers : List({ name : Str, value : Str }), max_response_bytes : U64, method : U8, method_ext : Str, timeout_ms : U64, uri : Str } => { body : List(U8), err : U8, err_message : Str, headers : List({ name : Str, value : Str }), status : U16 }
+/// Roc signature: { body : List(U8), headers : List({ name : Str, value : Str }), max_response_bytes : U64, method : U8, method_ext : Str, timeout_ms : U64, uri : Str } => Try({ body : List(U8), headers : List({ name : Str, value : Str }), status : U16 }, [MalformedResponse, NetworkError, Other(Str), Timeout])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_http_send(arg0: HostHttp_sendArgs) callconv(.c) __AnonStruct_da7cbd33c88fa20a;
+pub extern fn roc_http_send(arg0: HostHttp_sendArgs) callconv(.c) HostHttp_sendResult;
 
 /// Hosted symbol for Host.time_now!
 /// Roc signature: {} => { nanosecond : U32, seconds : I64 }
@@ -14983,88 +17381,88 @@ pub extern fn roc_stdio_write_line(arg0: u8, arg1: RocStr) callconv(.c) u8;
 pub extern fn roc_stdio_write_bytes(arg0: u8, arg1: RocListWith(u8, false)) callconv(.c) u8;
 
 /// Hosted symbol for Host.udp_bind!
-/// Roc signature: { ip : Str, port : U16 } => { err : U8, handle : Handle(Host.UdpSocketResource), ip : U32, port : U16 }
+/// Roc signature: { ip : Str, port : U16 } => Try({ handle : UdpSocket, ip : U32, port : U16 }, [AddressInUse, AddressUnavailable, InvalidAddress, PermissionDenied, ResourceLimit, Unavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_udp_bind(arg0: HostUdp_bindArgs) callconv(.c) __AnonStruct_c53c193ad2a36104;
+pub extern fn roc_udp_bind(arg0: HostUdp_bindArgs) callconv(.c) HostUdp_bindResult;
 
 /// Hosted symbol for Host.udp_send!
-/// Roc signature: { bytes : List(U8), ip : Str, port : U16, socket : Handle(Host.UdpSocketResource) } => U8
+/// Roc signature: { bytes : List(U8), ip : Str, port : U16, socket : UdpSocket } => U8
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
 pub extern fn roc_udp_send(arg0: HostUdp_sendArgs) callconv(.c) u8;
 
 /// Hosted symbol for Host.udp_receive!
-/// Roc signature: { max_datagrams : U32, socket : Handle(Host.UdpSocketResource), timeout_ms : U64 } => { err : U8, payload : List(U8), slices : List({ ip : U32, len : U64, port : U16, start : U64 }) }
+/// Roc signature: { max_datagrams : U32, socket : UdpSocket, timeout_ms : U64 } => Try({ payload : List(U8), slices : List({ ip : U32, len : U64, port : U16, start : U64 }) }, [AlreadyReceiving, ReceiveFailed, Timeout, Unavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_udp_receive(arg0: HostUdp_receiveArgs) callconv(.c) __AnonStruct_c44117854a91f9a7;
+pub extern fn roc_udp_receive(arg0: HostUdp_receiveArgs) callconv(.c) HostUdp_receiveResult;
 
 /// Hosted symbol for Host.sqlite_open!
-/// Roc signature: Str, U8, U64, U64 => { db : Handle(Host.SqliteDbResource), err : I64, message : Str }
+/// Roc signature: Str, U8, U64, U64 => Try(SqliteDb, [SqliteErr({ code : I64, message : Str }), TooManyConnections])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_sqlite_open(arg0: RocStr, arg1: u8, arg2: u64, arg3: u64) callconv(.c) __AnonStruct_d1ff90659ed42132;
+pub extern fn roc_sqlite_open(arg0: RocStr, arg1: u8, arg2: u64, arg3: u64) callconv(.c) HostSqlite_openResult;
 
 /// Hosted symbol for Host.sqlite_close!
-/// Roc signature: Handle(Host.SqliteDbResource) => { err : I64, message : Str }
+/// Roc signature: SqliteDb => Try({}, [SqliteErr({ code : I64, message : Str })])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
+///     arg0.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_sqlite_close(arg0: *u64) callconv(.c) __AnonStruct_e7ff50a9dfab1a8d;
+pub extern fn roc_sqlite_close(arg0: SqliteDb) callconv(.c) HostSqlite_closeResult;
 
 /// Hosted symbol for Host.sqlite_prepare!
-/// Roc signature: Handle(Host.SqliteDbResource), Str => { err : I64, message : Str, stmt : Handle(Host.SqliteStmtResource) }
+/// Roc signature: SqliteDb, Str => Try(SqliteStmt, [MultipleStatements, SqliteErr({ code : I64, message : Str }), TooManyStatements])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
+///     arg0.decref(roc_host);
 ///     arg1.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_sqlite_prepare(arg0: *u64, arg1: RocStr) callconv(.c) __AnonStruct_cff0e6766f0cb5bf;
+pub extern fn roc_sqlite_prepare(arg0: SqliteDb, arg1: RocStr) callconv(.c) HostSqlite_prepareResult;
 
 /// Hosted symbol for Host.sqlite_run_stmt!
-/// Roc signature: Handle(Host.SqliteStmtResource), List({ blob : List(U8), integer : I64, kind : U8, name : Str, real : F64, text : Str }) => { cells : List({ integer : I64, kind : U8, len : U64, real : F64, start : U64 }), changes : I64, err : I64, last_insert_rowid : I64, message : Str, names : List(U8), ncols : U64, payload : List(U8), row_count : U64 }
+/// Roc signature: SqliteStmt, List({ blob : List(U8), integer : I64, kind : U8, name : Str, real : F64, text : Str }) => Try({ cells : List({ integer : I64, kind : U8, len : U64, real : F64, start : U64 }), changes : I64, last_insert_rowid : I64, names : List(U8), ncols : U64, payload : List(U8), row_count : U64 }, [MultipleStatements, ResultTooLarge, SqliteErr({ code : I64, message : Str })])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
+///     arg0.decref(roc_host);
 ///     decrefListOf__AnonStruct_90c9f98ccd96f8ce(arg1, roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_sqlite_run_stmt(arg0: *u64, arg1: RocList(__AnonStruct_90c9f98ccd96f8ce)) callconv(.c) __AnonStruct_4bc5d3695423e2f1;
+pub extern fn roc_sqlite_run_stmt(arg0: SqliteStmt, arg1: RocList(__AnonStruct_90c9f98ccd96f8ce)) callconv(.c) HostSqlite_run_stmtResult;
 
 /// Hosted symbol for Host.sqlite_run_once!
-/// Roc signature: Handle(Host.SqliteDbResource), Str, List({ blob : List(U8), integer : I64, kind : U8, name : Str, real : F64, text : Str }) => { cells : List({ integer : I64, kind : U8, len : U64, real : F64, start : U64 }), changes : I64, err : I64, last_insert_rowid : I64, message : Str, names : List(U8), ncols : U64, payload : List(U8), row_count : U64 }
+/// Roc signature: SqliteDb, Str, List({ blob : List(U8), integer : I64, kind : U8, name : Str, real : F64, text : Str }) => Try({ cells : List({ integer : I64, kind : U8, len : U64, real : F64, start : U64 }), changes : I64, last_insert_rowid : I64, names : List(U8), ncols : U64, payload : List(U8), row_count : U64 }, [MultipleStatements, ResultTooLarge, SqliteErr({ code : I64, message : Str })])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
+///     arg0.decref(roc_host);
 ///     arg1.decref(roc_host);
 ///     decrefListOf__AnonStruct_90c9f98ccd96f8ce(arg2, roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_sqlite_run_once(arg0: *u64, arg1: RocStr, arg2: RocList(__AnonStruct_90c9f98ccd96f8ce)) callconv(.c) __AnonStruct_4bc5d3695423e2f1;
+pub extern fn roc_sqlite_run_once(arg0: SqliteDb, arg1: RocStr, arg2: RocList(__AnonStruct_90c9f98ccd96f8ce)) callconv(.c) HostSqlite_run_stmtResult;
 
 /// Hosted symbol for Host.sqlite_exec_script!
-/// Roc signature: Handle(Host.SqliteDbResource), Str => { err : I64, message : Str }
+/// Roc signature: SqliteDb, Str => Try({}, [SqliteErr({ code : I64, message : Str })])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     decrefBoxWith(@ptrCast(arg0), @alignOf(u64), false, null, roc_host);
+///     arg0.decref(roc_host);
 ///     arg1.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_sqlite_exec_script(arg0: *u64, arg1: RocStr) callconv(.c) __AnonStruct_e7ff50a9dfab1a8d;
+pub extern fn roc_sqlite_exec_script(arg0: SqliteDb, arg1: RocStr) callconv(.c) HostSqlite_closeResult;
 
 /// Hosted symbol for Host.cmd_run!
-/// Roc signature: { args : List(Str), clear_envs : Bool, envs : List({ name : Str, value : Str }), program : Str, stderr_limit_bytes : U64, stdout_limit_bytes : U64, timeout_ms : U64, working_dir : Str } => { err : U8, exit_code : I64, stderr : List(U8), stdout : List(U8) }
+/// Roc signature: { args : List(Str), clear_envs : Bool, envs : List({ name : Str, value : Str }), program : Str, stderr_limit_bytes : U64, stdout_limit_bytes : U64, timeout_ms : U64, working_dir : Str } => Try({ exit_code : I64, stderr : List(U8), stdout : List(U8) }, [Busy, CommandNotFound, PermissionDenied, SpawnFailed, StderrLimitExceeded, StdoutLimitExceeded, Timeout({ exit_code : I64, stderr : List(U8), stdout : List(U8) }), Unavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg0.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_cmd_run(arg0: HostCmd_runArgs) callconv(.c) __AnonStruct_fa110e8829dc221b;
+pub extern fn roc_cmd_run(arg0: HostCmd_runArgs) callconv(.c) HostCmd_runResult;
 
 /// Hosted symbol for Host.trace_mark!
 /// Roc signature: Str => {}

--- a/src/sqlite_effect.zig
+++ b/src/sqlite_effect.zig
@@ -247,7 +247,7 @@ const BindingBytes = struct {
 };
 
 /// One encoded cell. Field-for-field the record `Sqlite` decodes.
-const Cell = abi.HostSqlite_run_stmtCells;
+const Cell = abi.HostSqlite_run_stmtOkCells;
 
 /// What a worker filled in, and what the frame thread turns into Roc values.
 const Result = struct {
@@ -616,6 +616,44 @@ fn freeBindings(allocator: std.mem.Allocator, bindings: []const BindingBytes) vo
     }
 }
 
+/// A finished operation with nothing to report but whether it failed.
+///
+/// SQLite's own result codes are what `err` carries, so the code stays numeric
+/// here and `host_native` turns it into the effect's closed error union. The
+/// host's own refusals use the negative `ERR_*` codes above, which SQLite
+/// never produces.
+pub const StatusOutcome = struct {
+    err: i64,
+    message: abi.RocStr,
+};
+
+/// A finished operation that opened a connection.
+pub const OpenOutcome = struct {
+    err: i64,
+    message: abi.RocStr,
+    db: *u64,
+};
+
+/// A finished operation that compiled a statement.
+pub const PrepareOutcome = struct {
+    err: i64,
+    message: abi.RocStr,
+    stmt: *u64,
+};
+
+/// A finished query, in the flattened row-major form `Sqlite` decodes.
+pub const QueryOutcome = struct {
+    err: i64,
+    message: abi.RocStr,
+    names: abi.RocListWith(u8, false),
+    ncols: u64,
+    row_count: u64,
+    cells: abi.RocListWith(Cell, false),
+    payload: abi.RocListWith(u8, false),
+    changes: i64,
+    last_insert_rowid: i64,
+};
+
 /// Turn a worker's buffers into the Roc record the effect answers with.
 ///
 /// Every list is copied into a fresh Roc allocation rather than moved: the
@@ -665,7 +703,7 @@ pub fn open(
     mode: u8,
     busy_timeout_ms: u64,
     max_result_bytes: u64,
-) abi.HostSqlite_open {
+) OpenOutcome {
     _ = rt;
     const allocator = workerAllocator();
 
@@ -719,7 +757,7 @@ pub fn close(
     roc_host: *RocHost,
     rt: ?*zio.Runtime,
     db_arg: *u64,
-) abi.HostSqlite_close {
+) StatusOutcome {
     const resource = db_heap.get(db_arg.*) orelse return .{
         .err = @intCast(SQLITE_MISUSE),
         .message = abi.RocStr.fromSlice("database handle is closed", roc_host),
@@ -752,14 +790,14 @@ pub fn close(
     if (rt) |runtime| {
         var blocking = runtime.spawnBlocking(Closer.run, .{&job}) catch {
             Closer.run(&job);
-            return toRocStatus(abi.HostSqlite_close, roc_host, &result);
+            return toRocStatus(StatusOutcome, roc_host, &result);
         };
         blocking.join();
     } else {
         Closer.run(&job);
     }
 
-    return toRocStatus(abi.HostSqlite_close, roc_host, &result);
+    return toRocStatus(StatusOutcome, roc_host, &result);
 }
 
 /// `Sqlite.prepare!`: compile one statement for reuse.
@@ -768,7 +806,7 @@ pub fn prepare(
     rt: ?*zio.Runtime,
     db_arg: *u64,
     sql_arg: abi.RocStr,
-) abi.HostSqlite_prepare {
+) PrepareOutcome {
     _ = rt;
     const allocator = workerAllocator();
 
@@ -834,8 +872,8 @@ pub fn runStmt(
     rt: ?*zio.Runtime,
     stmt_arg: *u64,
     bindings_arg: abi.RocList(abi.HostSqlite_run_stmtArg1),
-) abi.HostSqlite_run_stmt {
-    const Record = abi.HostSqlite_run_stmt;
+) QueryOutcome {
+    const Record = QueryOutcome;
     const allocator = workerAllocator();
 
     const stmt_resource = stmt_heap.get(stmt_arg.*) orelse
@@ -873,8 +911,8 @@ pub fn runOnce(
     db_arg: *u64,
     sql_arg: abi.RocStr,
     bindings_arg: abi.RocList(abi.HostSqlite_run_stmtArg1),
-) abi.HostSqlite_run_once {
-    const Record = abi.HostSqlite_run_once;
+) QueryOutcome {
+    const Record = QueryOutcome;
     const allocator = workerAllocator();
 
     const resource = db_heap.get(db_arg.*) orelse
@@ -911,8 +949,8 @@ pub fn execScript(
     rt: ?*zio.Runtime,
     db_arg: *u64,
     sql_arg: abi.RocStr,
-) abi.HostSqlite_exec_script {
-    const Record = abi.HostSqlite_exec_script;
+) StatusOutcome {
+    const Record = StatusOutcome;
     const allocator = workerAllocator();
 
     const resource = db_heap.get(db_arg.*) orelse return .{

--- a/types/main.roc
+++ b/types/main.roc
@@ -27,6 +27,13 @@ package
 		Font,
 		Texture,
 		Shader,
+		Store,
+		TextPrepared,
+		AudioSound,
+		AudioMusic,
+		UdpSocket,
+		SqliteDb,
+		SqliteStmt,
 		Drawing,
 	]
 	{}
@@ -35,3 +42,10 @@ import resources/Handle
 import resources/Font
 import resources/Texture
 import resources/Shader
+import resources/Store
+import resources/TextPrepared
+import resources/AudioSound
+import resources/AudioMusic
+import resources/UdpSocket
+import resources/SqliteDb
+import resources/SqliteStmt

--- a/types/resources/AudioMusic.roc
+++ b/types/resources/AudioMusic.roc
@@ -1,0 +1,18 @@
+## Shared host-owned music-stream value.
+##
+## The handle is an opaque, reference-counted native resource identity for a
+## streamed music track. Loading and playback remain platform operations; this
+## value lets reusable packages retain music identity without importing the
+## platform.
+import Handle
+
+AudioMusic := { handle : AudioMusicHandle }.{
+	AudioMusicHandle : Handle([MusicResource])
+
+	## Resource-free music value for pure tests.
+	##
+	## The handle never resolves to a host resource. Do not use it to test
+	## loading, playback, seeking, or resource lifetime.
+	stub : AudioMusic
+	stub = { handle: Handle.stub }
+}

--- a/types/resources/AudioSound.roc
+++ b/types/resources/AudioSound.roc
@@ -1,0 +1,18 @@
+## Shared host-owned sound value.
+##
+## The handle is an opaque, reference-counted native resource identity for a
+## decoded short sound effect. Loading and playback remain platform operations;
+## this value lets reusable packages retain sound identity without importing
+## the platform.
+import Handle
+
+AudioSound := { handle : AudioSoundHandle }.{
+	AudioSoundHandle : Handle([SoundResource])
+
+	## Resource-free sound value for pure tests.
+	##
+	## The handle never resolves to a host resource. Do not use it to test
+	## loading, playback, or resource lifetime.
+	stub : AudioSound
+	stub = { handle: Handle.stub }
+}

--- a/types/resources/SqliteDb.roc
+++ b/types/resources/SqliteDb.roc
@@ -1,0 +1,18 @@
+## Shared host-owned SQLite connection value.
+##
+## The handle is an opaque, reference-counted native resource identity for an
+## open database connection. Opening, preparing, and closing remain platform
+## operations; this value lets reusable packages retain connection identity
+## without importing the platform.
+import Handle
+
+SqliteDb := { handle : SqliteDbHandle }.{
+	SqliteDbHandle : Handle([SqliteDbResource])
+
+	## Resource-free connection value for pure tests.
+	##
+	## The handle never resolves to an open database. Do not use it to test
+	## opening, statement preparation, or resource lifetime.
+	stub : SqliteDb
+	stub = { handle: Handle.stub }
+}

--- a/types/resources/SqliteStmt.roc
+++ b/types/resources/SqliteStmt.roc
@@ -1,0 +1,18 @@
+## Shared host-owned SQLite statement value.
+##
+## The handle is an opaque, reference-counted native resource identity for a
+## prepared statement. Preparation, binding, and execution remain platform
+## operations; this value lets reusable packages retain statement identity
+## without importing the platform.
+import Handle
+
+SqliteStmt := { handle : SqliteStmtHandle }.{
+	SqliteStmtHandle : Handle([SqliteStmtResource])
+
+	## Resource-free statement value for pure tests.
+	##
+	## The handle never resolves to a prepared statement. Do not use it to test
+	## binding, execution, or resource lifetime.
+	stub : SqliteStmt
+	stub = { handle: Handle.stub }
+}

--- a/types/resources/Store.roc
+++ b/types/resources/Store.roc
@@ -1,0 +1,19 @@
+## Shared host-owned asset-store value.
+##
+## The handle is an opaque, reference-counted native resource identity for an
+## open, explicitly located directory. Opening a store and resolving assets
+## through it remain platform operations; this value lets reusable packages
+## retain store identity without importing the platform.
+import Handle
+
+Store := { handle : StoreHandle }.{
+	StoreHandle : Handle([StoreResource])
+
+	## Resource-free store value for pure tests.
+	##
+	## The handle never resolves to an open directory, so every load made
+	## through it fails the way a load through a released store does. Do not use
+	## it to test asset resolution, manifest validation, or resource lifetime.
+	stub : Store
+	stub = { handle: Handle.stub }
+}

--- a/types/resources/TextPrepared.roc
+++ b/types/resources/TextPrepared.roc
@@ -1,0 +1,18 @@
+## Shared host-owned prepared-text value.
+##
+## The handle is an opaque, reference-counted native resource identity for a
+## laid-out run of text. Preparing and drawing it remain platform operations;
+## this value lets reusable packages retain prepared text without importing the
+## platform.
+import Handle
+
+TextPrepared := { handle : TextPreparedHandle }.{
+	TextPreparedHandle : Handle([PreparedTextResource])
+
+	## Resource-free prepared-text value for pure tests.
+	##
+	## The handle never resolves to a host resource. Do not use it to test text
+	## preparation, drawing, or resource lifetime.
+	stub : TextPrepared
+	stub = { handle: Handle.stub }
+}

--- a/types/resources/UdpSocket.roc
+++ b/types/resources/UdpSocket.roc
@@ -1,0 +1,18 @@
+## Shared host-owned UDP socket value.
+##
+## The handle is an opaque, reference-counted native resource identity for a
+## bound socket. Binding, sending, and receiving remain platform operations;
+## this value lets reusable packages retain socket identity without importing
+## the platform.
+import Handle
+
+UdpSocket := { handle : UdpSocketHandle }.{
+	UdpSocketHandle : Handle([UdpSocketResource])
+
+	## Resource-free socket value for pure tests.
+	##
+	## The handle never resolves to a bound socket. Do not use it to test
+	## binding, datagram transfer, or resource lifetime.
+	stub : UdpSocket
+	stub = { handle: Handle.stub }
+}


### PR DESCRIPTION
Completes both TODO lists left open by #187, then finishes the sweep so the
host boundary has one way of reporting failure rather than three.

## Shared resource values

`Store`, `TextPrepared`, `AudioSound`, `AudioMusic`, `UdpSocket`, `SqliteDb`
and `SqliteStmt` join `Font`, `Texture` and `Shader` in `types/resources/`,
each as `Xxx := { handle : Handle([XxxResource]) }` with a `stub` for pure
tests. `Host` imports them and its local markers are gone, so a package can
retain any of these without importing the platform.

The public adapters keep their own nominals and every receiver method they
had — `Sound.play!`, `Db.close!`, `Socket.send!` and the rest are unchanged.
Only the type they wrap moved. The runtime representation is unchanged too: a
nominal wrapping one `Box(U64)` erases to the same `*u64` the bare handle did,
so the change is confined to the generated Zig type names and the `.handle`
field access at the host sites.

One naming departure from the checklist: the TODO said `UdpHandle`, but that
reads as `UdpHandle.UdpHandleHandle`, so the module is `UdpSocket`. Its now
redundant `Host.UdpHandle` alias is dropped.

## Typed results

**Effects that answered with a result record** (the second TODO list) now
declare a closed error union and return a real `Try`:

- `Files.read_text!`, `read_bytes!`, `list!`, `metadata!`
- `Window.read_clipboard!`
- `Cmd.run!`, whose `Timeout` variant carries the output captured before the
  deadline rather than smuggling it through a success record
- `Http.send!`, whose `Other` variant carries the host's own message
- `Udp.bind!` and `receive!`
- `Capture.stop_recording!`, `pixel_at!`, `read_region!`
- every `Sqlite` effect, where the union keeps SQLite's own numeric code and
  message in a `SqliteErr(SqliteFailure)` payload and names the host's four
  refusals (`TooManyConnections`, `TooManyStatements`, `MultipleStatements`,
  `ResultTooLarge`) as variants of their own

**Effects that answered with a bare code** follow, so the treatment is
consistent rather than applied to whichever effects happened to be listed:

- `texture_update!`, `texture_update_region!`
- `shader_location!`, where a uniform raylib cannot find is
  `Err(UniformNotFound)` rather than a negative index
- `files_write_text!`, `files_write_bytes!`
- `stdio_write_text!`, `stdio_write_line!`, `stdio_write_bytes!`
- `udp_send!`
- the five `draw_begin_*!` scopes
- `capture_start_recording!`, `capture_screenshot!`,
  `capture_screenshot_texture!`

`random_i32!` keeps its `I32`: that is a value, not a code. Nothing else in
`Host.roc` returns a bare scalar.

The adapters pattern-match those unions and re-lift to their open public ones.
Every hand-written sentinel decoder and mirrored code constant they used to
call is deleted — `read_bytes_error`, `read_text_error`, `list_error`,
`metadata_error`, `write_result`, `write_error`, `clipboard_error`,
`run_error`, `to_transport_err`, `bind_error`, `receive_error`, `send_error`,
`pixel_read_error`, `screenshot_error`, `texture_export_error`,
`whole_texture_result`, `region_result`, `scope_ok`/`scope_limit`, and
`Stdout`/`Stderr`'s two copies of `write_result`.

The host keeps one internal code table per subsystem and translates it into
each effect's own union at the boundary. That is deliberate: reads, listings
and stats genuinely share their failures, so per-effect enums inside the host
would have duplicated one table into three. Each converted effect body stays a
`...Code` function returning the code — which is what the host's own tests
exercise — with a thin wrapper naming it.

## New ABI constructors

Beside the existing `abiTryOk` / `abiTryErr`:

- `abiUnion` names a payloadless variant of a generated union, and
  `abiUnionNamed` does the same for a variant named by a string, which is what
  the shared capture and sqlite mappers need to skip an arm a particular union
  has no variant for
- `abiUnionPayload` builds a payload-carrying variant, with the same 32/64-bit
  handling and generated-accessor type check `abiTryPayload` uses
- `abiTryEmptyOk` and `abiTryEmptyErr` build a `Try` whose success or failure
  is zero-sized, which glue emits with no accessor at all
- `abiVariantName` resolves a variant against either spelling glue emits,
  since a union with any payload becomes a tagged struct with PascalCase tags
  while a payloadless one becomes a snake_case enum

The typed bind result also retires `invalidResourceHandle` and the
`InvalidResourceBox` it read from: a `Try` has no failure path that needs a
structurally valid handle to hand back and discard.

## Two `roc glue` bugs this ran into

Both are worked around here, and both look worth fixing upstream:

1. **A tag is lowered to a Zig enum member without escaping.** `Unreachable`
   emits `unreachable = 5`, which will not compile. `Udp`'s wire union spells
   that variant `NoRoute` and the adapter re-lifts it; the public
   `Udp.SendError` still says `Unreachable`.
2. **`Try({}, [OneTag])` collapses to a bare `enum { err, ok }`**, and when two
   hosted functions share that collapsed type, the second gets
   `pub const ...ResultPayload = <first>ResultPayload;` aliases naming types
   that were never emitted. All five drawing scopes therefore share the
   two-variant `DrawScopeError`; camera and scissor cannot produce
   `ScopeUnavailable` and crash on it as a platform invariant, the way blend
   already did.

## Follow-up worth doing separately

`texture_update!`'s union names `NotMutable`, which the host has always been
able to report and which the adapter still folds into the public
`PixelCountMismatch`. Naming it on the wire is the first half; widening
`Assets`' public error set is an API change worth making on its own.

## Verification

Against the pinned `nightly-2026-09-06-d85e877`:

- `zig build test` — 330/330 host tests, plus the Python suites it drives
- `zig build lint`
- `scripts/roc_platform_abi.py --check` — generated ABI verified, not just regenerated
- `roc fmt --check` over `platform/`, `types/`
- `scripts/all_tests.py` — all tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJsZ1Kg2D67t9iGBrG2Q4m
