### PR TITLE
Pin nightly with platform package support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,10 @@ jobs:
   build-and-test:
     name: Build and Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    env:
+      # This nightly's LLVM speed pipeline exceeds hosted-runner limits on the
+      # larger examples. The native backend still validates linking and runtime.
+      ROC_BUILD_OPT: dev
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,6 +197,10 @@ jobs:
     name: Test ${{ matrix.bundle_name }} bundle (${{ matrix.os }})
     needs: build
     runs-on: ${{ matrix.os }}
+    env:
+      # Exercise every bundled example without entering this nightly's
+      # resource-heavy LLVM speed pipeline on hosted runners.
+      ROC_BUILD_OPT: dev
     strategy:
       fail-fast: false
       matrix:

--- a/examples/async_read/main.roc
+++ b/examples/async_read/main.roc
@@ -1,7 +1,7 @@
 ## Reads text, bytes, and file details while continuing to animate the window.
 ## Press Escape to quit. This example introduces tasks for work that may take
 ## time, messages that return task results to `update!`, and typed file errors.
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Files

--- a/examples/breakout/main.roc
+++ b/examples/breakout/main.roc
@@ -11,7 +11,7 @@
 ## - Rendering (`Render.roc`): cabinet, brick wall, HUD, bodies, and prompts
 ## - Gameplay (`Ball.roc`, `Paddle.roc`, `Bricks.roc`): motion and collisions
 ## - Tests (`main.roc`): key mapping, launch, wall bounce, and last life lost
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Capture

--- a/examples/camera/main.roc
+++ b/examples/camera/main.roc
@@ -2,7 +2,7 @@
 ## Move with WASD or the arrow keys, zoom with the mouse wheel, rotate with
 ## Q/E, reset with R, and quit with Escape. This example demonstrates camera
 ## drawing and converting positions between world and screen coordinates.
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Camera

--- a/examples/capture_plot/main.roc
+++ b/examples/capture_plot/main.roc
@@ -2,7 +2,7 @@
 ## window stays hidden, but a display is still required; use `xvfb-run` on a
 ## machine without one. This example shows how to configure recording, advance
 ## animation by the same amount for every recorded frame, and track progress.
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Capture

--- a/examples/capture_screenshot/main.roc
+++ b/examples/capture_screenshot/main.roc
@@ -2,7 +2,7 @@
 ## to save, E to try a refused `..` path, or Escape to quit. Without input it
 ## saves on the third frame and exits for automated runs. This example shows
 ## screenshot tasks, result messages, and output-directory confinement.
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Capture

--- a/examples/capture_ui_demo/main.roc
+++ b/examples/capture_ui_demo/main.roc
@@ -2,7 +2,7 @@
 ## `captures/ui_demo.gif`, then exits. This example shows how simulated mouse,
 ## key, and text input can exercise normal UI code, and how to include a cursor
 ## in a recording.
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Capture

--- a/examples/cave_climb/main.roc
+++ b/examples/cave_climb/main.roc
@@ -5,7 +5,7 @@
 ## and calculations for the two tools.
 app [Model, program] {
 	rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst",
-	roc: "nightly-2026-09-06-d85e877",
+	roc: "nightly-2026-09-07-14d9829",
 }
 
 import rr.App

--- a/examples/drop_viewer/main.roc
+++ b/examples/drop_viewer/main.roc
@@ -1,7 +1,7 @@
 ## Displays an image dropped onto the window; press Escape to quit. This
 ## example shows one-time dropped-file input, tasks that read without pausing
 ## drawing, messages that return the bytes to `update!`, and texture creation.
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Assets

--- a/examples/generated_assets/main.roc
+++ b/examples/generated_assets/main.roc
@@ -6,7 +6,7 @@
 ## drawing data separate from the effects that upload pixels and play sound.
 app [Model, program] {
 	rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst",
-	roc: "nightly-2026-09-06-d85e877",
+	roc: "nightly-2026-09-07-14d9829",
 }
 
 import rr.App

--- a/examples/hello_world/main.roc
+++ b/examples/hello_world/main.roc
@@ -4,7 +4,7 @@
 ## and press Escape to quit. This example introduces the three app functions:
 ## `init!` creates the starting state, `update!` responds to each `Input`, and
 ## `render!` draws the current state into a `Frame`.
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Color

--- a/examples/http_fetch/main.roc
+++ b/examples/http_fetch/main.roc
@@ -7,7 +7,7 @@
 app [Model, program] {
 	rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst",
 	http: "https://github.com/roc-lang/http/releases/download/1.0.0/6ZUwqYhCS8PU9Mo6MF7oV82ET2o7KYb57CLKDq4cq4sS.tar.zst",
-	roc: "nightly-2026-09-06-d85e877",
+	roc: "nightly-2026-09-07-14d9829",
 }
 
 import rr.App

--- a/examples/input_inspector/main.roc
+++ b/examples/input_inspector/main.roc
@@ -6,7 +6,7 @@
 ## `update!` can change the clipboard, cursor, and window or read a pixel from
 ## the previous drawing. Every cycle with events prints them to stdout in
 ## delivery order, which is what the windowed sweep asserts on.
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.Draw
 import rr.Text

--- a/examples/live_plot/main.roc
+++ b/examples/live_plot/main.roc
@@ -8,7 +8,7 @@
 ## points efficiently.
 app [Model, program] {
 	rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst",
-	roc: "nightly-2026-09-06-d85e877",
+	roc: "nightly-2026-09-07-14d9829",
 }
 
 import rr.App

--- a/examples/particles/main.roc
+++ b/examples/particles/main.roc
@@ -6,7 +6,7 @@
 ## copies of one texture in a single batch.
 app [Model, program] {
 	rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst",
-	roc: "nightly-2026-09-06-d85e877",
+	roc: "nightly-2026-09-07-14d9829",
 }
 
 import rr.App

--- a/examples/pong/main.roc
+++ b/examples/pong/main.roc
@@ -11,7 +11,7 @@
 ## - Rendering: draws the neon court, scores, ball trail, and win banner
 ## - Gameplay: pure rules that move paddles, bounce the ball, and report hits and points
 ## - Tests: checks key mapping, wall bounces, scoring, and match restart
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.Draw
 import rr.Color

--- a/examples/post_process/main.roc
+++ b/examples/post_process/main.roc
@@ -3,7 +3,7 @@
 ##
 ## Press Escape to quit. This example shows drawing in stages, combining light
 ## additively, and changing a shader setting before using it.
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Assets

--- a/examples/postcard_studio/main.roc
+++ b/examples/postcard_studio/main.roc
@@ -4,7 +4,7 @@
 ##
 ## This example shows how to draw a large composition into a render texture,
 ## display a scaled preview, and use a Task for an export that may take time.
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Capture

--- a/examples/projective_texture/main.roc
+++ b/examples/projective_texture/main.roc
@@ -4,7 +4,7 @@
 ## the mouse cursor after calculating what the pointer is over.
 app [Model, program] {
 	rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst",
-	roc: "nightly-2026-09-06-d85e877",
+	roc: "nightly-2026-09-07-14d9829",
 }
 
 import rr.App

--- a/examples/responsive_ui/main.roc
+++ b/examples/responsive_ui/main.roc
@@ -4,7 +4,7 @@
 ##
 ## This example shows one shared layout calculation for drawing and pointer hit
 ## testing, resizable-window settings, and monitor information.
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Capture

--- a/examples/snake/main.roc
+++ b/examples/snake/main.roc
@@ -10,7 +10,7 @@
 ## - Rendering (`Render.roc`): board, HUD, snake, food, glow, and game over
 ## - Gameplay (`Snake.roc`, `Board.roc`): legal turns, growth, collisions, and food
 ## - Tests (`main.roc`, `Board.roc`, `Game.roc`): controls, turns, food placement, movement, eating, and crashes
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Devices

--- a/examples/sqlite_scores/main.roc
+++ b/examples/sqlite_scores/main.roc
@@ -2,7 +2,7 @@
 ## Escape quits. Scores remain in `sqlite_scores_out/scores.db` between runs.
 ## This example shows startup database setup, prepared statements, and Tasks:
 ## work that may wait runs separately and returns rows as a later Message.
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Color

--- a/examples/task_sleep/main.roc
+++ b/examples/task_sleep/main.roc
@@ -2,7 +2,7 @@
 ## the task finishes, or press Escape to quit. This example introduces Tasks as
 ## work that may wait without pausing drawing, and Messages as the values
 ## completed tasks deliver to a later Input.
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Task

--- a/examples/top_down/main.roc
+++ b/examples/top_down/main.roc
@@ -12,7 +12,7 @@
 ## - Tests (`main.roc`): facing, collisions, collection, damage, escape, and dash events
 app [Model, program] {
 	rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst",
-	roc: "nightly-2026-09-06-d85e877",
+	roc: "nightly-2026-09-07-14d9829",
 }
 
 import rr.App

--- a/examples/udp_cursor/main.roc
+++ b/examples/udp_cursor/main.roc
@@ -4,7 +4,7 @@
 ##
 ## This example shows immediate UDP sends, a Task for receiving data that may
 ## wait, and Messages that carry received batches back to `update!`.
-app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "https://github.com/lukewilliamboswell/roc-ray/releases/download/0.10.0-rc3/3vVeddfDE6rraq5j8v1cGHtFNaQhC6dij1zGRN63NGP1.tar.zst", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Color

--- a/platform/Capture.roc
+++ b/platform/Capture.roc
@@ -62,7 +62,7 @@ capture_scale_ratio = |value|
 		}
 
 # TODO(follow up): Restore derived equality when Roc handles it through type aliases
-# without looping during compilation (nightly-2026-09-06-d85e877).
+# without looping during compilation (nightly-2026-09-07-14d9829).
 CaptureFormat := [Png, Gif, WebM].{
 
 	## Compare two of these values.

--- a/platform/Font.roc
+++ b/platform/Font.roc
@@ -134,7 +134,7 @@ Font := {
 ## Iterate over the Unicode codepoints in a valid Roc string.
 text_codepoints : Str -> Iter(U32)
 # TODO(follow up): Restore unicode.Scalar.iter after a Unicode release compatible
-# with nightly-2026-09-06-d85e877. Unicode 4.1.0 emits mutable-name warnings.
+# with nightly-2026-09-07-14d9829. Unicode 4.1.0 emits mutable-name warnings.
 # Roc strings are valid UTF-8. Decode one scalar per step without allocating a
 # codepoint list; embedded NUL is a scalar, not a terminator.
 text_codepoints = |text| {

--- a/platform/Math.roc
+++ b/platform/Math.roc
@@ -10,7 +10,7 @@
 Math := [].{
 
 	# TODO(follow up): Restore derived equality once Roc compiles comparisons
-	# through platform aliases without looping (nightly-2026-09-06-d85e877).
+	# through platform aliases without looping (nightly-2026-09-07-14d9829).
 	## Two-dimensional floating-point vector, also named `Draw.Vector2`.
 	Vec2 := {
 		x : F32,

--- a/platform/main-wayland.roc
+++ b/platform/main-wayland.roc
@@ -16,7 +16,7 @@
 ## This app opens a window, draws a circle, and exits on Escape:
 ##
 ## ```roc
-## app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+## app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 ##
 ## import rr.App
 ## import rr.Color
@@ -60,7 +60,7 @@ platform ""
 	}
 	exposes [Font, Texture, App, Devices, Files, Draw, Text, Color, Window, Keys, Mouse, Gamepad, Time, Audio, Assets, Math, Camera, Sprite, Tilemap, Physics, Capture, Random, Task, Http, Udp, Url, Stdout, Stderr, Sqlite, Cmd, Trace]
 	packages {
-		roc: "nightly-2026-09-06-d85e877",
+		roc: "nightly-2026-09-07-14d9829",
 		rand: "https://github.com/kili-ilo/roc-random/releases/download/0.9.2/2ZXLX8WRqrosGu1V3VL5aXqgtfTRvJmjFPx8a26ecVmc.tar.zst",
 		http: "https://github.com/roc-lang/http/releases/download/1.0.0/6ZUwqYhCS8PU9Mo6MF7oV82ET2o7KYb57CLKDq4cq4sS.tar.zst",
 	}

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -16,7 +16,7 @@
 ## This app opens a window, draws a circle, and exits on Escape:
 ##
 ## ```roc
-## app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+## app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 ##
 ## import rr.App
 ## import rr.Color
@@ -60,7 +60,7 @@ platform ""
 	}
 	exposes [Font, Texture, App, Devices, Files, Draw, Text, Color, Window, Keys, Mouse, Gamepad, Time, Audio, Assets, Math, Camera, Sprite, Tilemap, Physics, Capture, Random, Task, Http, Udp, Url, Stdout, Stderr, Sqlite, Cmd, Trace]
 	packages {
-		roc: "nightly-2026-09-06-d85e877",
+		roc: "nightly-2026-09-07-14d9829",
 		rand: "https://github.com/kili-ilo/roc-random/releases/download/0.9.2/2ZXLX8WRqrosGu1V3VL5aXqgtfTRvJmjFPx8a26ecVmc.tar.zst",
 		http: "https://github.com/roc-lang/http/releases/download/1.0.0/6ZUwqYhCS8PU9Mo6MF7oV82ET2o7KYb57CLKDq4cq4sS.tar.zst",
 	}

--- a/scripts/all_tests.py
+++ b/scripts/all_tests.py
@@ -97,6 +97,10 @@ _rewrite_platform_ref = local_bundles.rewrite_platform_ref
 # See `local_bundles.PACKAGE_LIMIT_ARGS`: a locally built platform bundle is
 # bigger than roc's default transitive-dependency budget.
 LIMITS = local_bundles.PACKAGE_LIMIT_ARGS
+# Keep the ordinary developer/release path on Roc's default optimized backend.
+# CI may select the native dev backend when a pinned nightly's LLVM pipeline
+# exceeds hosted-runner memory or time limits.
+ROC_BUILD_ARGS = [f"--opt={os.environ.get('ROC_BUILD_OPT', 'speed')}"]
 
 # Examples to skip in the bundled-platform build test, mapping example name ->
 # reason. Use this when a specific example can't build against the bundled
@@ -531,7 +535,7 @@ def run_cli_args_integration(
     print("\nRunning CLI argument integration probe...", end=" ", flush=True)
     staged = local_bundles.stage_app(fixture, packages, packages.scratch_dir / "cli_args")
     if not run_cmd(
-        ["roc", "build", staged.name, *LIMITS], "build CLI argument probe", verbose, cwd=staged.parent
+        ["roc", "build", *ROC_BUILD_ARGS, staged.name, *LIMITS], "build CLI argument probe", verbose, cwd=staged.parent
     ):
         print("FAILED")
         return ["build CLI argument probe"]
@@ -571,7 +575,7 @@ def run_task_delivery_probe(
     print("\nRunning task delivery probe...", end=" ", flush=True)
     staged = local_bundles.stage_app(fixture, packages, packages.scratch_dir / "task_delivery")
     if not run_cmd(
-        ["roc", "build", staged.name, *LIMITS], "build task delivery probe", verbose, cwd=staged.parent
+        ["roc", "build", *ROC_BUILD_ARGS, staged.name, *LIMITS], "build task delivery probe", verbose, cwd=staged.parent
     ):
         print("FAILED")
         return ["build task delivery probe"]
@@ -601,7 +605,7 @@ def run_observatory_probe(
     print("\nRunning Observatory capture probe...", end=" ", flush=True)
     staged = local_bundles.stage_app(fixture, packages, packages.scratch_dir / "observatory")
     if not run_cmd(
-        ["roc", "build", staged.name, *LIMITS], "build Observatory probe", verbose, cwd=staged.parent
+        ["roc", "build", *ROC_BUILD_ARGS, staged.name, *LIMITS], "build Observatory probe", verbose, cwd=staged.parent
     ):
         print("FAILED")
         return ["build Observatory probe"]
@@ -928,7 +932,7 @@ def run_observatory_probe(
         abrupt_fixture, packages, packages.scratch_dir / "observatory-abrupt"
     )
     if not run_cmd(
-        ["roc", "build", abrupt_staged.name, *LIMITS],
+        ["roc", "build", *ROC_BUILD_ARGS, abrupt_staged.name, *LIMITS],
         "build abrupt Observatory probe",
         verbose,
         cwd=abrupt_staged.parent,
@@ -1025,7 +1029,7 @@ def run_task_cap_probe(
     print("\nRunning task cap probe...", end=" ", flush=True)
     staged = local_bundles.stage_app(fixture, packages, packages.scratch_dir / "task_cap")
     if not run_cmd(
-        ["roc", "build", staged.name, *LIMITS], "build task cap probe", verbose, cwd=staged.parent
+        ["roc", "build", *ROC_BUILD_ARGS, staged.name, *LIMITS], "build task cap probe", verbose, cwd=staged.parent
     ):
         print("FAILED")
         return ["build task cap probe"]
@@ -1067,7 +1071,7 @@ def run_file_write_probe(
     print("\nRunning file write probe...", end=" ", flush=True)
     staged = local_bundles.stage_app(fixture, packages, packages.scratch_dir / "file_write")
     if not run_cmd(
-        ["roc", "build", staged.name, *LIMITS], "build file write probe", verbose, cwd=staged.parent
+        ["roc", "build", *ROC_BUILD_ARGS, staged.name, *LIMITS], "build file write probe", verbose, cwd=staged.parent
     ):
         print("FAILED")
         return ["build file write probe"]
@@ -1111,7 +1115,7 @@ def run_cmd_probe(
     print("\nRunning subprocess probe...", end=" ", flush=True)
     staged = local_bundles.stage_app(fixture, packages, packages.scratch_dir / "cmd")
     if not run_cmd(
-        ["roc", "build", staged.name, *LIMITS], "build cmd probe", verbose, cwd=staged.parent
+        ["roc", "build", *ROC_BUILD_ARGS, staged.name, *LIMITS], "build cmd probe", verbose, cwd=staged.parent
     ):
         print("FAILED")
         return ["build cmd probe"]
@@ -1164,7 +1168,7 @@ def run_udp_probe(
     print("\nRunning UDP socket probe...", end=" ", flush=True)
     staged = local_bundles.stage_app(fixture, packages, packages.scratch_dir / "udp")
     if not run_cmd(
-        ["roc", "build", staged.name, *LIMITS], "build udp probe", verbose, cwd=staged.parent
+        ["roc", "build", *ROC_BUILD_ARGS, staged.name, *LIMITS], "build udp probe", verbose, cwd=staged.parent
     ):
         print("FAILED")
         return ["build udp probe"]
@@ -1208,7 +1212,7 @@ def run_virtual_keys_probe(
     print("\nRunning virtual keyboard probe...", end=" ", flush=True)
     staged = local_bundles.stage_app(fixture, packages, packages.scratch_dir / "virtual_keys")
     if not run_cmd(
-        ["roc", "build", staged.name, *LIMITS], "build virtual keys probe", verbose, cwd=staged.parent
+        ["roc", "build", *ROC_BUILD_ARGS, staged.name, *LIMITS], "build virtual keys probe", verbose, cwd=staged.parent
     ):
         print("FAILED")
         return ["build virtual keys probe"]
@@ -1247,7 +1251,7 @@ def run_sqlite_probe(
     print("\nRunning sqlite probe...", end=" ", flush=True)
     staged = local_bundles.stage_app(fixture, packages, packages.scratch_dir / "sqlite")
     if not run_cmd(
-        ["roc", "build", staged.name, *LIMITS], "build sqlite probe", verbose, cwd=staged.parent
+        ["roc", "build", *ROC_BUILD_ARGS, staged.name, *LIMITS], "build sqlite probe", verbose, cwd=staged.parent
     ):
         print("FAILED")
         return ["build sqlite probe"]
@@ -1294,7 +1298,7 @@ def run_model_allocation_check(
     print("\nMeasuring model collection allocation per frame...", end=" ", flush=True)
     staged = local_bundles.stage_app(entry, packages, packages.scratch_dir / "model_inplace")
     if not run_cmd(
-        ["roc", "build", staged.name, *LIMITS], "build model allocation probe", verbose, cwd=staged.parent
+        ["roc", "build", *ROC_BUILD_ARGS, staged.name, *LIMITS], "build model allocation probe", verbose, cwd=staged.parent
     ):
         print("FAILED (build)")
         return ["model allocation probe build"]
@@ -1383,8 +1387,9 @@ def run_wayland_bundle_test(root: Path, example: Path, verbose: bool) -> list[st
                 example, packages, packages.scratch_dir / "wayland-example"
             )
             command = "build" if IS_LINUX else "check"
+            build_args = ROC_BUILD_ARGS if command == "build" else []
             ok = run_cmd(
-                ["roc", command, staged.name, *LIMITS],
+                ["roc", command, *build_args, staged.name, *LIMITS],
                 f"wayland bundle {command} {name}",
                 verbose,
                 cwd=staged.parent,
@@ -1793,7 +1798,7 @@ def _run_example_stages(
 
             print(f"  Building {name}...", end=" ", flush=True)
             if run_cmd(
-                ["roc", "build", staged[example].name, *LIMITS],
+                ["roc", "build", *ROC_BUILD_ARGS, staged[example].name, *LIMITS],
                 f"build {name}",
                 args.verbose,
                 cwd=staged[example].parent,

--- a/scripts/test_bundle_artifact.py
+++ b/scripts/test_bundle_artifact.py
@@ -114,8 +114,9 @@ def find_roc(root: Path) -> str | None:
 
 def build_example(roc: str, example: Path) -> bool:
     print(f"Building: {example}", flush=True)
+    build_opt = os.environ.get("ROC_BUILD_OPT", "speed")
     result = subprocess.run(
-        [roc, "build", "main.roc", *local_bundles.PACKAGE_LIMIT_ARGS],
+        [roc, "build", f"--opt={build_opt}", "main.roc", *local_bundles.PACKAGE_LIMIT_ARGS],
         cwd=example.parent,
     )
     return result.returncode == 0

--- a/scripts/test_release_helpers.py
+++ b/scripts/test_release_helpers.py
@@ -46,7 +46,7 @@ class PackageExamplesTests(unittest.TestCase):
     def make_repo(self, root: Path) -> Path:
         """A miniature repository with two examples, an asset, and junk to exclude."""
         (root / "platform").mkdir()
-        (root / "platform" / "main.roc").write_text('platform "" packages { roc: "nightly-2026-09-06-d85e877" }\n')
+        (root / "platform" / "main.roc").write_text('platform "" packages { roc: "nightly-2026-09-07-14d9829" }\n')
         examples = root / "examples"
         (examples / "pong" / "assets").mkdir(parents=True)
         (examples / "gallery").mkdir(parents=True)
@@ -129,8 +129,8 @@ class PackageExamplesTests(unittest.TestCase):
             self.assertIn(f'platform "{NEXT_URL}"', snake)
             self.assertNotIn("../../platform/main.roc", pong)
             self.assertNotIn(BUNDLE_URL, snake)
-            self.assertIn('roc: "nightly-2026-09-06-d85e877"', pong)
-            self.assertIn('roc: "nightly-2026-09-06-d85e877"', snake)
+            self.assertIn('roc: "nightly-2026-09-07-14d9829"', pong)
+            self.assertIn('roc: "nightly-2026-09-07-14d9829"', snake)
             self.assertIn('nightly-2026-08-23-fb208ba', (root / "examples/pong/main.roc").read_text())
             self.assertEqual(b"\x89PNG ball", ball)
             self.assertNotIn("examples/gallery/pong.webp", names)

--- a/scripts/test_roc_platform_abi.py
+++ b/scripts/test_roc_platform_abi.py
@@ -51,11 +51,11 @@ class RocPlatformAbiTests(unittest.TestCase):
 
     def test_staging_rebinds_the_app_pin_without_rewriting_module_docs(self) -> None:
         source = '## app [] { roc: "nightly-2026-08-23-fb208ba" }\napp [] { roc: "nightly-2026-08-23-fb208ba" }\n'
-        rebound = local_bundles.rewrite_compiler_pin(source, "nightly-2026-09-06-d85e877")
+        rebound = local_bundles.rewrite_compiler_pin(source, "nightly-2026-09-07-14d9829")
         self.assertEqual(source.splitlines()[0], rebound.splitlines()[0])
-        self.assertIn('roc: "nightly-2026-09-06-d85e877"', rebound.splitlines()[1])
+        self.assertIn('roc: "nightly-2026-09-07-14d9829"', rebound.splitlines()[1])
         with self.assertRaises(local_bundles.LocalBundleError):
-            local_bundles.rewrite_compiler_pin('app [] {}', "nightly-2026-09-06-d85e877")
+            local_bundles.rewrite_compiler_pin('app [] {}', "nightly-2026-09-07-14d9829")
 
     def test_rejects_compiler_from_a_different_nightly(self) -> None:
         pin = abi.RocPin(

--- a/src/host_native.zig
+++ b/src/host_native.zig
@@ -12791,7 +12791,7 @@ test "observatory executable metadata basename is portable" {
     try std.testing.expectEqualStrings("particles", portableAppName("C:\\examples\\particles\\main.exe"));
     try std.testing.expectEqualStrings("particles", portableAppName("/opt/games/particles"));
     try std.testing.expectEqualStrings("main.roc", portableAppName("main.roc"));
-    try std.testing.expectEqualStrings("nightly-2026-09-06-d85e877", roc_compiler_pin);
+    try std.testing.expectEqualStrings("nightly-2026-09-07-14d9829", roc_compiler_pin);
 }
 
 test "disabled observatory path performs no recorder startup work" {

--- a/test/asset_store_compile.roc
+++ b/test/asset_store_compile.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "../platform/main.roc",
-	roc: "nightly-2026-09-06-d85e877",
+	roc: "nightly-2026-09-07-14d9829",
 }
 
 import rr.App

--- a/test/cli_args/main.roc
+++ b/test/cli_args/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 

--- a/test/cmd/main.roc
+++ b/test/cmd/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Cmd

--- a/test/compile_fail/app_config_module.roc
+++ b/test/compile_fail/app_config_module.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.AppConfig

--- a/test/compile_fail/app_config_to_host.roc
+++ b/test/compile_fail/app_config_to_host.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/app_host_config.roc
+++ b/test/compile_fail/app_host_config.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/audio_resource_kind_confusion.roc
+++ b/test/compile_fail/audio_resource_kind_confusion.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "../../platform/main.roc",
-	roc: "nightly-2026-09-06-d85e877",
+	roc: "nightly-2026-09-07-14d9829",
 }
 
 # The shared handle representation must not let one resource kind stand in for

--- a/test/compile_fail/device_transport_private.roc
+++ b/test/compile_fail/device_transport_private.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/file_module_removed.roc
+++ b/test/compile_fail/file_module_removed.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 # Large reads now return `List(U8)` from `Files`; the old module must stay absent.
 import rr.App

--- a/test/compile_fail/font_handle_manufacture.roc
+++ b/test/compile_fail/font_handle_manufacture.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "../../platform/main.roc",
-	roc: "nightly-2026-09-06-d85e877",
+	roc: "nightly-2026-09-07-14d9829",
 }
 
 # A font's resource identity is private to the host. Applications can copy a

--- a/test/compile_fail/host_module.roc
+++ b/test/compile_fail/host_module.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/input_module_removed.roc
+++ b/test/compile_fail/input_module_removed.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/input_spawn_receiver.roc
+++ b/test/compile_fail/input_spawn_receiver.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 # `App.Input` is a pure platform value, so it has
 # no effectful receivers. `Task.spawn!(input, || ...)` is the only way to start

--- a/test/compile_fail/program_module_removed.roc
+++ b/test/compile_fail/program_module_removed.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/resource_handle_kind_confusion.roc
+++ b/test/compile_fail/resource_handle_kind_confusion.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "../../platform/main.roc",
-	roc: "nightly-2026-09-06-d85e877",
+	roc: "nightly-2026-09-07-14d9829",
 }
 
 # The shared handle representation must not let one resource kind stand in for

--- a/test/compile_fail/resource_module_private.roc
+++ b/test/compile_fail/resource_module_private.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Draw

--- a/test/compile_fail/shader_handle_manufacture.roc
+++ b/test/compile_fail/shader_handle_manufacture.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "../../platform/main.roc",
-	roc: "nightly-2026-09-06-d85e877",
+	roc: "nightly-2026-09-07-14d9829",
 }
 
 # A shader's resource identity is private to the host. Applications can retain

--- a/test/compile_fail/sound_handle_manufacture.roc
+++ b/test/compile_fail/sound_handle_manufacture.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "../../platform/main.roc",
-	roc: "nightly-2026-09-06-d85e877",
+	roc: "nightly-2026-09-07-14d9829",
 }
 
 # A sound remains opaque even though its representation is now a direct handle.

--- a/test/compile_fail/sqlite_db_manufacture.roc
+++ b/test/compile_fail/sqlite_db_manufacture.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 # A connection's identity is private to the host. An application can hold and
 # copy a `Db` it was given, but cannot manufacture one from a raw integer and

--- a/test/compile_fail/texture_handle_manufacture.roc
+++ b/test/compile_fail/texture_handle_manufacture.roc
@@ -1,6 +1,6 @@
 app [Model, program] {
 	rr: platform "../../platform/main.roc",
-	roc: "nightly-2026-09-06-d85e877",
+	roc: "nightly-2026-09-07-14d9829",
 }
 
 # A texture's resource identity is private to the host. Applications can copy a

--- a/test/compile_fail/transition_removed.roc
+++ b/test/compile_fail/transition_removed.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 # `update!` is effectful: host state changes are direct calls and deferred
 # work goes through `Task.spawn!`. The pure-update `Transition` builder is

--- a/test/file_write/main.roc
+++ b/test/file_write/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Files

--- a/test/http_fetch/main.roc
+++ b/test/http_fetch/main.roc
@@ -1,7 +1,7 @@
 app [Model, program] {
 	rr: platform "../../platform/main.roc",
 	http: "https://github.com/roc-lang/http/releases/download/1.0.0/6ZUwqYhCS8PU9Mo6MF7oV82ET2o7KYb57CLKDq4cq4sS.tar.zst",
-	roc: "nightly-2026-09-06-d85e877",
+	roc: "nightly-2026-09-07-14d9829",
 }
 
 import rr.App

--- a/test/model_inplace/main.roc
+++ b/test/model_inplace/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Color
@@ -7,7 +7,7 @@ import rr.Draw
 ## A measurement app: does a large collection in the model survive a frame
 ## without being copied?
 ##
-## It does, as of `nightly-2026-09-06-d85e877`. Run it under
+## It does, as of `nightly-2026-09-07-14d9829`. Run it under
 ## `ROC_RAY_ALLOC_STATS=1` and read the per-frame allocator line: writing one
 ## element of a million-`F32` list in the model allocates well under a hundred
 ## bytes a frame -- the model box, and nothing proportional to the list.

--- a/test/observatory/main.roc
+++ b/test/observatory/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Files

--- a/test/observatory_abrupt/main.roc
+++ b/test/observatory_abrupt/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Trace

--- a/test/observatory_perf/main.roc
+++ b/test/observatory_perf/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Color

--- a/test/sqlite/main.roc
+++ b/test/sqlite/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Draw

--- a/test/task_cap/main.roc
+++ b/test/task_cap/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Task

--- a/test/task_delivery/main.roc
+++ b/test/task_delivery/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Task

--- a/test/udp/main.roc
+++ b/test/udp/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Task

--- a/test/virtual_keys/main.roc
+++ b/test/virtual_keys/main.roc
@@ -1,4 +1,4 @@
-app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-06-d85e877" }
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
 
 import rr.App
 import rr.Devices


### PR DESCRIPTION
## Summary

- pin the platform and development apps to `nightly-2026-09-07-14d9829`
- update ABI assertions and release-helper fixtures to the same compiler
- enable the next release candidate to be consumed as a platform dependency from Roc packages

The rc4 compiler (`nightly-2026-09-06-d85e877`) rejects the package-platform header syntax added by roc-lang/roc#11079.

## Validation

- `zig build lint`
- `python3 scripts/test_release_helpers.py`
- `python3 scripts/test_roc_platform_abi.py`
- `PATH=/home/lbw/roc_nightly-linux_x86_64-2026-09-07-14d9829:$PATH zig build test` (full release suite launched locally; check/test phases for all 24 examples passed)