### PR TITLE
Introduce receiver capabilities and deny external effects by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -626,3 +626,22 @@ Before opening a PR:
 - Check `git status --short`, `git diff`, and `git diff --cached` for untracked
   files, generated output, platform-reference churn, binaries, or unrelated
   local edits.
+
+## External service permissions
+
+The development host denies external services unless launched with
+`--host-caps-allow-all`. Pass it explicitly when running an example that reads
+assets, accesses files or the network, uses the clipboard, or writes capture
+output. `scripts/run-example.py` forwards it after `--`; it never grants it
+implicitly. Existing integration probes request it explicitly where they test
+external services. Permission probes also run without it to test refusal.
+
+`App.Io` is supplied to `init!` and as the third `update!` argument. Delegate
+narrow receivers (`Files.Access`, `Http.Client`, and so on) to helpers and tasks.
+Permission checks precede native work and consume transferred arguments on
+refusal. Selecting a receiver is pure and allocates no host resource. The
+private scalar identity belongs to one application lifetime, is not a native
+pointer, and is checked against the host's fixed launch policy.
+
+A recording in `App.Config` is a description. Start it explicitly with
+`io.capture().start!(recording)`; configuration does not authorize output.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,29 @@ A RocRay app provides three functions:
   state.
 - `render!` draws that state on the screen.
 
+`init!` receives `App.Io`; the update signature is
+`update!(model, input, io)`. Select a service and call its receivers:
+
+```roc
+files = io.files()
+Task.spawn!(input, || Loaded(files.read_text!("data.json")))
+# In a task or init!:
+response = io.http().send!(request)?
+```
+
+Development builds deny external services by default. Launch a trusted app with
+`--host-caps-allow-all` to grant the previous broad behavior:
+
+```sh
+scripts/run-example.py examples/http_fetch -- --host-caps-allow-all
+```
+
+Files (including cwd and asset files), networking, processes, SQLite,
+environment, clipboard, stdout/stderr, and capture output otherwise return
+`PermissionDenied`. Drawing, input, generated resources, audio playback, clocks,
+and timers remain available. This is a host API policy, not an OS sandbox;
+allow-all does not confine files, network destinations, or child processes.
+
 Reading a file or waiting for a network reply can take time. Start that work as
 a task so the app can keep updating and drawing; when it finishes, `update!`
 receives the result.
@@ -92,11 +115,12 @@ complete app, then choose a project from the
 [API reference](https://lukewilliamboswell.github.io/roc-ray/) documents the
 available features and functions.
 
-Configure a shared startup font when one font serves most of the app:
+Configure a shared startup font when one font serves most of the app. Loading
+a font file requires `--host-caps-allow-all`; the built-in font does not:
 
 ```roc
 config = App.default.with_default_font({ path: "assets/body.ttf", size: 32 })
-font = startup.default_font!()?
+font = io.default_font!()?
 ```
 
 `Text.Font` carries both its opaque host handle and an immutable metric

--- a/design.md
+++ b/design.md
@@ -188,7 +188,7 @@ A RocRay program has three responsibilities:
 - `init!` validates startup configuration, performs one-time startup effects,
   and creates the initial model. Startup may load or allocate resources, and
   may use waiting effects, before interactive cycling begins.
-- `update!` receives the current model and one `App.Input`. It folds that input
+- `update!` receives the current model, one `App.Input`, and `App.Io`. It folds that input
   into the next model, calls host effects directly, and starts tasks. It
   returns the next model, or `Err(Exit(code))` to stop the application.
 - `render!` receives the resulting model and a `Draw.Frame`. It may issue
@@ -205,7 +205,7 @@ sequenceDiagram
 
     loop Each host cycle
         Host->>Host: give tasks a turn, collect finished messages
-        Host->>App: update!(model, App.Input with those messages)
+        Host->>App: update!(model, App.Input with those messages, App.Io)
         App->>Host: direct effects, in program order
         App->>Task: Task.spawn!(input, closure) -- it may start at once
         App-->>Host: next model, or Err(Exit(code))
@@ -306,7 +306,7 @@ failure semantics.
 
 | Protocol | Direction | Timing and cardinality |
 | --- | --- | --- |
-| Startup authority | Host to `init!`, with direct startup operations | Once, before cycling |
+| Host authority: `App.Io` | Host to `init!` and `update!` | At initialization and once per host cycle; the same lifetime authority |
 | `App.Input(msg)` | Host to `update!` | Exactly once per host cycle |
 | Effects | Application to host, in program order | Any number, synchronously, from the phases each effect permits |
 | `Draw.Frame` | Host to `render!`, with draw calls back to host | Zero or one per host cycle; exactly one per presentation frame |
@@ -733,19 +733,51 @@ queries, domain caching, and interpretation remain in Roc unless the host must
 own a narrowly defined piece for device or operating-system ownership, memory
 or concurrency safety, or a measured boundary-performance need.
 
-Every external facility states its authority boundary. A write or capture
-destination is confined to an application-selected root or capability. A
-process capability states what executable and environment it may use. Network
-and device capabilities state their platform permission behavior. The
-platform does not turn a convenient feature into ambient, undocumented access
-to the machine.
+The host supplies opaque `App.Io` authority to initialization and every
+`update!(model, input, io)` callback. `Input` remains observations and messages;
+rendering receives only its `Draw.Frame`. Pure receiver accessors select a
+service, such as `io.http()` or `io.files()`, and effects use receiver dispatch:
+`io.http().send!(request)`. Helpers and task closures should receive the narrow
+service they need. Selecting or copying a service neither performs I/O nor
+widens its authority. Captured services remain valid for the application
+lifetime; phase restrictions apply independently of possession.
+
+External services are denied by default. Their operations return typed
+`PermissionDenied` before admitting work or touching the external system.
+The launcher flag `--host-caps-allow-all` explicitly grants the existing broad
+external services, subject to the same phase rules and resource bounds.
+There are no per-service launch flags, interactive prompts, or revocation in
+this policy. The flag is host-owned and is removed from application arguments.
+
+The default profile retains the interactive surface, input, window control,
+audio playback, resource construction from app-owned bytes, clocks, entropy,
+timers, and reads of the app's own framebuffer. Filesystem access (including
+cwd writes and packaged assets), HTTP, UDP, processes, SQLite, environment,
+clipboard, stdout/stderr, and capture output require external authority.
+Indirect file loaders and configured file fonts obey the same policy. Dropped
+file paths are observations, not grants. Configuration may describe a recording
+but cannot start external work: the application explicitly starts it through
+its capture capability during initialization or another permitted phase.
+
+Each service states the extent of its authority. The initial allow-all grant
+is broad: files are not directory-confined, HTTP is not origin-confined,
+processes are not executable-confined, and SQLite is not a restricted VFS.
+An asset store still enforces its relative path contract, but this is not a
+general filesystem sandbox. These typed boundaries prepare for narrower future
+grants without claiming operating-system isolation today. Derived resources
+retain the authority required for their documented operations.
+
+App-controlled diagnostic payloads cannot bypass denied raw output. Restricted
+runs suppress payloads from debug, failed expectations, and crash text while
+retaining fixed host diagnostics. An operator may separately request host
+Observatory output; that is launcher authority, not an application grant.
 
 There is no arbitrary native-call facility. Effectful closures exist for
 exactly one purpose — the body of a task — and a task runs on the frame thread
 under the same phase guard as every other application code. No API accepts a
 closure the host will run at an unspecified time, on an unspecified thread, or
 outside a phase. New host work is represented by a typed effect, waiting
-effect, input field, render operation, or startup capability.
+effect, input field, render operation, or host authority.
 
 ## Targets and capability profiles
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -96,3 +96,11 @@ Use these as focused references, not starter projects.
 
 Exhaustive API probes and invalid-input cases belong in [`../test/`](../test/),
 where they can be explicit without making an example harder to understand.
+
+## Development permissions
+
+Pass `--host-caps-allow-all` after `--` when using `scripts/run-example.py` for
+examples that load files, use external services, or write captures. Without it,
+those effects return `PermissionDenied`, including writes in the working
+directory. `hello_world` uses the built-in font and runs with the default
+restricted policy. Recording examples start capture explicitly in `init!`.

--- a/examples/async_read/main.roc
+++ b/examples/async_read/main.roc
@@ -51,7 +51,7 @@ program = { init!, update!, render! }
 init! : App.Init(Model, [ResourceLimit])
 init! = App.init(
 	App.default.with_title("RocRay Async Read").with_size({ width: 880, height: 480 }).with_frame_pacing(Capped(120)),
-	|_host| {
+	|_io| {
 		font = Draw.default_font!()
 		Ok({
 			small: Waiting,
@@ -65,13 +65,13 @@ init! = App.init(
 	},
 )
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, io| {
 	resolved = List.fold(program_input.messages, { small: model.small, large: model.large, meta: model.meta }, apply_message)
 	if program_input.time.cycle_count == 0 {
-		Task.spawn!(program_input, || SmallReadFinished(Files.read_text!(small_path)))
-		Task.spawn!(program_input, || BytesReadFinished(Files.read_bytes!(large_path)))
-		Task.spawn!(program_input, || MetadataFinished(Files.metadata!(small_path)))
+		Task.spawn!(program_input, || SmallReadFinished(io.files().read_text!(small_path)))
+		Task.spawn!(program_input, || BytesReadFinished(io.files().read_bytes!(large_path)))
+		Task.spawn!(program_input, || MetadataFinished(io.files().metadata!(small_path)))
 	}
 
 	if program_input.devices.key_pressed(KeyEscape) {
@@ -121,6 +121,7 @@ string_state = |result|
 	match result {
 		Ok(contents) => Loaded(Str.count_utf8_bytes(contents))
 		Err(NotFound) => Failed("not found")
+		Err(PermissionDenied) => Failed("file access was not granted")
 		Err(ReadFailed) => Failed("read failed")
 		Err(Busy) => Failed("host busy")
 		Err(Unavailable) => Failed("reads unavailable")
@@ -133,6 +134,7 @@ bytes_state = |result|
 	match result {
 		Ok(bytes) => Held(bytes)
 		Err(NotFound) => Failed("not found")
+		Err(PermissionDenied) => Failed("file access was not granted")
 		Err(ReadFailed) => Failed("read failed")
 		Err(Busy) => Failed("host busy")
 		Err(Unavailable) => Failed("reads unavailable")

--- a/examples/breakout/main.roc
+++ b/examples/breakout/main.roc
@@ -63,11 +63,16 @@ breakout_config = |args| {
 }
 
 ## Loads presentation assets and creates the first ready-to-launch world.
-init! : App.Init(Model, [ResourceLimit, SoundGenerationFailed])
+init! : App.Init(Model, [PermissionDenied, ResourceLimit, SoundGenerationFailed])
 init! = App.init_for_args(
 	breakout_config,
-	|startup| {
-		demo = List.contains(App.args!(startup), record_demo_flag)
+	|io| {
+		match breakout_config(io.args!()).recording() {
+			NoRecording => {}
+			Record(recording) => io.capture().start!(recording)?
+		}
+
+		demo = List.contains(io.args!(), record_demo_flag)
 		Ok({ assets: Assets.load!()?, world: Game.new_world(), demo, elapsed: 0 })
 	},
 )
@@ -114,8 +119,8 @@ play_event! = |assets, event|
 Msg : []
 
 ## Advances the world, plays its events, and handles quitting or recording end.
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, _io| {
 	dt = program_input.time.elapsed_seconds
 	controls = if model.demo demo_controls(model.world) else read_controls(program_input.devices)
 	(world, events) = Game.update(model.world, controls, dt)

--- a/examples/camera/main.roc
+++ b/examples/camera/main.roc
@@ -41,7 +41,7 @@ world_bottom = 1200.F32
 init! : App.Init(Model, [ResourceLimit])
 init! = App.init(
 	App.default.with_title("RocRay Camera").with_frame_pacing(Capped(120)),
-	|_startup| {
+	|_io| {
 		font = Draw.default_font!()
 		Ok({
 			player: { x: 400, y: 300 },
@@ -78,8 +78,8 @@ move_player = |player, input, dt| {
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, _io| {
 	input = program_input.devices
 	dt = program_input.time.elapsed_seconds
 

--- a/examples/capture_plot/main.roc
+++ b/examples/capture_plot/main.roc
@@ -30,24 +30,31 @@ bar_count = 12.U64
 ## Frames recorded before the host finalizes the files and the app exits.
 recorded_frames = 75.U64
 
-init! : App.Init(Model, [ResourceLimit])
+startup_config = App.default
+	.with_title("RocRay Capture: Plot")
+	.with_size({ width: 640, height: 360 })
+	.with_frame_pacing(Capped(60))
+	.with_visible(Bool.False)
+	.with_output_dir("captures")
+	.with_recording(
+		Capture.default
+			.with_path("plot.webm")
+			.with_format(WebM)
+			.with_fps(25)
+			.with_max_frames(recorded_frames)
+			.with_scale(Half)
+			.with_timing(FixedStep),
+	)
+
+init! : App.Init(Model, [PermissionDenied, ResourceLimit])
 init! = App.init(
-	App.default
-		.with_title("RocRay Capture: Plot")
-		.with_size({ width: 640, height: 360 })
-		.with_frame_pacing(Capped(60))
-		.with_visible(Bool.False)
-		.with_output_dir("captures")
-		.with_recording(
-			Capture.default
-				.with_path("plot.webm")
-				.with_format(WebM)
-				.with_fps(25)
-				.with_max_frames(recorded_frames)
-				.with_scale(Half)
-				.with_timing(FixedStep),
-		),
-	|_startup| {
+	startup_config,
+	|io| {
+		match startup_config.recording() {
+			NoRecording => {}
+			Record(recording) => io.capture().start!(recording)?
+		}
+
 		font = Draw.default_font!()
 		Ok({
 			elapsed: 0,
@@ -66,8 +73,8 @@ init! = App.init(
 ## the devices and the clock, not asked for with an effect.
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, _io| {
 	# The host finalizes the file itself once the recording reaches its frame
 	# cap, and says so with `Finished`. Match on that rather than on `Idle`:
 	# `Idle` is also what a run with no recording at all looks like -- a

--- a/examples/capture_screenshot/main.roc
+++ b/examples/capture_screenshot/main.roc
@@ -53,7 +53,7 @@ init! = App.init(
 		.with_title("RocRay Capture: Screenshot")
 		.with_size({ width: 720, height: 420 })
 		.with_output_dir("shots"),
-	|_startup|
+	|_io|
 		{
 			font = Draw.default_font!()
 			shot_path = "scene-${Time.now!().to_file_stamp()}.png"
@@ -74,8 +74,8 @@ init! = App.init(
 ## Screenshot saving may wait, so it runs in a Task instead of pausing
 ## `update!`. A Task is work that can wait and later returns one Message through
 ## `App.Input`. The captured pixels still come from the frame that requested it.
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, io| {
 	input = program_input.devices
 	outcome = apply_messages(model.outcome, program_input.messages)
 
@@ -90,13 +90,13 @@ update! = |model, program_input| {
 	settled = outcome != NoCapture
 
 	if escape_requested {
-		Task.spawn!(program_input, || EscapingScreenshotFinished(Capture.screenshot!("../escaped.png")))
+		Task.spawn!(program_input, || EscapingScreenshotFinished(io.capture().screenshot!("../escaped.png")))
 	}
 	if save_requested {
 		# Read out of the model before spawning: the closure captures the name,
 		# and a task cannot reach into the model for it.
 		shot_path = model.shot_path
-		Task.spawn!(program_input, || SavedScreenshotFinished(Capture.screenshot!(shot_path)))
+		Task.spawn!(program_input, || SavedScreenshotFinished(io.capture().screenshot!(shot_path)))
 	}
 
 	if input.key_pressed(KeyEscape) or (settled and program_input.time.cycle_count > 4) or program_input.time.cycle_count > 240 {

--- a/examples/capture_ui_demo/main.roc
+++ b/examples/capture_ui_demo/main.roc
@@ -84,25 +84,32 @@ backspace_frame = 215.U64
 expect backspace_frame > first_type_frame + (List.len(field_text) - 1) * type_every
 expect backspace_frame < recorded_frames
 
-init! : App.Init(Model, [ResourceLimit])
+startup_config = App.default
+	.with_title("RocRay Capture: UI demo")
+	.with_size({ width: 490, height: 380 })
+	.with_frame_pacing(Capped(60))
+	.with_visible(Bool.False)
+	.with_output_dir("captures")
+	.with_recording(
+		Capture.default
+			.with_path("ui_demo.gif")
+			.with_format(Gif)
+			.with_fps(25)
+			.with_max_frames(recorded_frames)
+			.with_scale(Full)
+			.with_timing(FixedStep)
+			.with_cursor(DrawCursor),
+	)
+
+init! : App.Init(Model, [PermissionDenied, ResourceLimit])
 init! = App.init(
-	App.default
-		.with_title("RocRay Capture: UI demo")
-		.with_size({ width: 490, height: 380 })
-		.with_frame_pacing(Capped(60))
-		.with_visible(Bool.False)
-		.with_output_dir("captures")
-		.with_recording(
-			Capture.default
-				.with_path("ui_demo.gif")
-				.with_format(Gif)
-				.with_fps(25)
-				.with_max_frames(recorded_frames)
-				.with_scale(Full)
-				.with_timing(FixedStep)
-				.with_cursor(DrawCursor),
-		),
-	|_startup| {
+	startup_config,
+	|io| {
+		match startup_config.recording() {
+			NoRecording => {}
+			Record(recording) => io.capture().start!(recording)?
+		}
+
 		font = Draw.default_font!()
 		Ok({
 			frame: 0,
@@ -157,8 +164,8 @@ expect field_prefix(List.len(field_text)) == "roc-ray!"
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, _io| {
 	input = program_input.devices
 	# Drive the pointer for the *next* frame from the script.
 	pointer_step = pointer_for_frame(model.frame)

--- a/examples/cave_climb/main.roc
+++ b/examples/cave_climb/main.roc
@@ -133,13 +133,13 @@ air_drag = 0.35.F32
 init! : App.Init(Model, _)
 init! = App.init(
 	App.default.with_title("RocRay Cave Climb").with_frame_pacing(Capped(120)),
-	|_startup| {
-		assets = Assets.Store.open!(Assets.working_directory("examples/cave_climb/assets"))?
+	|io| {
+		assets = io.assets().open!(Assets.working_directory("examples/cave_climb/assets"))?
 		tiles = Assets.load_texture!(assets, "kenney-platformer/spritesheet-tiles-default.png")?
 		characters = Assets.load_texture!(assets, "kenney-platformer/spritesheet-characters-default.png")?
 		enemies_texture = Assets.load_texture!(assets, "kenney-platformer/spritesheet-enemies-default.png")?
 		background = Assets.load_texture!(assets, "kenney-platformer/background_color_hills.png")?
-		raw_map = Tilemap.load_tmx!(map_path)?
+		raw_map = io.tilemaps().load_tmx!(map_path)?
 
 		tilemap = Tilemap.from_raw(raw_map)
 			.with_tileset_texture(
@@ -756,8 +756,8 @@ advance_world = |level, world, move_axis, jump_pressed, input, dt| {
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, _io| {
 	input = program_input.devices
 
 	restart = input.key_pressed(KeySpace)

--- a/examples/drop_viewer/main.roc
+++ b/examples/drop_viewer/main.roc
@@ -49,7 +49,7 @@ init! = App.init(
 		.with_title("RocRay Drop Viewer")
 		.with_size({ width: 900, height: 620 })
 		.with_frame_pacing(Capped(120)),
-	|_startup| {
+	|_io| {
 		font = Draw.default_font!()
 		Ok({
 			font,
@@ -65,13 +65,13 @@ init! = App.init(
 	},
 )
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, input, io| {
 	# One dropped path starts one read. If several files are dropped, the app
 	# displays the result whose message arrives last.
 	List.for_each!(
 		input.dropped,
-		|drop| Task.spawn!(input, || Opened(drop.path, drop.position, Files.read_bytes!(drop.path))),
+		|drop| Task.spawn!(input, || Opened(drop.path, drop.position, io.files().read_bytes!(drop.path))),
 	)
 
 	requested = match List.last(input.dropped) {
@@ -122,6 +122,7 @@ describe_read : Files.ReadBytesError -> Str
 describe_read = |reason|
 	match reason {
 		NotFound => "not found"
+		PermissionDenied => "file access was not granted"
 		ReadFailed => "could not be read"
 		Busy => "the host was busy"
 		Unavailable => "reads are unavailable"

--- a/examples/generated_assets/main.roc
+++ b/examples/generated_assets/main.roc
@@ -114,10 +114,15 @@ initial_pixels = List.map_with_index(
 	},
 )
 
-init! : App.Init(Model, [PixelCountMismatch, ResourceLimit, SoundGenerationFailed, TextureGenerationFailed])
+init! : App.Init(Model, [PermissionDenied, PixelCountMismatch, ResourceLimit, SoundGenerationFailed, TextureGenerationFailed])
 init! = App.init_for_args(
 	generated_assets_config,
-	|startup| {
+	|io| {
+		match generated_assets_config(io.args!()).recording() {
+			NoRecording => {}
+			Record(recording) => io.capture().start!(recording)?
+		}
+
 		font = Draw.default_font!()
 		texture = Assets.generate_color_texture!({ width: 16, height: 16, color: Color.white })?
 		Assets.update_texture!(texture, initial_pixels)?
@@ -132,7 +137,7 @@ init! = App.init_for_args(
 			palette: 1,
 			last_cell: Idle,
 			mouse: { x: 0, y: 0 },
-			demo: List.contains(App.args!(startup), record_demo_flag),
+			demo: List.contains(io.args!(), record_demo_flag),
 			demo_frame: 0,
 			ui: Box.box({
 				title: Text.from("Pixel Workshop", font).size(26).prepare!()?,
@@ -316,8 +321,8 @@ perform_edit! = |texture, edit| {
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, _io| {
 	input = if model.demo demo_input(model.demo_frame) else program_input.devices
 
 	next = update_editor(model, input)

--- a/examples/hello_world/main.roc
+++ b/examples/hello_world/main.roc
@@ -33,15 +33,14 @@ Layout : {
 
 program = { init!, update!, render! }
 
-init! : App.Init(Model, [AssetPathInvalid, AssetNotFound, AssetReadFailed, FontLoadFailed, ResourceLimit])
+init! : App.Init(Model, [ResourceLimit])
 init! = App.init(
 	App.default
 		.with_title("Hello RocRay")
 		.with_size({ width: 800, height: 600 })
-		.with_frame_pacing(Capped(120))
-		.with_default_font({ path: "examples/live_plot/assets/fonts/LiberationSans-Regular.ttf", size: 38 }),
-	|startup| {
-		font = startup.default_font!()?
+		.with_frame_pacing(Capped(120)),
+	|_io| {
+		font = Draw.default_font!()
 		Ok({
 			title: Text.from("Roc :heart: Raylib", font).size(38).prepare!()?,
 			help: Text.from("Move the pointer  -  click for an accent  -  ESC exits", font).size(18).prepare!()?,
@@ -58,8 +57,8 @@ init! = App.init(
 ## tasks answer with; see the `task_sleep` and `async_read` examples.
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, _io| {
 	input = program_input.devices
 	if input.key_pressed(KeyEscape) {
 		Err(Exit(0))

--- a/examples/http_fetch/main.roc
+++ b/examples/http_fetch/main.roc
@@ -69,9 +69,9 @@ program = { init!, update!, render! }
 init! : App.Init(Model, [ResourceLimit])
 init! = App.init_for_args(
 	|_args| App.default.with_title("RocRay HTTP Fetch").with_size({ width: 900, height: 640 }).with_frame_pacing(Capped(60)),
-	|startup| {
+	|io| {
 		font = Draw.default_font!()
-		url = chosen_url(App.args!(startup), App.read_env!(startup, "ROC_RAY_HTTP_URL"))
+		url = chosen_url(io.args!(), io.env().read!("ROC_RAY_HTTP_URL"))
 		Ok({
 			url,
 			state: Waiting,
@@ -106,8 +106,8 @@ chosen_url = |args, from_env| {
 	}
 }
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, input, io| {
 	elapsed = model.elapsed + input.time.elapsed_seconds
 
 	# Cycle 0 starts the first fetch; R starts another one. Both are the same
@@ -122,7 +122,8 @@ update! = |model, input| {
 	if refetch {
 		url = model.url
 		id = fetch
-		Task.spawn!(input, || fetch!(id, url))
+		http = io.http()
+		Task.spawn!(input, || fetch!(http, id, url))
 	}
 
 	if input.devices.key_pressed(KeyEscape) {
@@ -145,14 +146,15 @@ update! = |model, input| {
 ## string: `get_utf8!` takes an already-validated `Url`, which is what a quoted
 ## literal in the source becomes. `send!` does the parsing itself and reports
 ## `InvalidUrl` when the string is not one.
-fetch! : U64, Str => Msg
-fetch! = |id, url|
-	match Http.send!(Request.from_method(GET).with_uri(url)) {
+fetch! : Http.Client, U64, Str => Msg
+fetch! = |http, id, url|
+	match http.send!(Request.from_method(GET).with_uri(url)) {
 		Ok(response) =>
 			match Str.from_utf8(Response.body(response)) {
 				Ok(body) => Arrived(id, Response.status(response), body)
 				Err(_) => Broke(id, "the response body was not valid UTF-8")
 			}
+		Err(PermissionDenied) => Broke(id, "HTTP access was not granted")
 		Err(InvalidUrl(_)) => Broke(id, "that is not a URL this platform will fetch")
 		Err(HttpErr(Timeout)) => Broke(id, "the request timed out")
 		Err(HttpErr(NetworkError)) => Broke(id, "the request failed at the network layer")

--- a/examples/input_inspector/main.roc
+++ b/examples/input_inspector/main.roc
@@ -34,7 +34,7 @@ Model : {
 	## The frame this view describes. An input inspector's whole job is to show
 	## the snapshot, so here the snapshot genuinely is the model.
 	##
-	## `init!` cannot supply one: `App.Startup` is authority, and nothing has
+	## `init!` cannot supply one: `App.Io` is authority, and nothing has
 	## been sampled before the first cycle. `Devices.empty` is that "nothing" as a
 	## value -- every list empty, the pointer at the origin, and every receiver
 	## answering `False` rather than crashing.
@@ -79,7 +79,7 @@ program = { init!, update!, render! }
 Msg : []
 
 ## What a clipboard read can come back with.
-Paste : Try(Str, [Unavailable, TooLarge, Busy])
+Paste : Try(Str, [PermissionDenied, Unavailable, TooLarge, Busy])
 
 init! : App.Init(Model, [ResourceLimit])
 init! = App.init(
@@ -91,7 +91,7 @@ init! = App.init(
 	# below could never light up. Q exits instead.
 		.with_exit_key(NoExitKey)
 		.with_frame_pacing(Capped(120)),
-	|_startup| {
+	|_io| {
 		font = Draw.default_font!()
 		Ok({
 			font,
@@ -151,8 +151,8 @@ ascii_typed = |codepoints|
 ## answers immediately -- the windowing backend hands over a pointer on the
 ## window's own thread -- so its result feeds the frame that asked for it and
 ## nothing has to be carried across a cycle boundary.
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, io| {
 	input = program_input.devices
 
 	ctrl_held = input.key_down(KeyLeftControl) or input.key_down(KeyRightControl)
@@ -161,11 +161,14 @@ update! = |model, program_input| {
 
 	# One chain, so two shortcuts pressed together still resolve in this order.
 	clipboard = if ctrl_held and input.key_pressed(KeyC) {
-		Window.set_clipboard_text!(buffered)
-		{ typed: buffered, clipboard_status: "copied to clipboard" }
+		status = match io.clipboard().set_text!(buffered) {
+			Ok({}) => "copied to clipboard"
+			Err(PermissionDenied) => "clipboard access was not granted"
+		}
+		{ typed: buffered, clipboard_status: status }
 	} else if ctrl_held and input.key_pressed(KeyV) {
 		# The read returns its answer, so the pasted text lands on this frame.
-		apply_paste({ typed: buffered, clipboard_status: model.clipboard_status }, Window.read_clipboard!())
+		apply_paste({ typed: buffered, clipboard_status: model.clipboard_status }, io.clipboard().read_text!())
 	} else if ctrl_held and input.key_pressed(KeyX) {
 		{ typed: "", clipboard_status: "cleared" }
 	} else if ctrl_held and input.key_pressed(KeyE) {
@@ -209,7 +212,7 @@ update! = |model, program_input| {
 			model.events_line
 		} else {
 			line = describe_events(input.events, input.events_overflow)
-			_ = Stdout.line!(line)
+			_ = io.stdout().line!(line)
 			line
 		}
 
@@ -311,6 +314,7 @@ apply_paste = |state, result|
 		Ok(text) => { typed: Str.concat(state.typed, text), clipboard_status: "pasted from clipboard" }
 		# One error covers an empty clipboard and non-text content alike; the
 		# windowing backend does not tell them apart.
+		Err(PermissionDenied) => { ..state, clipboard_status: "clipboard access was not granted" }
 		Err(Unavailable) => { ..state, clipboard_status: "clipboard has no text" }
 		Err(TooLarge) => { ..state, clipboard_status: "clipboard holds too much text to paste" }
 		Err(Busy) => { ..state, clipboard_status: "host was busy -- press Ctrl+V again" }

--- a/examples/live_plot/main.roc
+++ b/examples/live_plot/main.roc
@@ -685,11 +685,11 @@ walk_root : Str
 walk_root = "."
 
 ## Run one unit of work as a task. The only effectful line in the walk.
-start_work! : App.Input(Msg), Work => {}
-start_work! = |input, work|
+start_work! : Files.Access, App.Input(Msg), Work => {}
+start_work! = |files, input, work|
 	match work {
-		ListDir(path) => Task.spawn!(input, || Listed(path, Files.list!(path)))
-		ReadFile(path, slot) => Task.spawn!(input, || FileRead(path, slot, Files.read_bytes!(path)))
+		ListDir(path) => Task.spawn!(input, || Listed(path, files.list!(path)))
+		ReadFile(path, slot) => Task.spawn!(input, || FileRead(path, slot, files.read_bytes!(path)))
 	}
 
 ## Turn one directory's entries into the work they imply.
@@ -752,6 +752,7 @@ describe_list_error = |reason|
 	match reason {
 		NotFound => "not found"
 		NotADirectory => "not a directory"
+		PermissionDenied => "file access was not granted"
 		ReadFailed => "read failed"
 		Busy => "host busy"
 		Unavailable => "listings unavailable"
@@ -762,6 +763,7 @@ describe_read_error : Files.ReadBytesError -> Str
 describe_read_error = |reason|
 	match reason {
 		NotFound => "not found"
+		PermissionDenied => "file access was not granted"
 		ReadFailed => "read failed"
 		Busy => "host busy"
 		Unavailable => "reads unavailable"
@@ -1599,7 +1601,12 @@ other_mode = |mode|
 init! : App.Init(Model, _)
 init! = App.init_for_args(
 	live_plot_config,
-	|startup| {
+	|io| {
+		match live_plot_config(io.args!()).recording() {
+			NoRecording => {}
+			Record(recording) => io.capture().start!(recording)?
+		}
+
 		# Two sizes of the same face rather than one scaled about. A glyph atlas
 		# is rasterised at the size it is loaded at, so a masthead drawn from a
 		# 15-pixel atlas is soft and a table label drawn from a 34-pixel one is
@@ -1625,7 +1632,7 @@ init! = App.init_for_args(
 				.prepare!()?
 
 		Ok({
-			demo: List.contains(App.args!(startup), record_demo_flag),
+			demo: List.contains(io.args!(), record_demo_flag),
 			glow: glow,
 			queue: WorkQueue.new(),
 			walk: { dirs_found: 0, dirs_listed: 0, dirs_failed: 0, files_found: 0, files_skipped: 0, bytes_read: 0 },
@@ -1664,8 +1671,8 @@ init! = App.init_for_args(
 sprite_of : Model -> Draw.Texture
 sprite_of = |model| model.glow.texture()
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, io| {
 	update_zone = Trace.begin!("update live plot")
 	# 1. Fold this cycle's completions in. Each one ends a task this update
 	#    started, so each one frees a slot -- and a listing may enqueue a great
@@ -1731,7 +1738,7 @@ update! = |model, program_input| {
 		}
 
 	for work in ready.starting {
-		start_work!(program_input, work)
+		start_work!(io.files(), program_input, work)
 	}
 
 	exit =

--- a/examples/particles/main.roc
+++ b/examples/particles/main.roc
@@ -152,10 +152,15 @@ initial_particles = List.map_with_index(
 	},
 )
 
-init! : App.Init(Model, [ResourceLimit, TextureGenerationFailed])
+init! : App.Init(Model, [PermissionDenied, ResourceLimit, TextureGenerationFailed])
 init! = App.init_for_args(
 	particles_config,
-	|startup| {
+	|io| {
+		match particles_config(io.args!()).recording() {
+			NoRecording => {}
+			Record(recording) => io.capture().start!(recording)?
+		}
+
 		sprite = Assets.generate_color_texture!({ width: 8, height: 8, color: Color.white })?
 		font = Draw.default_font!()
 		Ok({
@@ -163,13 +168,13 @@ init! = App.init_for_args(
 			particles: initial_particles,
 			instances: List.map(initial_particles, Particle.to_instance),
 			hud: Text.from("4000 sprites, one hosted call - Space widens the spray, ESC quits", font).size(18).prepare!()?,
-			demo: List.contains(App.args!(startup), record_demo_flag),
+			demo: List.contains(io.args!(), record_demo_flag),
 		})
 	},
 )
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, _io| {
 	input = program_input.devices
 	# A long first frame or a resize stall must not teleport the fountain.
 	dt = F32.min(program_input.time.elapsed_seconds, 0.05)

--- a/examples/pong/main.roc
+++ b/examples/pong/main.roc
@@ -193,7 +193,7 @@ program = { init!, update!, render! }
 init! : App.Init(Model, [ResourceLimit, SoundGenerationFailed])
 init! = App.init(
 	App.default.with_title("RocRay Pong").with_size({ width: 800, height: 600 }),
-	|startup| {
+	|io| {
 		# Generate and prepare every host resource before the first cycle.
 		font = Draw.default_font!()
 		# Only scores 0..win_score can ever be shown, so the whole scoreboard is
@@ -225,7 +225,7 @@ init! = App.init(
 			# model state that `update!` advances without an effect, so this
 			# whole run reproduces from the one number below. Replace it with
 			# a constant to get the same game every time.
-			rng: Random.seed(U64.to_u32_wrap(App.entropy!(startup))),
+			rng: Random.seed(U64.to_u32_wrap(io.entropy!())),
 		}
 
 		Ok({ assets, world: new_match(world_seed) })
@@ -245,8 +245,8 @@ play_event! = |assets, event|
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, _io| {
 	controls = read_controls(program_input.devices)
 
 	# Seconds since the previous frame - the basis for all motion this frame.

--- a/examples/post_process/main.roc
+++ b/examples/post_process/main.roc
@@ -34,11 +34,11 @@ program = { init!, update!, render! }
 init! : App.Init(Model, _)
 init! = App.init(
 	App.default.with_title("RocRay Offscreen Post-processing").with_size({ width: 800, height: 600 }),
-	|_host| {
+	|io| {
 
 		## This source tree example deliberately opts into CWD-relative assets.
 		## Packaged applications normally use `Assets.beside_executable("assets")`.
-		assets = Assets.Store.open!(Assets.working_directory("examples/post_process/assets"))?
+		assets = io.assets().open!(Assets.working_directory("examples/post_process/assets"))?
 		font = Draw.default_font!()
 		target = Draw.RenderTexture.load!({ width: 800, height: 600 })?
 		shader = Draw.Shader.from_store!(assets, { vertex_path: "", fragment_path: "post_process.fs" })?
@@ -56,8 +56,8 @@ init! = App.init(
 ## the draws it precedes.
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input|
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, _io|
 	if program_input.devices.key_pressed(KeyEscape) {
 		Err(Exit(0))
 	} else {

--- a/examples/postcard_studio/main.roc
+++ b/examples/postcard_studio/main.roc
@@ -80,10 +80,15 @@ postcard_config = |args| {
 	}
 }
 
-init! : App.Init(Model, [ResourceLimit, RenderTextureLoadFailed])
+init! : App.Init(Model, [PermissionDenied, ResourceLimit, RenderTextureLoadFailed])
 init! = App.init_for_args(
 	postcard_config,
-	|startup| {
+	|io| {
+		match postcard_config(io.args!()).recording() {
+			NoRecording => {}
+			Record(recording) => io.capture().start!(recording)?
+		}
+
 		font = Draw.default_font!()
 		idle = Text.from("Ready to export 1440x960", font).size(14).prepare!()?
 		Ok({
@@ -102,13 +107,13 @@ init! = App.init_for_args(
 			theme: 0,
 			sun: { x: 520, y: 170 },
 			status: idle,
-			demo: List.contains(App.args!(startup), record_demo_flag),
+			demo: List.contains(io.args!(), record_demo_flag),
 		})
 	},
 )
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, io| {
 	input = program_input.devices
 	chrome = Box.unbox(model.chrome)
 	resolved = List.fold(
@@ -148,7 +153,7 @@ update! = |model, program_input| {
 	}
 
 	if save {
-		Task.spawn!(program_input, || PostcardExported(Capture.screenshot_texture!(next.poster, "sunrise.png")))
+		Task.spawn!(program_input, || PostcardExported(io.capture().screenshot_texture!(next.poster, "sunrise.png")))
 	}
 
 	if resolved.demo {

--- a/examples/projective_texture/main.roc
+++ b/examples/projective_texture/main.roc
@@ -75,7 +75,7 @@ initial_corners = {
 init! : App.Init(Model, [ResourceLimit, TextureGenerationFailed, NonFiniteQuad, DegenerateQuad, NonConvexQuad, ProjectiveHorizon])
 init! = App.init(
 	App.default.with_title("Projective Texture").with_frame_pacing(Capped(120)),
-	|_startup| {
+	|_io| {
 		texture = Assets.generate_checked_texture!({
 			width: 512,
 			height: 512,
@@ -94,8 +94,8 @@ init! = App.init(
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, _io| {
 	dragged = model.drag_corner(program_input.devices)
 	Mouse.set_cursor!(dragged.cursor)
 	Ok({ ..dragged.model, elapsed: model.elapsed + program_input.time.elapsed_seconds })

--- a/examples/responsive_ui/main.roc
+++ b/examples/responsive_ui/main.roc
@@ -114,10 +114,15 @@ responsive_config = |args| {
 	}
 }
 
-init! : App.Init(Model, [ResourceLimit])
+init! : App.Init(Model, [PermissionDenied, ResourceLimit])
 init! = App.init_for_args(
 	responsive_config,
-	|startup| {
+	|io| {
+		match responsive_config(io.args!()).recording() {
+			NoRecording => {}
+			Record(recording) => io.capture().start!(recording)?
+		}
+
 		font = Draw.default_font!()
 		Ok({
 			ui: Box.box({
@@ -137,7 +142,7 @@ init! = App.init_for_args(
 			simulation_nanos: 0,
 			monitors: Window.monitors!(),
 			monitor_choice: 0,
-			demo: List.contains(App.args!(startup), record_demo_flag),
+			demo: List.contains(io.args!(), record_demo_flag),
 		})
 	},
 )
@@ -320,8 +325,8 @@ Layout := {
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, _io| {
 	input = program_input.devices
 
 	# Layout follows the window, pointing follows the mouse, and the preview

--- a/examples/snake/main.roc
+++ b/examples/snake/main.roc
@@ -32,8 +32,8 @@ program = { init!, update!, render! }
 init! : App.Init(Model, [ResourceLimit, SoundGenerationFailed])
 init! = App.init(
 	App.default.with_title("RocRay Snake").with_size({ width: 800, height: 600 }).with_frame_pacing(Capped(120)),
-	|startup| {
-		rng = Random.seed(U64.to_u32_wrap(App.entropy!(startup)))
+	|io| {
+		rng = Random.seed(U64.to_u32_wrap(io.entropy!()))
 		Ok({ assets: Assets.load!()?, world: Game.new_world(rng), elapsed: 0 })
 	},
 )
@@ -68,8 +68,8 @@ play_event! = |assets, event|
 Msg : []
 
 ## Advances pure rules, plays their events, and handles the quit control.
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, _io| {
 	controls = read_controls(program_input.devices)
 	dt = Math.clamp(program_input.time.elapsed_seconds, 0, 0.25)
 	(world, events) = Game.update(model.world, controls, dt)

--- a/examples/sqlite_scores/main.roc
+++ b/examples/sqlite_scores/main.roc
@@ -78,12 +78,12 @@ program = { init!, update!, render! }
 init! : App.Init(Model, [ResourceLimit, ..])
 init! = App.init(
 	App.default.with_title("RocRay SQLite Scores").with_size({ width: 880, height: 560 }).with_frame_pacing(Capped(60)),
-	|startup| {
+	|io| {
 		# A write builds the tree on its way, which is how the directory the
 		# database lives in comes to exist.
-		_ = Files.write_bytes!("${db_dir}/.keep", [])
+		_ = io.files().write_bytes!("${db_dir}/.keep", [])
 
-		rng = Random.seed(U64.to_u32_wrap(App.entropy!(startup)))
+		rng = Random.seed(U64.to_u32_wrap(io.entropy!()))
 		font = Draw.default_font!()
 		title = Text.from("High scores that outlive the process", font).size(26).prepare!()?
 		subtitle = Text.from("the write and the re-read share one task, so the board is told what the database holds", font).size(15).prepare!()?
@@ -92,7 +92,7 @@ init! = App.init(
 		# A store that will not open is shown rather than fatal: the stub
 		# handles keep the model well-formed, every later call through them
 		# answers `Misuse`, and the status line says what went wrong.
-		match open_board!() {
+		match open_board!(io) {
 			Err(reason) =>
 				Ok({
 					db: Sqlite.Db.stub,
@@ -126,9 +126,9 @@ init! = App.init(
 )
 
 ## Open the store and read the first board. Waits, which `init!` permits.
-open_board! : () => Try({ db : Sqlite.Db, insert : Sqlite.Stmt, rows : List(Entry) }, Str)
-open_board! = || {
-	db = Sqlite.Db.open!(db_path) ? |err| describe(err)
+open_board! : App.Io => Try({ db : Sqlite.Db, insert : Sqlite.Stmt, rows : List(Entry) }, Str)
+open_board! = |io| {
+	db = io.sqlite().open!(db_path) ? |err| describe(err)
 	Sqlite.exec_script!(db, schema) ? |err| describe(err)
 	insert = Sqlite.prepare!(db, insert_run) ? |err| describe(err)
 	rows = read_board!(db)?
@@ -281,8 +281,8 @@ next_run = |state| {
 	}
 }
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, input, _io| {
 	folded = List.fold(input.messages, { ..model, elapsed: model.elapsed + input.time.elapsed_seconds }, apply_message)
 
 	if input.devices.key_pressed(KeyEscape) {

--- a/examples/task_sleep/main.roc
+++ b/examples/task_sleep/main.roc
@@ -38,7 +38,7 @@ program = { init!, update!, render! }
 init! : App.Init(Model, [ResourceLimit])
 init! = App.init(
 	App.default.with_title("RocRay Task Sleep").with_frame_pacing(Capped(60)),
-	|_host| {
+	|_io| {
 		font = Draw.default_font!()
 		Ok({
 			state: Waiting,
@@ -51,8 +51,8 @@ init! = App.init(
 	},
 )
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, input, io| {
 	cycle = input.time.cycle_count
 	settled = List.fold(input.messages, model.state, |current, message| apply_message(current, message, cycle))
 	if cycle == 0 {
@@ -68,7 +68,7 @@ update! = |model, input| {
 			},
 		)
 		# Printed from `update!` too, one line before any of the waiting starts.
-		_ = Stdout.line!(start_line)
+		_ = io.stdout().line!(start_line)
 	}
 
 	match settled {
@@ -76,7 +76,7 @@ update! = |model, input| {
 			# The line is queued here and written by the host's own thread, so
 			# exiting on the next expression does not race it out of the
 			# process: shutdown drains the queue.
-			_ = Stdout.line!(report_line(arrived_on))
+			_ = io.stdout().line!(report_line(arrived_on))
 			Err(Exit(0))
 		}
 		Waiting =>

--- a/examples/top_down/GameAssets.roc
+++ b/examples/top_down/GameAssets.roc
@@ -1,4 +1,5 @@
 ## Spark Run textures, font, music, and sound effects loaded at startup.
+import rr.App
 import rr.Assets
 import rr.Audio
 import rr.Draw
@@ -22,12 +23,12 @@ GameAssets := {
 	}
 
 	## Loads every texture, font, sound, and music stream before the first frame.
-	load! = || {
-		store = Assets.Store.open!(Assets.working_directory("examples/top_down/assets"))?
+	load! = |io| {
+		store = io.assets().open!(Assets.working_directory("examples/top_down/assets"))?
 		characters = Assets.load_texture!(store, "kenney-topdown/characters.png")?
 		tiles = Assets.load_texture!(store, "kenney-topdown/tiles.png")?
 		font = Draw.default_font!()
-		sounds = load_sounds!()?
+		sounds = load_sounds!(io)?
 		Ok({ characters, tiles, font, sounds })
 	}
 }
@@ -54,23 +55,23 @@ make_sound! = |waveform, from, to, ms, volume|
 	Audio.gen_sound!({ waveform, freq_start: from, freq_end: to, ms, attack_ms: 2, decay_ms: 24, sustain: 0.45, release_ms: 45, volume })
 
 ## Loads a sound file or retains its generated fallback.
-load_sound_or! : Str, Audio.Sound => Audio.Sound
-load_sound_or! = |path, fallback|
-	match Audio.load_sound!(path) {
+load_sound_or! : App.Io, Str, Audio.Sound => Audio.Sound
+load_sound_or! = |io, path, fallback|
+	match io.audio().load_sound!(path) {
 		Ok(sound) => sound
 		Err(_) => fallback
 	}
 
 ## Loads the complete sound set and configures looping background music.
-load_sounds! = || {
-	collect = load_sound_or!(collect_path, make_sound!(Sine, 880, 1160, 110, 0.55)?)
-	hurt = load_sound_or!(hurt_path, make_sound!(Noise, 180, 70, 220, 0.7)?)
-	win = load_sound_or!(win_path, make_sound!(Square, 640, 1280, 520, 0.45)?)
-	lose = load_sound_or!(lose_path, make_sound!(Saw, 120, 45, 520, 0.5)?)
-	gate = load_sound_or!(gate_path, make_sound!(Square, 220, 390, 240, 0.45)?)
-	dash = load_sound_or!(dash_path, make_sound!(Noise, 520, 120, 130, 0.38)?)
+load_sounds! = |io| {
+	collect = load_sound_or!(io, collect_path, make_sound!(Sine, 880, 1160, 110, 0.55)?)
+	hurt = load_sound_or!(io, hurt_path, make_sound!(Noise, 180, 70, 220, 0.7)?)
+	win = load_sound_or!(io, win_path, make_sound!(Square, 640, 1280, 520, 0.45)?)
+	lose = load_sound_or!(io, lose_path, make_sound!(Saw, 120, 45, 520, 0.5)?)
+	gate = load_sound_or!(io, gate_path, make_sound!(Square, 220, 390, 240, 0.45)?)
+	dash = load_sound_or!(io, dash_path, make_sound!(Noise, 520, 120, 130, 0.38)?)
 	sparkle = make_sound!(Sine, 980, 1620, 140, 0.36)?
-	music = Audio.load_music!(music_path)?
+	music = io.audio().load_music!(music_path)?
 	music.set_volume!(music_volume)
 	music.set_looping!(Bool.True)
 	Ok({ collect, hurt, win, lose, gate, dash, sparkle, music })

--- a/examples/top_down/Level.roc
+++ b/examples/top_down/Level.roc
@@ -1,4 +1,5 @@
 ## Static arena data loaded from Tiled, with a complete fallback layout.
+import rr.App
 import rr.Color
 import rr.Draw
 import rr.Math
@@ -48,8 +49,8 @@ Level := {
 	}
 
 	## Loads the authored Tiled map and binds its visible layers to the tile texture.
-	load! = |tiles| {
-		raw_map = Tilemap.load_tmx!("examples/top_down/assets/top_down.tmx")?
+	load! = |io, tiles| {
+		raw_map = io.tilemaps().load_tmx!("examples/top_down/assets/top_down.tmx")?
 		tilemap = Tilemap.from_raw(raw_map)
 			.with_origin({ x: world_left, y: world_top })
 			.with_tileset_texture(1, tiles)

--- a/examples/top_down/main.roc
+++ b/examples/top_down/main.roc
@@ -84,11 +84,16 @@ top_down_config = |args| {
 init! : App.Init(Model, _)
 init! = App.init_for_args(
 	top_down_config,
-	|startup| {
-		assets = GameAssets.load!()?
-		level = Level.load!(assets.tiles)?
+	|io| {
+		match top_down_config(io.args!()).recording() {
+			NoRecording => {}
+			Record(recording) => io.capture().start!(recording)?
+		}
+
+		assets = GameAssets.load!(io)?
+		level = Level.load!(io, assets.tiles)?
 		assets.sounds.music.play!()
-		Ok({ assets, level, world: Game.new(level), demo: List.contains(App.args!(startup), record_demo_flag), demo_frame: 0 })
+		Ok({ assets, level, world: Game.new(level), demo: List.contains(io.args!(), record_demo_flag), demo_frame: 0 })
 	},
 )
 
@@ -167,8 +172,8 @@ play_event! = |assets, level, previous_world, world, event| {
 Msg : []
 
 ## Advances pure gameplay, performs its events, and handles capture or quit.
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, _io| {
 	controls = if model.demo demo_controls(model.demo_frame) else read_controls(program_input.devices)
 	dt = program_input.time.elapsed_seconds
 	(world, events) = Game.update(model.level, model.world, controls, dt)

--- a/examples/udp_cursor/main.roc
+++ b/examples/udp_cursor/main.roc
@@ -42,11 +42,11 @@ program = { init!, update!, render! }
 init! : App.Init(Model, [ResourceLimit, BindFailed])
 init! = App.init_for_args(
 	|_args| App.default.with_title("RocRay UDP Cursor").with_frame_pacing(Capped(60)),
-	|startup| {
-		args = App.args!(startup)
+	|io| {
+		args = io.args!()
 		font = Draw.default_font!()
 		port = flag_port(args, "--udp-port", 0)
-		socket = Udp.bind!({ ip: "127.0.0.1", port }) ? |_err| BindFailed
+		socket = io.udp().bind!({ ip: "127.0.0.1", port }) ? |_err| BindFailed
 		local = Udp.Socket.local_address(socket)
 
 		# With no `--udp-peer`, the peer is this instance itself. The datagrams
@@ -68,8 +68,8 @@ init! = App.init_for_args(
 	},
 )
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, input, _io| {
 	# One listener at a time. It answered this cycle, or has never run, so
 	# start the next one; in between, datagrams wait in the kernel's buffer.
 	socket = model.socket

--- a/platform/App.roc
+++ b/platform/App.roc
@@ -19,7 +19,7 @@
 ## Each effect documents its legal phases. Host-state effects are legal in
 ## `init!`, `update!`, and tasks. Drawing effects are legal only in `render!`.
 ## Waiting effects are legal in `init!`, where they block startup, and in tasks,
-## where they park the task. `Capture.screenshot!` is task-only because it
+## where they park the task. `Capture.Writer.screenshot!` is task-only because it
 ## waits for a frame to finish.
 ##
 ## Calling an effect from a phase it does not permit is a programmer error, not
@@ -37,6 +37,15 @@
 ## receivers. Host resource types provide inert `stub` values for constructing
 ## models; stubs cannot test loading or resource lifetime.
 import Host
+import Resource
+import Tilemap
+import Assets
+import Sqlite
+import Udp
+import Stderr
+import Stdout
+import Cmd
+import Http
 import Keys
 import Mouse
 
@@ -79,7 +88,7 @@ App := [].{
 	## handled by starting a task:
 	##
 	## ```roc
-	## Task.spawn!(input, || Opened(Files.read_bytes!(drop.path)))
+	## Task.spawn!(input, || Opened(io.files().read_bytes!(drop.path)))
 	## ```
 	##
 	## `position` is the pointer position the host sampled for the cycle the
@@ -323,12 +332,9 @@ App := [].{
 		with_output_dir : Config, Str -> Config
 		with_output_dir = |cfg, value| { ..cfg, output_dir: value }
 
-		## Return a config that starts recording before the first frame.
-		##
-		## This is how an app captures itself with no runtime code at all, so a
-		## visualization can be rendered straight to a file. The recording
-		## finalizes when it reaches its frame cap, when `Capture.stop!` is
-		## called, or when the app exits.
+		## Store a recording description in the configuration. This is pure data;
+		## start it explicitly with `io.capture().start!(recording)` in `init!`.
+		## Starting requires external authority and may return PermissionDenied.
 		with_recording : Config, Capture.Recording -> Config
 		with_recording = |cfg, value| { ..cfg, recording: Record(value) }
 
@@ -338,7 +344,7 @@ App := [].{
 
 		## Load the startup default font from a working-directory-relative asset
 		## path at the requested base pixel size. The path is validated and loaded
-		## once before `Startup.default_font!` returns it.
+		## once before `Io.default_font!` returns it.
 		with_default_font : Config, { path : Str, size : I32 } -> Config
 		with_default_font = |cfg, value| { ..cfg, default_font: value }
 
@@ -393,210 +399,196 @@ App := [].{
 		default_font = |cfg| cfg.default_font
 	}
 
-	## Opaque, zero-sized authority the host supplies only while it runs `init!`.
-	##
-	## The signature renders as `Startup : Startup` because this is an alias of
-	## an identically named private nominal. There is nothing to construct: the
-	## host hands one to the `init!` callback and that is the only one there is.
-	##
-	## Every effect that takes a `Startup` is legal only in `init!`. Startup
-	## provides one-shot system effects but no input, window, or timing
-	## observations: seed models that require devices with `Devices.empty`, and
-	## the first `App.Input` supplies the first sampled values. After
-	## initialization, change host state by calling effects from `update!`, and
-	## ask for work that waits with `Task.spawn!`.
-	Startup :: Host.AppStartup.{
+	## Application-lifetime authority supplied by the host to init! and update!.
+	## Accessors are pure, allocation-free selections. Keep individual capabilities
+	## in helpers and task closures; effects retain their documented phase rules.
+	Io :: Resource.Authority.{
 
-		## Return the configured startup font. Legal only in `init!`.
-		default_font! : Startup => Try(Font, [AssetPathInvalid, AssetNotFound, AssetReadFailed, FontLoadFailed, ResourceLimit, ..])
-		default_font! = |startup| App.default_font!(startup)
+		## Private adapter construction. The argument cannot be manufactured by applications.
+		for_host : Resource.Authority -> Io
+		for_host = |authority| Io.(authority)
 
-		## Construct the public startup capability at the private host boundary.
-		for_host : Host.AppStartup -> Startup
-		for_host = |startup| Startup.(startup)
+		## IO for pure tests; it never grants access to external services.
+		stub : Io
+		stub = Io.(Resource.Authority.stub)
+
+		## Select files authority without performing an effect.
+		files : Io -> Files.Access
+		files = |Io.(authority)| Files.Access.for_host(authority)
+
+		## Select http authority without performing an effect.
+		http : Io -> Http.Client
+		http = |Io.(authority)| Http.Client.for_host(authority)
+
+		## Select commands authority without performing an effect.
+		commands : Io -> Cmd.Runner
+		commands = |Io.(authority)| Cmd.Runner.for_host(authority)
+
+		## Select stdout authority without performing an effect.
+		stdout : Io -> Stdout.Writer
+		stdout = |Io.(authority)| Stdout.Writer.for_host(authority)
+
+		## Select stderr authority without performing an effect.
+		stderr : Io -> Stderr.Writer
+		stderr = |Io.(authority)| Stderr.Writer.for_host(authority)
+
+		## Select udp authority without performing an effect.
+		udp : Io -> Udp.Network
+		udp = |Io.(authority)| Udp.Network.for_host(authority)
+
+		## Select sqlite authority without performing an effect.
+		sqlite : Io -> Sqlite.Service
+		sqlite = |Io.(authority)| Sqlite.Service.for_host(authority)
+
+		## Select assets authority without performing an effect.
+		assets : Io -> Assets.Loader
+		assets = |Io.(authority)| Assets.Loader.for_host(authority)
+
+		## Select audio authority without performing an effect.
+		audio : Io -> Audio.Loader
+		audio = |Io.(authority)| Audio.Loader.for_host(authority)
+
+		## Select tilemaps authority without performing an effect.
+		tilemaps : Io -> Tilemap.Loader
+		tilemaps = |Io.(authority)| Tilemap.Loader.for_host(authority)
+
+		## Select clipboard authority without performing an effect.
+		clipboard : Io -> Window.Clipboard
+		clipboard = |Io.(authority)| Window.Clipboard.for_host(authority)
+
+		## Select capture authority without performing an effect.
+		capture : Io -> Capture.Writer
+		capture = |Io.(authority)| Capture.Writer.for_host(authority)
+
+		## Select environment access.
+		env : Io -> Environment
+		env = |Io.(authority)| Environment.(authority)
+
+		## Exit the application with the given exit code.
+		##
+		## The exit happens after startup completes, so `init!` finishes and the
+		## host shuts down in the ordinary way. Legal only in `init!`.
+		exit! : Io, I32 => {}
+		exit! = |io, code| app_exit!(io, code)
+
+		## Return the complete process argument list supplied by the launcher.
+		##
+		## The first element is `argv[0]`, followed by application-owned arguments
+		## in order. The host removes its reserved `--host-*` switches before this
+		## list reaches the app. The value is stable for the process lifetime.
+		##
+		## Legal only in `init!`. `App.init_for_args` is the other way to read
+		## argv, before the window exists.
+		args! : Io => List(Str)
+		args! = |io| app_args!(io)
+
+		## Draw one number from the operating system's entropy source.
+		##
+		## This is the only thing in the platform that makes a run differ from the
+		## last one by itself, and it is deliberately the app's decision:
+		##
+		## ```roc
+		## seed = Random.seed(U64.to_u32_wrap(io.entropy!()))
+		## ```
+		##
+		## Keep the returned `Random.State` in the model and draw with pure
+		## `Random.Generator` values during `update!`, so the run is reproducible
+		## from its seed. A run that must reproduce writes a constant seed instead
+		## and never calls this; a run that should vary calls it once. Nothing else
+		## about the platform is affected either way, because the generator's state
+		## is the model's rather than the host's.
+		##
+		## The entropy is real in every mode, including headless: determinism comes
+		## from an app choosing a fixed seed, not from the host quietly handing out
+		## the same "random" number on every run.
+		##
+		## Legal only in `init!`.
+		entropy! : Io => U64
+		entropy! = |io| app_entropy!(io)
+
+		## Get a varying startup number in the inclusive range `[min, max]`.
+		##
+		## Legal only in `init!`. `entropy!` is the one to seed a generator from:
+		## it draws on the operating system rather than on the backend's own
+		## generator, and it says what it is for. This remains for a one-off value
+		## in a range, such as a jittered start position that nothing else depends
+		## on.
+		random_i32! : Io, I32, I32 => I32
+		random_i32! = |io, min, max| app_random_i32!(io, min, max)
+
+		## Suggest positive initial window dimensions to the window manager.
+		##
+		## Answers `Err(NotSupported)` on a target whose windows cannot be resized.
+		## Call as `io.suggest_window_size!(size)`. Legal in `init!`, `update!`, and tasks; refused in `render!`.
+		## A running app resizes itself with `Window.suggest_size!`, which reaches
+		## the same host call, and only this spelling can report a refusal.
+		suggest_window_size! : Io, { width : I32, height : I32 } => Try({}, [InvalidSize, NotSupported, ..])
+		suggest_window_size! = |io, size| app_suggest_window_size!(io, size)
+
+		## Suggest the smallest window size the user can drag the window down to.
+		##
+		## Each negative dimension is clamped to `0`, which leaves that axis
+		## unconstrained. The minimum only applies to a resizable window, so pair it
+		## with `App.default.with_resizable(Bool.True)`. Call as
+		## `io.suggest_window_min_size!(size)`. Legal in `init!`, `update!`, and tasks; refused in `render!`.
+		suggest_window_min_size! : Io, { width : I32, height : I32 } => {}
+		suggest_window_min_size! = |io, size| app_suggest_window_min_size!(io, size)
+
+		## Set raylib's CPU-side frame-rate cap.
+		##
+		## Values at or below zero render uncapped. This neither selects a software
+		## renderer nor controls VSync. Call as `io.set_target_fps!(fps)`.
+		## Legal in `init!`, `update!`, and tasks; refused in `render!`. A running app changes the cap with
+		## `Window.set_target_fps!`.
+		set_target_fps! : Io, I32 => {}
+		set_target_fps! = |io, fps| app_set_target_fps!(io, fps)
+
+		## Set which key closes the window, or `NoExitKey` to stop any key from
+		## closing it.
+		##
+		## raylib defaults to `ExitKey(KeyEscape)`. The window close button is
+		## unaffected either way, so an app that disables the exit key should still
+		## handle shutdown itself by returning `Err(Exit(code))`. Call as
+		## `io.set_exit_key!(NoExitKey)`. Legal in `init!`, `update!`, and tasks; refused in `render!`.
+		set_exit_key! : Io, ExitKey => {}
+		set_exit_key! = |io, key| app_set_exit_key!(io, key)
+
+		## Apply cursor visibility and capture atomically through one tagged
+		## operation. Legal in `init!`, `update!`, and tasks; refused in `render!`. `Mouse.set_cursor_mode!` is the same
+		## change from `update!` or a task.
+		set_cursor_mode! : Io, Mouse.CursorMode => {}
+		set_cursor_mode! = |io, mode| app_set_cursor_mode!(io, mode)
+
+		## Set the native operating-system cursor shape. Legal in `init!`, `update!`, and tasks; refused in `render!`.
+		## `Mouse.set_cursor!` is the same change from `update!` or a task.
+		set_cursor! : Io, Mouse.Cursor => {}
+		set_cursor! = |io, cursor| app_set_cursor!(io, cursor)
+
+		## Return the configured startup font, or the backend's built-in font when
+		## none was configured. A configured path is resolved from the process
+		## working directory. The host loads it once; repeat calls return retained
+		## aliases of the same resource. Legal only in `init!`.
+		## A configured file requires external authority; otherwise PermissionDenied.
+		default_font! : Io => Try(Font, [PermissionDenied, AssetPathInvalid, AssetNotFound, AssetReadFailed, FontLoadFailed, ResourceLimit, ..])
+		default_font! = |io| app_default_font!(io)
 	}
 
-	## Exit the application with the given exit code.
-	##
-	## The exit happens after startup completes, so `init!` finishes and the
-	## host shuts down in the ordinary way. Legal only in `init!`.
-	exit! : Startup, I32 => {}
-	exit! = |_startup, code| Host.app_exit!(code)
+	## Opaque access to startup environment variables.
+	Environment :: Resource.Authority.{
 
-	## Return the complete process argument list supplied by the launcher.
-	##
-	## The first element is `argv[0]`, followed by application-owned arguments
-	## in order. The host removes its reserved `--host-*` switches before this
-	## list reaches the app. The value is stable for the process lifetime.
-	##
-	## Legal only in `init!`. `App.init_for_args` is the other way to read
-	## argv, before the window exists.
-	args! : Startup => List(Str)
-	args! = |_startup| Host.app_args!()
-
-	## Read an environment variable by key.
-	##
-	## Answers `Err(NotFound)` when the variable is not set. Legal only in
-	## `init!`.
-	read_env! : Startup, Str => Try(Str, [NotFound, ..])
-	read_env! = |_startup, key|
-	# closed error union to open error union
-		match Host.app_read_env!(key) {
+		## Read a variable; denied access is `PermissionDenied`. Legal only in `init!`.
+		read! : Environment, Str => Try(Str, [NotFound, PermissionDenied, ..])
+		read! = |Environment.(authority), key| match Host.app_read_env!(authority, key) {
 			Ok(value) => Ok(value)
 			Err(NotFound) => Err(NotFound)
+			Err(PermissionDenied) => Err(PermissionDenied)
 		}
-
-	## Read a UTF-8 text file from disk, blocking until it is read.
-	##
-	## Call as `App.read_text!(startup, path)`. Legal only in `init!`. Use
-	## `Files.read_text!` inside a task to read a file while the app runs, and
-	## for the fuller error report.
-	read_text! : Startup, Str => Try(Str, [NotFound, ReadFailed, ..])
-	read_text! = |_startup, path|
-	# closed error union to open error union
-		match Host.app_read_text!(path) {
-			Ok(contents) => Ok(contents)
-			Err(NotFound) => Err(NotFound)
-			Err(ReadFailed) => Err(ReadFailed)
-		}
-
-	## Draw one number from the operating system's entropy source.
-	##
-	## This is the only thing in the platform that makes a run differ from the
-	## last one by itself, and it is deliberately the app's decision:
-	##
-	## ```roc
-	## seed = Random.seed(U64.to_u32_wrap(App.entropy!(startup)))
-	## ```
-	##
-	## Keep the returned `Random.State` in the model and draw with pure
-	## `Random.Generator` values during `update!`, so the run is reproducible
-	## from its seed. A run that must reproduce writes a constant seed instead
-	## and never calls this; a run that should vary calls it once. Nothing else
-	## about the platform is affected either way, because the generator's state
-	## is the model's rather than the host's.
-	##
-	## The entropy is real in every mode, including headless: determinism comes
-	## from an app choosing a fixed seed, not from the host quietly handing out
-	## the same "random" number on every run.
-	##
-	## Legal only in `init!`.
-	entropy! : Startup => U64
-	entropy! = |_startup| Host.random_entropy!()
-
-	## Get a varying startup number in the inclusive range `[min, max]`.
-	##
-	## Legal only in `init!`. `entropy!` is the one to seed a generator from:
-	## it draws on the operating system rather than on the backend's own
-	## generator, and it says what it is for. This remains for a one-off value
-	## in a range, such as a jittered start position that nothing else depends
-	## on.
-	random_i32! : Startup, I32, I32 => I32
-	random_i32! = |_startup, min, max| Host.random_i32!(min, max)
-
-	## Suggest positive initial window dimensions to the window manager.
-	##
-	## Answers `Err(NotSupported)` on a target whose windows cannot be resized.
-	## Call as `App.suggest_window_size!(startup, size)`. Legal only in `init!`.
-	## A running app resizes itself with `Window.suggest_size!`, which reaches
-	## the same host call, and only this spelling can report a refusal.
-	suggest_window_size! : Startup, { width : I32, height : I32 } => Try({}, [InvalidSize, NotSupported, ..])
-	suggest_window_size! = |_startup, size|
-		if size.width <= 0 or size.height <= 0 {
-			Err(InvalidSize)
-		} else {
-			match Host.window_suggest_size!(size) {
-				Ok({}) => Ok({})
-				Err(NotSupported) => Err(NotSupported)
-			}
-		}
-
-	## Suggest the smallest window size the user can drag the window down to.
-	##
-	## Each negative dimension is clamped to `0`, which leaves that axis
-	## unconstrained. The minimum only applies to a resizable window, so pair it
-	## with `App.default.with_resizable(Bool.True)`. Call as
-	## `App.suggest_window_min_size!(startup, size)`. Legal only in `init!`.
-	suggest_window_min_size! : Startup, { width : I32, height : I32 } => {}
-	suggest_window_min_size! = |_startup, size|
-		Host.window_suggest_min_size!({
-			width: if size.width > 0 size.width else 0,
-			height: if size.height > 0 size.height else 0,
-		})
-
-	## Set raylib's CPU-side frame-rate cap.
-	##
-	## Values at or below zero render uncapped. This neither selects a software
-	## renderer nor controls VSync. Call as `App.set_target_fps!(startup, fps)`.
-	## Legal only in `init!`. A running app changes the cap with
-	## `Window.set_target_fps!`.
-	set_target_fps! : Startup, I32 => {}
-	set_target_fps! = |_startup, fps| Host.window_set_target_fps!(fps)
-
-	## Set which key closes the window, or `NoExitKey` to stop any key from
-	## closing it.
-	##
-	## raylib defaults to `ExitKey(KeyEscape)`. The window close button is
-	## unaffected either way, so an app that disables the exit key should still
-	## handle shutdown itself by returning `Err(Exit(code))`. Call as
-	## `App.set_exit_key!(startup, NoExitKey)`. Legal only in `init!`.
-	set_exit_key! : Startup, ExitKey => {}
-	set_exit_key! = |_startup, key| Host.keys_set_exit_key!(Keys.exit_key_code(key))
-
-	## Read UTF-8 text from the system clipboard.
-	##
-	## Answers `Err(Unavailable)` when the clipboard is empty, holds non-text
-	## content, or the windowing backend refuses the request -- the underlying
-	## platform does not distinguish these cases. Call as
-	## `App.get_clipboard_text!(startup)`. Legal only in `init!`. A running app
-	## reads the clipboard with `Window.read_clipboard!`, which names the
-	## refusals separately.
-	get_clipboard_text! : Startup => Try(Str, [Unavailable, ..])
-	get_clipboard_text! = |_startup|
-		match Host.window_read_clipboard!() {
-			# Startup deliberately collapses every refusal into one outcome.
-			Ok(contents) => Ok(contents)
-			Err(_) => Err(Unavailable)
-		}
-
-	## Replace the system clipboard contents with UTF-8 text.
-	##
-	## Call as `App.set_clipboard_text!(startup, text)`. Legal only in `init!`.
-	## A running app writes it with `Window.set_clipboard_text!`.
-	set_clipboard_text! : Startup, Str => {}
-	set_clipboard_text! = |_startup, text| Host.window_set_clipboard_text!(text)
-
-	## Apply cursor visibility and capture atomically through one tagged
-	## operation. Legal only in `init!`. `Mouse.set_cursor_mode!` is the same
-	## change from `update!` or a task.
-	set_cursor_mode! : Startup, Mouse.CursorMode => {}
-	set_cursor_mode! = |_startup, mode| Host.mouse_set_cursor_mode!(Mouse.cursor_mode_code(mode))
-
-	## Set the native operating-system cursor shape. Legal only in `init!`.
-	## `Mouse.set_cursor!` is the same change from `update!` or a task.
-	set_cursor! : Startup, Mouse.Cursor => {}
-	set_cursor! = |_startup, cursor| Host.mouse_set_cursor!(Mouse.cursor_code(cursor))
-
-	## Return the configured startup font, or the backend's built-in font when
-	## none was configured. A configured path is resolved from the process
-	## working directory. The host loads it once; repeat calls return retained
-	## aliases of the same resource. Legal only in `init!`.
-	default_font! : Startup => Try(Font, [AssetPathInvalid, AssetNotFound, AssetReadFailed, FontLoadFailed, ResourceLimit, ..])
-	default_font! = |_startup|
-	# closed error union to open error union
-		match Host.text_startup_default_font!() {
-			Ok(font) => Ok(font)
-			Err(AssetPathInvalid) => Err(AssetPathInvalid)
-			Err(AssetNotFound) => Err(AssetNotFound)
-			Err(AssetReadFailed) => Err(AssetReadFailed)
-			Err(FontLoadFailed) => Err(FontLoadFailed)
-			Err(ResourceLimit) => Err(ResourceLimit)
-		}
+	}
 
 	## Effectful startup callback run after the host has initialized raylib and
 	## audio. Return `Ok(model)` to start the app, `Err(Exit(code))` to quit
 	## before the first frame, or let other initialization errors propagate.
-	InitCallback(model, errors) : Startup => Try(model, [Exit(I64), ..errors])
+	InitCallback(model, errors) : Io => Try(model, [Exit(I64), ..errors])
 
 	## Pure startup configuration chosen from the complete process argv before
 	## the host creates its native window. This is where an app can opt into a
@@ -793,3 +785,59 @@ expect counter_step(fresh_counter, neutral_input) == Continue(fresh_counter)
 
 ## Delivered messages are folded in, in the order the input carries them.
 expect counter_step(fresh_counter, neutral_input.with_messages([Tick, Tick, Tick])) == Continue({ ticks: 3, quitting: Bool.False })
+
+## Private IO implementations.
+app_exit! : App.Io, I32 => {}
+app_exit! = |_startup, code| Host.app_exit!(code)
+
+app_args! : App.Io => List(Str)
+app_args! = |_startup| Host.app_args!()
+
+app_entropy! : App.Io => U64
+app_entropy! = |_startup| Host.random_entropy!()
+
+app_random_i32! : App.Io, I32, I32 => I32
+app_random_i32! = |_startup, min, max| Host.random_i32!(min, max)
+
+app_suggest_window_size! : App.Io, { width : I32, height : I32 } => Try({}, [InvalidSize, NotSupported, ..])
+app_suggest_window_size! = |_startup, size|
+	if size.width <= 0 or size.height <= 0 {
+		Err(InvalidSize)
+	} else {
+		match Host.window_suggest_size!(size) {
+			Ok({}) => Ok({})
+			Err(NotSupported) => Err(NotSupported)
+		}
+	}
+
+app_suggest_window_min_size! : App.Io, { width : I32, height : I32 } => {}
+app_suggest_window_min_size! = |_startup, size|
+	Host.window_suggest_min_size!({
+		width: if size.width > 0 size.width else 0,
+		height: if size.height > 0 size.height else 0,
+	})
+
+app_set_target_fps! : App.Io, I32 => {}
+app_set_target_fps! = |_startup, fps| Host.window_set_target_fps!(fps)
+
+app_set_exit_key! : App.Io, App.ExitKey => {}
+app_set_exit_key! = |_startup, key| Host.keys_set_exit_key!(Keys.exit_key_code(key))
+
+app_set_cursor_mode! : App.Io, Mouse.CursorMode => {}
+app_set_cursor_mode! = |_startup, mode| Host.mouse_set_cursor_mode!(Mouse.cursor_mode_code(mode))
+
+app_set_cursor! : App.Io, Mouse.Cursor => {}
+app_set_cursor! = |_startup, cursor| Host.mouse_set_cursor!(Mouse.cursor_code(cursor))
+
+app_default_font! : App.Io => Try(Font, [PermissionDenied, AssetPathInvalid, AssetNotFound, AssetReadFailed, FontLoadFailed, ResourceLimit, ..])
+app_default_font! = |App.Io.(authority)|
+# closed error union to open error union
+	match Host.text_startup_default_font!(authority) {
+		Ok(font) => Ok(font)
+		Err(PermissionDenied) => Err(PermissionDenied)
+		Err(AssetPathInvalid) => Err(AssetPathInvalid)
+		Err(AssetNotFound) => Err(AssetNotFound)
+		Err(AssetReadFailed) => Err(AssetReadFailed)
+		Err(FontLoadFailed) => Err(FontLoadFailed)
+		Err(ResourceLimit) => Err(ResourceLimit)
+	}

--- a/platform/Assets.roc
+++ b/platform/Assets.roc
@@ -5,8 +5,8 @@
 ## ```roc
 ## init! = App.init(
 ##     App.default,
-##     |_startup| {
-##         store = Assets.Store.open!(Assets.working_directory("assets"))?
+##     |_io| {
+##         store = io.assets().open!(Assets.working_directory("assets"))?
 ##         Ok({ logo: Assets.load_texture!(store, "logo.png")?, store })
 ##     },
 ## )
@@ -55,54 +55,6 @@ Assets := [].{
 	## directory handle, not the process working directory; every relative asset
 	## lookup is made through that handle.
 	Store :: Resource.Store.{
-
-		## Open the store described by a `StoreConfig`, checking its manifest if
-		## one was required.
-		##
-		## Legal in `init!`, where it blocks startup, and in tasks, where it
-		## parks the task; refused in `update!` and `render!`. Opening the
-		## directory and reading the manifest are filesystem work, so the host
-		## does both off the frame thread and answers when they are done.
-		##
-		## The first four failures are about the root directory: `RootNotFound`
-		## is nothing at that path, `RootNotDirectory` is something there that
-		## is not a directory, `RootUnreadable` is a directory the process may
-		## not open, and `InvalidRootPath` is a path this host will not accept
-		## at all -- one holding a NUL, or a relative form that escapes.
-		##
-		## The rest are about the `roc-assets.manifest` a `RequireManifest`
-		## config asked for. `ManifestMissing` is no manifest beside the assets,
-		## `ManifestUnreadable` is one that could not be read, and
-		## `ManifestMalformed` is one that is not a manifest. Of the four
-		## comparisons, `AssetSetMismatch` is a manifest describing a different
-		## asset set than the one expected, `SchemaMismatch` a manifest written
-		## to a different schema version, `ContentVersionMismatch` a different
-		## content version, and `ContentHashMismatch` a declared content hash
-		## that is not the expected one. `InvalidExpectedContentHash` is the
-		## expectation itself being unusable -- a `Sha256` string that is not 64
-		## hexadecimal characters.
-		##
-		## A `Sha256` expectation compares against the manifest's declaration
-		## only. Nothing walks or hashes the loose files, so opening a store
-		## stays constant-time in the number of assets.
-		open! : StoreConfig => Try(Store, [RootNotFound, RootNotDirectory, RootUnreadable, InvalidRootPath, InvalidExpectedContentHash, ManifestMissing, ManifestUnreadable, ManifestMalformed, AssetSetMismatch, SchemaMismatch, ContentVersionMismatch, ContentHashMismatch, ResourceLimit, ..])
-		open! = |cfg|
-			match Host.store_open!(store_open_config(cfg)) {
-				Ok(store) => Ok(Store.(store))
-				Err(RootNotFound) => Err(RootNotFound)
-				Err(RootNotDirectory) => Err(RootNotDirectory)
-				Err(RootUnreadable) => Err(RootUnreadable)
-				Err(InvalidRootPath) => Err(InvalidRootPath)
-				Err(InvalidExpectedContentHash) => Err(InvalidExpectedContentHash)
-				Err(ManifestMissing) => Err(ManifestMissing)
-				Err(ManifestUnreadable) => Err(ManifestUnreadable)
-				Err(ManifestMalformed) => Err(ManifestMalformed)
-				Err(AssetSetMismatch) => Err(AssetSetMismatch)
-				Err(SchemaMismatch) => Err(SchemaMismatch)
-				Err(ContentVersionMismatch) => Err(ContentVersionMismatch)
-				Err(ContentHashMismatch) => Err(ContentHashMismatch)
-				Err(ResourceLimit) => Err(ResourceLimit)
-			}
 
 		## Resource-free store value for pure tests.
 		##
@@ -339,6 +291,48 @@ Assets := [].{
 
 	expect filter_code(Bilinear) == 1
 	expect wrap_code(MirrorClamp) == 3
+
+	## Opaque assets authority supplied by App.Io. Effects return PermissionDenied when external access is disabled.
+	Loader :: Resource.Authority.{
+
+		## Private platform construction; no application can manufacture the argument.
+		for_host : Resource.Authority -> Loader
+		for_host = |authority| Loader.(authority)
+
+		## Open the store described by a `StoreConfig`, checking its manifest if
+		## one was required.
+		##
+		## Legal in `init!`, where it blocks startup, and in tasks, where it
+		## parks the task; refused in `update!` and `render!`. Opening the
+		## directory and reading the manifest are filesystem work, so the host
+		## does both off the frame thread and answers when they are done.
+		##
+		## The first four failures are about the root directory: `RootNotFound`
+		## is nothing at that path, `RootNotDirectory` is something there that
+		## is not a directory, `RootUnreadable` is a directory the process may
+		## not open, and `InvalidRootPath` is a path this host will not accept
+		## at all -- one holding a NUL, or a relative form that escapes.
+		##
+		## The rest are about the `roc-assets.manifest` a `RequireManifest`
+		## config asked for. `ManifestMissing` is no manifest beside the assets,
+		## `ManifestUnreadable` is one that could not be read, and
+		## `ManifestMalformed` is one that is not a manifest. Of the four
+		## comparisons, `AssetSetMismatch` is a manifest describing a different
+		## asset set than the one expected, `SchemaMismatch` a manifest written
+		## to a different schema version, `ContentVersionMismatch` a different
+		## content version, and `ContentHashMismatch` a declared content hash
+		## that is not the expected one. `InvalidExpectedContentHash` is the
+		## expectation itself being unusable -- a `Sha256` string that is not 64
+		## hexadecimal characters.
+		##
+		## A `Sha256` expectation compares against the manifest's declaration
+		## only. Nothing walks or hashes the loose files, so opening a store
+		## stays constant-time in the number of assets.
+		open! : Loader, StoreConfig => Try(Store, [PermissionDenied, RootNotFound, RootNotDirectory, RootUnreadable, InvalidRootPath, InvalidExpectedContentHash, ManifestMissing, ManifestUnreadable, ManifestMalformed, AssetSetMismatch, SchemaMismatch, ContentVersionMismatch, ContentHashMismatch, ResourceLimit, ..])
+		open! = |Loader.(authority), cfg| perform_open!(authority, cfg)
+
+	}
+
 }
 
 store_open_config : Assets.StoreConfig -> Host.StoreOpen
@@ -399,4 +393,25 @@ wrap_code = |wrap|
 		Clamp => 1
 		MirrorRepeat => 2
 		MirrorClamp => 3
+	}
+
+## Private authority-taking implementations.
+perform_open! : Resource.Authority, Assets.StoreConfig => Try(Assets.Store, [PermissionDenied, RootNotFound, RootNotDirectory, RootUnreadable, InvalidRootPath, InvalidExpectedContentHash, ManifestMissing, ManifestUnreadable, ManifestMalformed, AssetSetMismatch, SchemaMismatch, ContentVersionMismatch, ContentHashMismatch, ResourceLimit, ..])
+perform_open! = |authority, cfg|
+	match Host.store_open!(authority, store_open_config(cfg)) {
+		Ok(store) => Ok(Assets.Store.(store))
+		Err(PermissionDenied) => Err(PermissionDenied)
+		Err(RootNotFound) => Err(RootNotFound)
+		Err(RootNotDirectory) => Err(RootNotDirectory)
+		Err(RootUnreadable) => Err(RootUnreadable)
+		Err(InvalidRootPath) => Err(InvalidRootPath)
+		Err(InvalidExpectedContentHash) => Err(InvalidExpectedContentHash)
+		Err(ManifestMissing) => Err(ManifestMissing)
+		Err(ManifestUnreadable) => Err(ManifestUnreadable)
+		Err(ManifestMalformed) => Err(ManifestMalformed)
+		Err(AssetSetMismatch) => Err(AssetSetMismatch)
+		Err(SchemaMismatch) => Err(SchemaMismatch)
+		Err(ContentVersionMismatch) => Err(ContentVersionMismatch)
+		Err(ContentHashMismatch) => Err(ContentHashMismatch)
+		Err(ResourceLimit) => Err(ResourceLimit)
 	}

--- a/platform/Audio.roc
+++ b/platform/Audio.roc
@@ -7,7 +7,7 @@
 ## ```roc
 ## init! = App.init(
 ##     App.default,
-##     |_startup| Ok({ blip: Audio.gen_tone!({ freq: 440, ms: 120 })? }),
+##     |_io| Ok({ blip: Audio.gen_tone!({ freq: 440, ms: 120 })? }),
 ## )
 ## ```
 ##
@@ -238,30 +238,6 @@ Audio := [].{
 		volume : F32,
 	}
 
-	## Load a short sound effect from disk.
-	##
-	## Legal in `init!`, where it blocks startup, and in tasks, where it parks
-	## the task; refused in `update!` and `render!`. The file is read off the
-	## frame thread and decoded onto the audio device when the bytes are back.
-	## `SoundLoadFailed` covers both a path with nothing behind it and bytes
-	## raylib would not decode; the format is taken from the extension, and
-	## `.wav`, `.ogg`, `.mp3`, `.qoa` and `.flac` are the ones it reads.
-	load_sound! : Str => Try(Sound, [SoundLoadFailed, ResourceLimit, ..])
-	load_sound! = |path| loaded_sound_from_resource(Host.audio_load_sound!(path))
-
-	## Load a streamed music file. Keep the returned value in the app model.
-	##
-	## Legal in `init!`, where it blocks startup, and in tasks, where it parks
-	## the task; refused in `update!` and `render!`. The file is read off the
-	## frame thread and the host keeps those bytes for as long as the stream
-	## exists, releasing them with the final reference to the `Music`.
-	## `MusicLoadFailed` covers both a path with nothing behind it and bytes
-	## raylib would not decode; the format is taken from the extension, and
-	## `.wav`, `.ogg`, `.mp3`, `.qoa`, `.flac`, `.xm` and `.mod` are the ones it
-	## reads.
-	load_music! : Str => Try(Music, [MusicLoadFailed, ResourceLimit, ..])
-	load_music! = |path| music_from_resource(Host.audio_load_music!(path))
-
 	## Generate a reusable procedural sound. Generation can fail if the fixed host
 	## resource heap is exhausted, so initialization should propagate the returned
 	## error.
@@ -295,13 +271,48 @@ Audio := [].{
 
 	expect waveform_code(Sine) == 0
 	expect waveform_code(Noise) == 4
+
+	## Opaque audio authority supplied by App.Io. Effects return PermissionDenied when external access is disabled.
+	Loader :: Resource.Authority.{
+
+		## Private platform construction; no application can manufacture the argument.
+		for_host : Resource.Authority -> Loader
+		for_host = |authority| Loader.(authority)
+
+		## Load a short sound effect from disk.
+		##
+		## Legal in `init!`, where it blocks startup, and in tasks, where it parks
+		## the task; refused in `update!` and `render!`. The file is read off the
+		## frame thread and decoded onto the audio device when the bytes are back.
+		## `SoundLoadFailed` covers both a path with nothing behind it and bytes
+		## raylib would not decode; the format is taken from the extension, and
+		## `.wav`, `.ogg`, `.mp3`, `.qoa` and `.flac` are the ones it reads.
+		load_sound! : Loader, Str => Try(Sound, [PermissionDenied, SoundLoadFailed, ResourceLimit, ..])
+		load_sound! = |Loader.(authority), path| perform_load_sound!(authority, path)
+
+		## Load a streamed music file. Keep the returned value in the app model.
+		##
+		## Legal in `init!`, where it blocks startup, and in tasks, where it parks
+		## the task; refused in `update!` and `render!`. The file is read off the
+		## frame thread and the host keeps those bytes for as long as the stream
+		## exists, releasing them with the final reference to the `Music`.
+		## `MusicLoadFailed` covers both a path with nothing behind it and bytes
+		## raylib would not decode; the format is taken from the extension, and
+		## `.wav`, `.ogg`, `.mp3`, `.qoa`, `.flac`, `.xm` and `.mod` are the ones it
+		## reads.
+		load_music! : Loader, Str => Try(Music, [PermissionDenied, MusicLoadFailed, ResourceLimit, ..])
+		load_music! = |Loader.(authority), path| perform_load_music!(authority, path)
+
+	}
+
 }
 
-loaded_sound_from_resource : Try(Resource.Sound, Host.AudioLoadSoundError) -> Try(Audio.Sound, [SoundLoadFailed, ResourceLimit, ..])
+loaded_sound_from_resource : Try(Resource.Sound, Host.AudioLoadSoundError) -> Try(Audio.Sound, [PermissionDenied, SoundLoadFailed, ResourceLimit, ..])
 loaded_sound_from_resource = |result|
 	match result {
 		# closed error union to open error union
 		Ok(resource) => Ok(Audio.Sound.(resource))
+		Err(PermissionDenied) => Err(PermissionDenied)
 		Err(SoundLoadFailed) => Err(SoundLoadFailed)
 		Err(ResourceLimit) => Err(ResourceLimit)
 	}
@@ -315,11 +326,12 @@ generated_sound_from_resource = |result|
 		Err(ResourceLimit) => Err(ResourceLimit)
 	}
 
-music_from_resource : Try(Resource.Music, Host.AudioLoadMusicError) -> Try(Audio.Music, [MusicLoadFailed, ResourceLimit, ..])
+music_from_resource : Try(Resource.Music, Host.AudioLoadMusicError) -> Try(Audio.Music, [PermissionDenied, MusicLoadFailed, ResourceLimit, ..])
 music_from_resource = |result|
 	match result {
 		# closed error union to open error union
 		Ok(resource) => Ok(Audio.Music.(resource))
+		Err(PermissionDenied) => Err(PermissionDenied)
 		Err(MusicLoadFailed) => Err(MusicLoadFailed)
 		Err(ResourceLimit) => Err(ResourceLimit)
 	}
@@ -346,3 +358,10 @@ raw_config = |cfg| {
 	release_ms: cfg.release_ms,
 	volume: cfg.volume,
 }
+
+## Private authority-taking implementations.
+perform_load_sound! : Resource.Authority, Str => Try(Audio.Sound, [PermissionDenied, SoundLoadFailed, ResourceLimit, ..])
+perform_load_sound! = |authority, path| loaded_sound_from_resource(Host.audio_load_sound!(authority, path))
+
+perform_load_music! : Resource.Authority, Str => Try(Audio.Music, [PermissionDenied, MusicLoadFailed, ResourceLimit, ..])
+perform_load_music! = |authority, path| music_from_resource(Host.audio_load_music!(authority, path))

--- a/platform/Capture.roc
+++ b/platform/Capture.roc
@@ -7,8 +7,8 @@
 ## Every path here is relative to the output directory set with
 ## `App.default.with_output_dir`, and one that would escape it -- absolute, or
 ## containing `..` -- is refused rather than rewritten. Capture is the only
-## path-sandboxed writer the platform grants: `Files.write_text!` and
-## `Files.write_bytes!` write wherever the process may write, while everything
+## path-sandboxed writer the platform grants: `Files.Access.write_text!` and
+## `Files.Access.write_bytes!` write wherever the process may write, while everything
 ## here is confined to the output directory.
 ##
 ## `start!` and `stop!` control recording. `screenshot!` writes a presented
@@ -19,6 +19,7 @@
 ## or a render texture without writing a file. Both are refused in `render!`.
 ##
 import Host
+import Resource
 import Color
 import Draw
 
@@ -323,47 +324,7 @@ Capture := [].{
 	## the app is shutting down and the wait was cancelled before the frame
 	## ended. It is not what a call from the wrong callback gets: that is a
 	## programmer error and stops the app. See `screenshot!`.
-	ScreenshotError : [PathInvalid, PathEscapesOutputDir, AlreadyPending, WriteFailed, Busy, Unavailable]
-
-	## Write one PNG of the app's rendered output.
-	##
-	## The framebuffer is read back at the end of the frame that asked -- after
-	## the draw batch is flushed and before the buffers are swapped, so the
-	## pixels are the ones just drawn -- and the PNG is encoded and written off
-	## the frame thread. This call waits for that write, so it parks the task
-	## until the file exists and answers with the write's own outcome.
-	##
-	## Legal only in a task, where it parks the task; refused in `init!`,
-	## `update!`, and `render!`. Every other waiting effect also works in
-	## `init!`, where it blocks; a screenshot cannot, because what it waits for
-	## is the end of a frame and `init!` runs before the frame loop has drawn
-	## one. Spawn a task from `update!` instead -- on the first cycle if the
-	## shot is meant to be of the first frame:
-	##
-	## ```roc
-	## if input.time.cycle_count == 0 {
-	##     Task.spawn!(input, || Shot(Capture.screenshot!("frame0.png")))
-	## }
-	## ```
-	##
-	## A headless run has no framebuffer at all and answers `Ok({})` without
-	## writing, so a screenshotting app still runs under `--host-headless`.
-	##
-	## Only one screenshot can be in flight: a second one while the first is
-	## still waiting for its frame is `AlreadyPending`.
-	screenshot! : Str => Try({}, ScreenshotError)
-	screenshot! = |path| {
-		# closed error union to open error union
-		match Host.capture_screenshot!(path) {
-			Ok({}) => Ok({})
-			Err(AlreadyPending) => Err(AlreadyPending)
-			Err(Busy) => Err(Busy)
-			Err(PathEscapesOutputDir) => Err(PathEscapesOutputDir)
-			Err(PathInvalid) => Err(PathInvalid)
-			Err(Unavailable) => Err(Unavailable)
-			Err(WriteFailed) => Err(WriteFailed)
-		}
-	}
+	ScreenshotError : [PermissionDenied, PathInvalid, PathEscapesOutputDir, AlreadyPending, WriteFailed, Busy, Unavailable]
 
 	## Why an offscreen export did not become a file.
 	##
@@ -374,6 +335,7 @@ Capture := [].{
 	## not in flight, so a later frame may take it. `Unavailable` is the app
 	## shutting down before the write started.
 	TextureExportError : [
+		PermissionDenied,
 		PathInvalid,
 		PathEscapesOutputDir,
 		TargetUnavailable,
@@ -384,47 +346,6 @@ Capture := [].{
 		WriteFailed,
 		Unavailable,
 	]
-
-	## Write one PNG of what a render target holds, at the target's own size.
-	##
-	## This is how an app exports an image larger than its window: draw the
-	## composition into a `Draw.RenderTexture` of the size the output needs and
-	## export the target rather than the frame. Transparency survives, unlike a
-	## `screenshot!`, whose framebuffer readback is always opaque.
-	##
-	## Legal in `init!`, where it blocks startup, and in tasks, where it parks
-	## the task; refused in `update!` and `render!`. Nothing here waits on the
-	## frame loop, which is why `init!` is allowed where a `screenshot!` cannot
-	## be -- but drawing into a target is only possible during `render!`, so a
-	## target no `render!` has drawn into holds undefined pixels.
-	##
-	## The pixels are the ones the last completed `render!` left in the target,
-	## so an app that draws its composition every frame exports what it last
-	## showed. The path is resolved under the output directory exactly as
-	## `screenshot!` resolves one.
-	##
-	## A headless run has no pixels to read and answers `Ok({})` without writing,
-	## so an exporting app still runs under `--host-headless`.
-	##
-	## ```roc
-	## Task.spawn!(input, || Exported(Capture.screenshot_texture!(poster, "poster.png")))
-	## ```
-	screenshot_texture! : Draw.RenderTexture, Str => Try({}, TextureExportError)
-	screenshot_texture! = |target, path| {
-		# closed error union to open error union
-		match Host.capture_screenshot_texture!({ target: target.for_host(), path }) {
-			Ok({}) => Ok({})
-			Err(BudgetExceeded) => Err(BudgetExceeded)
-			Err(Busy) => Err(Busy)
-			Err(OutOfMemory) => Err(OutOfMemory)
-			Err(PathEscapesOutputDir) => Err(PathEscapesOutputDir)
-			Err(PathInvalid) => Err(PathInvalid)
-			Err(ReadbackFailed) => Err(ReadbackFailed)
-			Err(TargetUnavailable) => Err(TargetUnavailable)
-			Err(Unavailable) => Err(Unavailable)
-			Err(WriteFailed) => Err(WriteFailed)
-		}
-	}
 
 	## Where a pixel readback takes its pixels from.
 	##
@@ -553,47 +474,92 @@ Capture := [].{
 	max_readback_bytes : U64
 	max_readback_bytes = 128 * 1024 * 1024
 
-	## Begin recording.
-	##
-	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	##
-	## Frames accumulate until the recording hits its frame cap, `Capture.stop!`
-	## is called, or the app exits -- all three finalize the file.
-	##
-	## A rejected start appears as `Failed` in `input.capture` on the next cycle;
-	## the call itself reports nothing, so the recording's outcome is observed
-	## the same way whichever phase started it.
-	start! : Recording => {}
-	start! = |recording| {
-		ratio = capture_scale_ratio(recording.scale())
-		# The host latches the refusal for the next `Input` to report, so there
-		# is nothing to answer with here.
-		_refusal = Host.capture_start_recording!({
-			path: recording.path(),
-			format: capture_format_code(recording.format()),
-			fps: recording.fps(),
-			max_frames: recording.max_frames(),
-			scale_numerator: ratio.numerator,
-			scale_denominator: ratio.denominator,
-			every_nth: recording.every_nth(),
-			timing: capture_timing_code(recording.timing()),
-			cursor: capture_cursor_code(recording.cursor()),
-			quality: capture_quality_code(recording.quality()),
-		})
-		{}
-	}
+	## Opaque capture authority supplied by App.Io. Effects return PermissionDenied when external access is disabled.
+	Writer :: Resource.Authority.{
 
-	## Finish the current recording and write its file.
-	##
-	## Legal in `init!`, `update!`, and tasks; refused in `render!`. An encode and
-	## a file write would otherwise land in the middle of drawing a frame.
-	##
-	## Stopping while idle does nothing. The next input reports the frame count
-	## and file size as `Finished`.
-	stop! : () => {}
-	stop! = || {
-		_finished = Host.capture_stop_recording!()
-		{}
+		## Private platform construction; no application can manufacture the argument.
+		for_host : Resource.Authority -> Writer
+		for_host = |authority| Writer.(authority)
+
+		## Write one PNG of the app's rendered output.
+		##
+		## The framebuffer is read back at the end of the frame that asked -- after
+		## the draw batch is flushed and before the buffers are swapped, so the
+		## pixels are the ones just drawn -- and the PNG is encoded and written off
+		## the frame thread. This call waits for that write, so it parks the task
+		## until the file exists and answers with the write's own outcome.
+		##
+		## Legal only in a task, where it parks the task; refused in `init!`,
+		## `update!`, and `render!`. Every other waiting effect also works in
+		## `init!`, where it blocks; a screenshot cannot, because what it waits for
+		## is the end of a frame and `init!` runs before the frame loop has drawn
+		## one. Spawn a task from `update!` instead -- on the first cycle if the
+		## shot is meant to be of the first frame:
+		##
+		## ```roc
+		## if input.time.cycle_count == 0 {
+		##     Task.spawn!(input, || Shot(io.capture().screenshot!("frame0.png")))
+		## }
+		## ```
+		##
+		## A headless run has no framebuffer at all and answers `Ok({})` without
+		## writing, so a screenshotting app still runs under `--host-headless`.
+		##
+		## Only one screenshot can be in flight: a second one while the first is
+		## still waiting for its frame is `AlreadyPending`.
+		screenshot! : Writer, Str => Try({}, ScreenshotError)
+		screenshot! = |Writer.(authority), path| perform_screenshot!(authority, path)
+
+		## Write one PNG of what a render target holds, at the target's own size.
+		##
+		## This is how an app exports an image larger than its window: draw the
+		## composition into a `Draw.RenderTexture` of the size the output needs and
+		## export the target rather than the frame. Transparency survives, unlike a
+		## `screenshot!`, whose framebuffer readback is always opaque.
+		##
+		## Legal in `init!`, where it blocks startup, and in tasks, where it parks
+		## the task; refused in `update!` and `render!`. Nothing here waits on the
+		## frame loop, which is why `init!` is allowed where a `screenshot!` cannot
+		## be -- but drawing into a target is only possible during `render!`, so a
+		## target no `render!` has drawn into holds undefined pixels.
+		##
+		## The pixels are the ones the last completed `render!` left in the target,
+		## so an app that draws its composition every frame exports what it last
+		## showed. The path is resolved under the output directory exactly as
+		## `screenshot!` resolves one.
+		##
+		## A headless run has no pixels to read and answers `Ok({})` without writing,
+		## so an exporting app still runs under `--host-headless`.
+		##
+		## ```roc
+		## Task.spawn!(input, || Exported(io.capture().screenshot_texture!(poster, "poster.png")))
+		## ```
+		screenshot_texture! : Writer, Draw.RenderTexture, Str => Try({}, TextureExportError)
+		screenshot_texture! = |Writer.(authority), target, path| perform_screenshot_texture!(authority, target, path)
+
+		## Begin recording.
+		##
+		## Legal in `init!`, `update!`, and tasks; refused in `render!`.
+		##
+		## Frames accumulate until the recording hits its frame cap, `Capture.Writer.stop!`
+		## is called, or the app exits -- all three finalize the file.
+		##
+		## A rejected start appears as `Failed` in `input.capture` on the next cycle;
+		## the call itself reports nothing, so the recording's outcome is observed
+		## the same way whichever phase started it.
+		start! : Writer, Recording => Try({}, [PermissionDenied, ..])
+		start! = |Writer.(authority), recording| perform_start!(authority, recording)
+
+		## Finish the current recording and write its file.
+		##
+		## Legal in `init!`, `update!`, and tasks; refused in `render!`. An encode and
+		## a file write would otherwise land in the middle of drawing a frame.
+		##
+		## Stopping while idle does nothing. The next input reports the frame count
+		## and file size as `Finished`.
+		stop! : Writer => Try({}, [PermissionDenied, ..])
+		stop! = |Writer.(authority)| perform_stop!(authority)
+
 	}
 
 }
@@ -696,3 +662,72 @@ expect capture_scale_ratio(Quarter) == { numerator: 1, denominator: 4 }
 expect capture_scale_ratio(Ratio({ numerator: 2, denominator: 3 })) == { numerator: 2, denominator: 3 }
 expect capture_scale_ratio(Ratio({ numerator: 1, denominator: 0 })) == { numerator: 1, denominator: 1 }
 expect capture_scale_ratio(Ratio({ numerator: 0, denominator: 4 })) == { numerator: 1, denominator: 1 }
+
+## Private authority-taking implementations.
+perform_screenshot! : Resource.Authority, Str => Try({}, Capture.ScreenshotError)
+perform_screenshot! = |authority, path| {
+	# closed error union to open error union
+	match Host.capture_screenshot!(authority, path) {
+		Ok({}) => Ok({})
+		Err(PermissionDenied) => Err(PermissionDenied)
+		Err(AlreadyPending) => Err(AlreadyPending)
+		Err(Busy) => Err(Busy)
+		Err(PathEscapesOutputDir) => Err(PathEscapesOutputDir)
+		Err(PathInvalid) => Err(PathInvalid)
+		Err(Unavailable) => Err(Unavailable)
+		Err(WriteFailed) => Err(WriteFailed)
+	}
+}
+
+perform_screenshot_texture! : Resource.Authority, Draw.RenderTexture, Str => Try({}, Capture.TextureExportError)
+perform_screenshot_texture! = |authority, target, path| {
+	# closed error union to open error union
+	match Host.capture_screenshot_texture!(authority, { target: target.for_host(), path }) {
+		Ok({}) => Ok({})
+		Err(PermissionDenied) => Err(PermissionDenied)
+		Err(BudgetExceeded) => Err(BudgetExceeded)
+		Err(Busy) => Err(Busy)
+		Err(OutOfMemory) => Err(OutOfMemory)
+		Err(PathEscapesOutputDir) => Err(PathEscapesOutputDir)
+		Err(PathInvalid) => Err(PathInvalid)
+		Err(ReadbackFailed) => Err(ReadbackFailed)
+		Err(TargetUnavailable) => Err(TargetUnavailable)
+		Err(Unavailable) => Err(Unavailable)
+		Err(WriteFailed) => Err(WriteFailed)
+	}
+}
+
+perform_start! : Resource.Authority, Capture.Recording => Try({}, [PermissionDenied, ..])
+perform_start! = |authority, recording| {
+	ratio = capture_scale_ratio(recording.scale())
+	# The host latches the refusal for the next `Input` to report, so there
+	# is nothing to answer with here.
+	result = Host.capture_start_recording!(
+		authority,
+		{
+			path: recording.path(),
+			format: capture_format_code(recording.format()),
+			fps: recording.fps(),
+			max_frames: recording.max_frames(),
+			scale_numerator: ratio.numerator,
+			scale_denominator: ratio.denominator,
+			every_nth: recording.every_nth(),
+			timing: capture_timing_code(recording.timing()),
+			cursor: capture_cursor_code(recording.cursor()),
+			quality: capture_quality_code(recording.quality()),
+		},
+	)
+	match result {
+		Err(PermissionDenied) => Err(PermissionDenied)
+		_ => Ok({})
+	}
+}
+
+perform_stop! : Resource.Authority => Try({}, [PermissionDenied, ..])
+perform_stop! = |authority| {
+	result = Host.capture_stop_recording!(authority)
+	match result {
+		Err(PermissionDenied) => Err(PermissionDenied)
+		_ => Ok({})
+	}
+}

--- a/platform/Cmd.roc
+++ b/platform/Cmd.roc
@@ -9,7 +9,7 @@
 ##         .with_args(["-y", "-i", input, "out.mp4"])
 ##         .with_timeout_ms(120_000)
 ##
-##     match Cmd.run!(cmd) {
+##     match io.commands().run!(cmd) {
 ##         Ok(output) if output.exit_code == 0 => Encoded("out.mp4")
 ##         Ok(output) => EncodeRefused(Str.from_utf8_lossy(output.stderr))
 ##         Err(err) => EncodeFailed(err)
@@ -39,6 +39,7 @@
 ## Orderly shutdown terminates children still managed by the host. Detached
 ## descendants and forced process termination are outside this guarantee.
 import Host
+import Resource
 
 Cmd := {
 
@@ -222,81 +223,54 @@ Cmd := {
 	with_stderr_limit : Cmd, U64 -> Cmd
 	with_stderr_limit = |cmd, limit_bytes| { ..cmd, stderr_limit_bytes: limit_bytes }
 
-	## Run the command and wait for the child to finish.
-	##
-	## At most eight children run at once. The slot is taken before anything
-	## is started and released when the child has been reaped, so a `Busy`
-	## means precisely that no process was created. Bounding what is started
-	## is what keeps a task per child from becoming a process per task.
-	##
-	## Legal in `init!`, where it blocks startup, and in tasks, where it parks
-	## the task; refused in `update!` and `render!`.
-	##
-	## ```roc
-	## update! = |model, input| {
-	##     if input.devices.key_pressed(KeyE) {
-	##         Task.spawn!(
-	##             input,
-	##             || match Cmd.run!(Cmd.new("git").with_args(["rev-parse", "HEAD"])) {
-	##                 Ok(output) => Revision(Str.from_utf8_lossy(output.stdout))
-	##                 Err(err) => RevisionFailed(err)
-	##             },
-	##         )
-	##     }
-	##     Ok(model)
-	## }
-	## ```
-	run! : Cmd => Try(Output, CmdErr)
-	run! = |cmd| {
-		result = Host.cmd_run!({
-			program: cmd.program,
-			args: cmd.args,
-			envs: cmd.envs,
-			clear_envs: cmd.clear_envs,
-			working_dir: match cmd.working_dir {
-				Inherit => ""
-				Set(dir) => dir
-			},
-			timeout_ms: cmd.timeout_ms,
-			stdout_limit_bytes: cmd.stdout_limit_bytes,
-			stderr_limit_bytes: cmd.stderr_limit_bytes,
-		})
+	## Opaque commands authority supplied by App.Io. Effects return PermissionDenied when external access is disabled.
+	Runner :: Resource.Authority.{
 
-		# closed error union to open error union
-		match result {
-			Ok(output) => Ok(output)
-			Err(Timeout(output)) => Err(Timeout(output))
-			Err(Busy) => Err(Busy)
-			Err(CommandNotFound) => Err(CommandNotFound)
-			Err(PermissionDenied) => Err(PermissionDenied)
-			Err(SpawnFailed) => Err(SpawnFailed)
-			Err(StderrLimitExceeded) => Err(StderrLimitExceeded)
-			Err(StdoutLimitExceeded) => Err(StdoutLimitExceeded)
-			Err(Unavailable) => Err(Unavailable)
-		}
+		## Private platform construction; no application can manufacture the argument.
+		for_host : Resource.Authority -> Runner
+		for_host = |authority| Runner.(authority)
+
+		## Run the command and wait for the child to finish.
+		##
+		## At most eight children run at once. The slot is taken before anything
+		## is started and released when the child has been reaped, so a `Busy`
+		## means precisely that no process was created. Bounding what is started
+		## is what keeps a task per child from becoming a process per task.
+		##
+		## Legal in `init!`, where it blocks startup, and in tasks, where it parks
+		## the task; refused in `update!` and `render!`.
+		##
+		## ```roc
+		## update! = |model, input, io| {
+		##     if input.devices.key_pressed(KeyE) {
+		##         Task.spawn!(
+		##             input,
+		##             || match io.commands().run!(Cmd.new("git").with_args(["rev-parse", "HEAD"])) {
+		##                 Ok(output) => Revision(Str.from_utf8_lossy(output.stdout))
+		##                 Err(err) => RevisionFailed(err)
+		##             },
+		##         )
+		##     }
+		##     Ok(model)
+		## }
+		## ```
+		run! : Runner, Cmd => Try(Output, CmdErr)
+		run! = |Runner.(authority), cmd| perform_run!(authority, cmd)
+
+		## Run the command and read both streams as text.
+		##
+		## The decoding is lossy: bytes that are not valid UTF-8 become the
+		## replacement character rather than failing the run, because a tool that
+		## puts one stray byte in a progress line has still told the app what it
+		## needed to know. Use `run!` when a stream has to survive exactly.
+		##
+		## Legal in `init!`, where it blocks startup, and in tasks, where it parks
+		## the task; refused in `update!` and `render!`.
+		run_utf8! : Runner, Cmd => Try(Utf8Output, CmdErr)
+		run_utf8! = |Runner.(authority), cmd| perform_run_utf8!(authority, cmd)
+
 	}
 
-	## Run the command and read both streams as text.
-	##
-	## The decoding is lossy: bytes that are not valid UTF-8 become the
-	## replacement character rather than failing the run, because a tool that
-	## puts one stray byte in a progress line has still told the app what it
-	## needed to know. Use `run!` when a stream has to survive exactly.
-	##
-	## Legal in `init!`, where it blocks startup, and in tasks, where it parks
-	## the task; refused in `update!` and `render!`.
-	run_utf8! : Cmd => Try(Utf8Output, CmdErr)
-	run_utf8! = |cmd|
-		match run!(cmd) {
-			Ok(output) =>
-				Ok({
-					exit_code: output.exit_code,
-					stdout: Str.from_utf8_lossy(output.stdout),
-					stderr: Str.from_utf8_lossy(output.stderr),
-				})
-
-			Err(err) => Err(err)
-		}
 }
 
 expect Cmd.new("ls").program == "ls"
@@ -317,3 +291,51 @@ expect Cmd.new("sleep").with_timeout_ms(0).timeout_ms == 1
 expect Cmd.new("sleep").with_timeout_ms(500).timeout_ms == 500
 expect Cmd.new("ls").with_stdout_limit(64).stdout_limit_bytes == 64
 expect Cmd.new("ls").with_stderr_limit(64).stderr_limit_bytes == 64
+
+## Private authority-taking implementations.
+perform_run! : Resource.Authority, Cmd => Try(Cmd.Output, Cmd.CmdErr)
+perform_run! = |authority, cmd| {
+	result = Host.cmd_run!(
+		authority,
+		{
+			program: cmd.program,
+			args: cmd.args,
+			envs: cmd.envs,
+			clear_envs: cmd.clear_envs,
+			working_dir: match cmd.working_dir {
+				Inherit => ""
+				Set(dir) => dir
+			},
+			timeout_ms: cmd.timeout_ms,
+			stdout_limit_bytes: cmd.stdout_limit_bytes,
+			stderr_limit_bytes: cmd.stderr_limit_bytes,
+		},
+	)
+
+	# closed error union to open error union
+	match result {
+		Ok(output) => Ok(output)
+		Err(Timeout(output)) => Err(Timeout(output))
+		Err(Busy) => Err(Busy)
+		Err(CommandNotFound) => Err(CommandNotFound)
+		Err(PermissionDenied) => Err(PermissionDenied)
+		Err(SpawnFailed) => Err(SpawnFailed)
+		Err(StderrLimitExceeded) => Err(StderrLimitExceeded)
+		Err(StdoutLimitExceeded) => Err(StdoutLimitExceeded)
+		Err(Unavailable) => Err(Unavailable)
+	}
+}
+
+perform_run_utf8! : Resource.Authority, Cmd => Try(Cmd.Utf8Output, Cmd.CmdErr)
+perform_run_utf8! = |authority, cmd|
+	match perform_run!(authority, cmd) {
+		Ok(output) =>
+			Ok({
+				exit_code: output.exit_code,
+				stdout: Str.from_utf8_lossy(output.stdout),
+				stderr: Str.from_utf8_lossy(output.stderr),
+			})
+
+		Err(PermissionDenied) => Err(PermissionDenied)
+		Err(err) => Err(err)
+	}

--- a/platform/Files.roc
+++ b/platform/Files.roc
@@ -5,9 +5,9 @@
 ## `render!`.
 ##
 ## ```roc
-## update! = |model, input| {
+## update! = |model, input, io| {
 ##     if input.devices.key_pressed(KeyEnter) {
-##         Task.spawn!(input, || SaveLoaded(Files.read_text!("save.json")))
+##         Task.spawn!(input, || SaveLoaded(io.files().read_text!("save.json")))
 ##     }
 ##     Ok(model)
 ## }
@@ -17,6 +17,7 @@
 ## directory. Filesystem access is not sandboxed; `Capture` confines only its
 ## own outputs.
 import Host
+import Resource
 import Time
 
 Files := [].{
@@ -42,7 +43,7 @@ Files := [].{
 	## not have is one of them: the host does not distinguish it from a read
 	## that failed for any other reason. `metadata!` does, so a path that may be
 	## unreadable can be stat'd first to tell the two apart.
-	ReadTextError : [NotFound, ReadFailed, Busy, Unavailable, TooLarge, NotUtf8]
+	ReadTextError : [PermissionDenied, NotFound, ReadFailed, Busy, Unavailable, TooLarge, NotUtf8]
 
 	## Why `read_bytes!` produced no byte list.
 	##
@@ -50,7 +51,7 @@ Files := [].{
 	## the bytes is inspected, and with a much larger ceiling: `TooLarge` here
 	## is a file past 16 mebibytes. `ReadFailed` covers a permission denial in
 	## exactly the same way.
-	ReadBytesError : [NotFound, ReadFailed, Busy, Unavailable, TooLarge]
+	ReadBytesError : [PermissionDenied, NotFound, ReadFailed, Busy, Unavailable, TooLarge]
 
 	## Why `list!` produced no directory entries.
 	##
@@ -58,7 +59,7 @@ Files := [].{
 	## directory whose listing would exceed 8192 entries or one mebibyte of
 	## encoded names, whichever binds first. The rest mean what they mean for a
 	## read, `ReadFailed` included.
-	ListError : [NotFound, NotADirectory, ReadFailed, Busy, Unavailable, TooLarge]
+	ListError : [PermissionDenied, NotFound, NotADirectory, ReadFailed, Busy, Unavailable, TooLarge]
 
 	## What one path is, how big it is, and when it last changed.
 	##
@@ -93,193 +94,157 @@ Files := [].{
 	## is every other refusal the host cannot name more precisely.
 	WriteError : [NotFound, PermissionDenied, NoSpace, WriteFailed, Unavailable]
 
-	## Read a bounded UTF-8 file into a `Str`.
-	##
-	## The whole file is copied into the string, so this is capped well below
-	## what `read_bytes!` will read: at most 64 kibibytes, and a file past that
-	## is `TooLarge` rather than truncated. One that is not valid UTF-8 is
-	## `NotUtf8` rather than an invalid `Str`.
-	##
-	## Legal in `init!`, where it blocks startup, and in tasks, where it parks
-	## the task; refused in `update!` and `render!`.
-	read_text! : Str => Try(Str, ReadTextError)
-	read_text! = |path|
-		match Host.files_read_text!(path) {
-			# closed error union to open error union
-			Ok(contents) => Ok(contents)
-			Err(Busy) => Err(Busy)
-			Err(NotFound) => Err(NotFound)
-			Err(NotUtf8) => Err(NotUtf8)
-			Err(ReadFailed) => Err(ReadFailed)
-			Err(TooLarge) => Err(TooLarge)
-			Err(Unavailable) => Err(Unavailable)
-		}
+	## Opaque files authority supplied by App.Io. Effects return PermissionDenied when external access is disabled.
+	Access :: Resource.Authority.{
 
-	## Read a bounded file as ordinary Roc bytes.
-	##
-	## At most 16 mebibytes, and a file past that is `TooLarge`. The ceiling is
-	## far above `read_text!`'s because nothing is copied: the buffer the read
-	## filled is the buffer Roc gets.
-	##
-	## That is also why there is a second bound. The delivered list owns
-	## host-backed storage through Roc ARC, and at most 32 such allocations are
-	## live at once; a read made while all 32 are held answers `Busy` without
-	## touching the disk. Retaining a sublist retains the complete source
-	## allocation and so holds a slot, which `List.release_excess_capacity`
-	## releases by copying out the part worth keeping.
-	##
-	## Legal in `init!`, where it blocks startup, and in tasks, where it parks
-	## the task; refused in `update!` and `render!`.
-	read_bytes! : Str => Try(List(U8), ReadBytesError)
-	read_bytes! = |path|
-		match Host.files_read_bytes!(path) {
-			# closed error union to open error union
-			Ok(bytes) => Ok(bytes)
-			Err(Busy) => Err(Busy)
-			Err(NotFound) => Err(NotFound)
-			Err(ReadFailed) => Err(ReadFailed)
-			Err(TooLarge) => Err(TooLarge)
-			Err(Unavailable) => Err(Unavailable)
-		}
+		## Private platform construction; no application can manufacture the argument.
+		for_host : Resource.Authority -> Access
+		for_host = |authority| Access.(authority)
 
-	## List one directory without recursively walking its children.
-	##
-	## Entry order is the filesystem's observed order and is not sorted.
-	## Recursion is the app's to drive: only the app knows which subtrees are
-	## worth descending into, and a host-side walk would be one unbounded wait.
-	##
-	## A listing is bounded at 8192 entries and at one mebibyte of encoded
-	## names, whichever binds first; a directory past either is `TooLarge`
-	## rather than a partial listing. It is delivered through the same 32
-	## file-byte slots a byte read uses, so it can answer `Busy` for the same
-	## reason.
-	##
-	## Legal in `init!`, where it blocks startup, and in tasks, where it parks
-	## the task; refused in `update!` and `render!`.
-	list! : Str => Try(List(Entry), ListError)
-	list! = |path|
-		match Host.files_list!(path) {
-			# closed error union to open error union
-			Ok(bytes) => Ok(decode_listing(bytes))
-			Err(Busy) => Err(Busy)
-			Err(NotADirectory) => Err(NotADirectory)
-			Err(NotFound) => Err(NotFound)
-			Err(ReadFailed) => Err(ReadFailed)
-			Err(TooLarge) => Err(TooLarge)
-			Err(Unavailable) => Err(Unavailable)
-		}
+		## Read a bounded UTF-8 file into a `Str`.
+		##
+		## The whole file is copied into the string, so this is capped well below
+		## what `read_bytes!` will read: at most 64 kibibytes, and a file past that
+		## is `TooLarge` rather than truncated. One that is not valid UTF-8 is
+		## `NotUtf8` rather than an invalid `Str`.
+		##
+		## Legal in `init!`, where it blocks startup, and in tasks, where it parks
+		## the task; refused in `update!` and `render!`.
+		read_text! : Access, Str => Try(Str, ReadTextError)
+		read_text! = |Access.(authority), path| perform_read_text!(authority, path)
 
-	## What one path is, how big it is, and when it last changed.
-	##
-	## Symbolic links are followed, so a link to a file is `File` and a link to
-	## nothing is `NotFound`. That differs from `list!`, which reports the kind
-	## the directory itself records and so calls a symbolic link `Other`;
-	## `metadata!` answers about the thing at the end of the path, which is
-	## what an app deciding whether to read it wants to know.
-	##
-	## Polling `modified` is how an app hot-reloads a shader, a level, or a
-	## dataset it did not write. Do it inside a task, and sleep between stats,
-	## so the watching costs a parked task rather than a stat every frame:
-	##
-	## ```roc
-	## watch! : Str, Time.Timestamp => Msg
-	## watch! = |path, seen| {
-	##     var $outcome = Unchanged
-	##     while $outcome == Unchanged {
-	##         Task.sleep!(250)
-	##         $outcome = match Files.metadata!(path) {
-	##             Ok(meta) if meta.modified != seen => Modified(meta.modified)
-	##             Ok(_) => Unchanged
-	##             Err(NotFound) => Unchanged
-	##             Err(other) => Stopped(other)
-	##         }
-	##     }
-	##     match $outcome {
-	##         Modified(at) => Changed(path, at)
-	##         Stopped(err) => WatchFailed(err)
-	##         Unchanged => crash("watch!: the loop only ends once the path changed or the stat failed")
-	##     }
-	## }
-	## ```
-	##
-	## The loop carries a sentinel tag rather than the message itself, so its
-	## `while` condition can compare it, and the `match` after the loop turns
-	## that sentinel into the one message the task owes.
-	##
-	## A loop rather than a recursive call, because a task runs on a
-	## fixed-size coroutine stack. `NotFound` keeps waiting rather than giving
-	## up: an editor saving a file often replaces it, so the path can be
-	## missing for a moment. `update!` spawns the watcher again when it handles
-	## `Changed`, and each live watcher holds one of the host's thirty-two task
-	## slots for as long as it watches.
-	##
-	## Legal in `init!`, where it blocks startup, and in tasks, where it parks
-	## the task; refused in `update!` and `render!`.
-	metadata! : Str => Try(Metadata, MetadataError)
-	metadata! = |path|
-		match Host.files_metadata!(path) {
-			# closed error union to open error union
-			Ok(stat) =>
-			# The host normalizes the instant before it crosses, so the only
-			# way this fails is a host that is wrong about its own contract.
-			# Saying so is more use than reporting it as a filesystem error an
-			# app could act on.
-				match Time.Timestamp.from_parts({ seconds: stat.modified_seconds, nanosecond: stat.modified_nanosecond }) {
-					Ok(modified) => Ok({ kind: entry_kind(stat.kind), size_bytes: stat.size_bytes, modified: modified })
-					Err(InvalidNanosecond) => crash ("roc-ray: Files.metadata! received a modification time the host had not normalized")
-				}
-			Err(NotFound) => Err(NotFound)
-			Err(PermissionDenied) => Err(PermissionDenied)
-			Err(ReadFailed) => Err(ReadFailed)
-			Err(Unavailable) => Err(Unavailable)
-		}
+		## Read a bounded file as ordinary Roc bytes.
+		##
+		## At most 16 mebibytes, and a file past that is `TooLarge`. The ceiling is
+		## far above `read_text!`'s because nothing is copied: the buffer the read
+		## filled is the buffer Roc gets.
+		##
+		## That is also why there is a second bound. The delivered list owns
+		## host-backed storage through Roc ARC, and at most 32 such allocations are
+		## live at once; a read made while all 32 are held answers `Busy` without
+		## touching the disk. Retaining a sublist retains the complete source
+		## allocation and so holds a slot, which `List.release_excess_capacity`
+		## releases by copying out the part worth keeping.
+		##
+		## Legal in `init!`, where it blocks startup, and in tasks, where it parks
+		## the task; refused in `update!` and `render!`.
+		read_bytes! : Access, Str => Try(List(U8), ReadBytesError)
+		read_bytes! = |Access.(authority), path| perform_read_bytes!(authority, path)
 
-	## Replace a file's contents with a `Str`, creating it if it is not there.
-	##
-	## The write replaces the whole file: there is no append, and no partial
-	## write is reported as success. Missing parent directories are created,
-	## the same as for every file the host writes itself, so an app's first
-	## `write_text!("saves/slot1.json", ...)` does not need a separate step to
-	## make `saves/`.
-	##
-	## The path is used as the app gave it, resolved against the process
-	## working directory, exactly as `read_text!` resolves one. `Files` is not
-	## sandboxed in either direction: an app that can read `/etc/hosts` can
-	## write `/tmp/out.txt`. The one output root this platform enforces belongs
-	## to `Capture`, whose paths are computed by recording machinery rather
-	## than written out by the app, and it confines captures only.
-	##
-	## Legal in `init!`, where it blocks startup, and in tasks, where it parks
-	## the task; refused in `update!` and `render!`.
-	##
-	## ```roc
-	## update! = |model, input| {
-	##     if input.devices.key_pressed(KeyS) {
-	##         Task.spawn!(
-	##             input,
-	##             || match Files.write_text!("saves/slot1.json", encode(model)) {
-	##                 Ok({}) => Saved
-	##                 Err(err) => SaveFailed(err)
-	##             },
-	##         )
-	##     }
-	##     Ok(model)
-	## }
-	## ```
-	write_text! : Str, Str => Try({}, WriteError)
-	write_text! = |path, contents| lifted(Host.files_write_text!(path, contents))
+		## List one directory without recursively walking its children.
+		##
+		## Entry order is the filesystem's observed order and is not sorted.
+		## Recursion is the app's to drive: only the app knows which subtrees are
+		## worth descending into, and a host-side walk would be one unbounded wait.
+		##
+		## A listing is bounded at 8192 entries and at one mebibyte of encoded
+		## names, whichever binds first; a directory past either is `TooLarge`
+		## rather than a partial listing. It is delivered through the same 32
+		## file-byte slots a byte read uses, so it can answer `Busy` for the same
+		## reason.
+		##
+		## Legal in `init!`, where it blocks startup, and in tasks, where it parks
+		## the task; refused in `update!` and `render!`.
+		list! : Access, Str => Try(List(Entry), ListError)
+		list! = |Access.(authority), path| perform_list!(authority, path)
 
-	## Replace a file's contents with ordinary Roc bytes.
-	##
-	## The same path rules, the same whole-file replacement, and the same
-	## parent-directory creation as `write_text!`; only the payload differs.
-	## Nothing about the bytes is inspected, so this is the call for a PNG, a
-	## save blob, or anything else that is not text.
-	##
-	## Legal in `init!`, where it blocks startup, and in tasks, where it parks
-	## the task; refused in `update!` and `render!`.
-	write_bytes! : Str, List(U8) => Try({}, WriteError)
-	write_bytes! = |path, bytes| lifted(Host.files_write_bytes!(path, bytes))
+		## What one path is, how big it is, and when it last changed.
+		##
+		## Symbolic links are followed, so a link to a file is `File` and a link to
+		## nothing is `NotFound`. That differs from `list!`, which reports the kind
+		## the directory itself records and so calls a symbolic link `Other`;
+		## `metadata!` answers about the thing at the end of the path, which is
+		## what an app deciding whether to read it wants to know.
+		##
+		## Polling `modified` is how an app hot-reloads a shader, a level, or a
+		## dataset it did not write. Do it inside a task, and sleep between stats,
+		## so the watching costs a parked task rather than a stat every frame:
+		##
+		## ```roc
+		## watch! : Str, Time.Timestamp => Msg
+		## watch! = |path, seen| {
+		##     var $outcome = Unchanged
+		##     while $outcome == Unchanged {
+		##         Task.sleep!(250)
+		##         $outcome = match io.files().metadata!(path) {
+		##             Ok(meta) if meta.modified != seen => Modified(meta.modified)
+		##             Ok(_) => Unchanged
+		##             Err(NotFound) => Unchanged
+		##             Err(other) => Stopped(other)
+		##         }
+		##     }
+		##     match $outcome {
+		##         Modified(at) => Changed(path, at)
+		##         Stopped(err) => WatchFailed(err)
+		##         Unchanged => crash("watch!: the loop only ends once the path changed or the stat failed")
+		##     }
+		## }
+		## ```
+		##
+		## The loop carries a sentinel tag rather than the message itself, so its
+		## `while` condition can compare it, and the `match` after the loop turns
+		## that sentinel into the one message the task owes.
+		##
+		## A loop rather than a recursive call, because a task runs on a
+		## fixed-size coroutine stack. `NotFound` keeps waiting rather than giving
+		## up: an editor saving a file often replaces it, so the path can be
+		## missing for a moment. `update!` spawns the watcher again when it handles
+		## `Changed`, and each live watcher holds one of the host's thirty-two task
+		## slots for as long as it watches.
+		##
+		## Legal in `init!`, where it blocks startup, and in tasks, where it parks
+		## the task; refused in `update!` and `render!`.
+		metadata! : Access, Str => Try(Metadata, MetadataError)
+		metadata! = |Access.(authority), path| perform_metadata!(authority, path)
+
+		## Replace a file's contents with a `Str`, creating it if it is not there.
+		##
+		## The write replaces the whole file: there is no append, and no partial
+		## write is reported as success. Missing parent directories are created,
+		## the same as for every file the host writes itself, so an app's first
+		## `io.files().write_text!("saves/slot1.json", ...)` does not need a separate step to
+		## make `saves/`.
+		##
+		## The path is used as the app gave it, resolved against the process
+		## working directory, exactly as `read_text!` resolves one. `Files` is not
+		## sandboxed in either direction: an app that can read `/etc/hosts` can
+		## write `/tmp/out.txt`. The one output root this platform enforces belongs
+		## to `Capture`, whose paths are computed by recording machinery rather
+		## than written out by the app, and it confines captures only.
+		##
+		## Legal in `init!`, where it blocks startup, and in tasks, where it parks
+		## the task; refused in `update!` and `render!`.
+		##
+		## ```roc
+		## update! = |model, input, io| {
+		##     if input.devices.key_pressed(KeyS) {
+		##         Task.spawn!(
+		##             input,
+		##             || match io.files().write_text!("saves/slot1.json", encode(model)) {
+		##                 Ok({}) => Saved
+		##                 Err(err) => SaveFailed(err)
+		##             },
+		##         )
+		##     }
+		##     Ok(model)
+		## }
+		## ```
+		write_text! : Access, Str, Str => Try({}, WriteError)
+		write_text! = |Access.(authority), path, contents| perform_write_text!(authority, path, contents)
+
+		## Replace a file's contents with ordinary Roc bytes.
+		##
+		## The same path rules, the same whole-file replacement, and the same
+		## parent-directory creation as `write_text!`; only the payload differs.
+		## Nothing about the bytes is inspected, so this is the call for a PNG, a
+		## save blob, or anything else that is not text.
+		##
+		## Legal in `init!`, where it blocks startup, and in tasks, where it parks
+		## the task; refused in `update!` and `render!`.
+		write_bytes! : Access, Str, List(U8) => Try({}, WriteError)
+		write_bytes! = |Access.(authority), path, bytes| perform_write_bytes!(authority, path, bytes)
+
+	}
 
 }
 
@@ -379,3 +344,70 @@ expect decode_listing([2, 's', 'r', 'c', 0, 1, 'a', '.', 't', 0]) == [
 ## A kind byte with no terminator after it ends the listing rather than being
 ## guessed at, so a truncated buffer still yields the entries that were whole.
 expect decode_listing([1, 'a', 0, 2, 'b']) == [{ name: "a", kind: File }]
+
+## Private authority-taking implementations.
+perform_read_text! : Resource.Authority, Str => Try(Str, Files.ReadTextError)
+perform_read_text! = |authority, path|
+	match Host.files_read_text!(authority, path) {
+		# closed error union to open error union
+		Ok(contents) => Ok(contents)
+		Err(PermissionDenied) => Err(PermissionDenied)
+		Err(Busy) => Err(Busy)
+		Err(NotFound) => Err(NotFound)
+		Err(NotUtf8) => Err(NotUtf8)
+		Err(ReadFailed) => Err(ReadFailed)
+		Err(TooLarge) => Err(TooLarge)
+		Err(Unavailable) => Err(Unavailable)
+	}
+
+perform_read_bytes! : Resource.Authority, Str => Try(List(U8), Files.ReadBytesError)
+perform_read_bytes! = |authority, path|
+	match Host.files_read_bytes!(authority, path) {
+		# closed error union to open error union
+		Ok(bytes) => Ok(bytes)
+		Err(PermissionDenied) => Err(PermissionDenied)
+		Err(Busy) => Err(Busy)
+		Err(NotFound) => Err(NotFound)
+		Err(ReadFailed) => Err(ReadFailed)
+		Err(TooLarge) => Err(TooLarge)
+		Err(Unavailable) => Err(Unavailable)
+	}
+
+perform_list! : Resource.Authority, Str => Try(List(Files.Entry), Files.ListError)
+perform_list! = |authority, path|
+	match Host.files_list!(authority, path) {
+		# closed error union to open error union
+		Ok(bytes) => Ok(decode_listing(bytes))
+		Err(PermissionDenied) => Err(PermissionDenied)
+		Err(Busy) => Err(Busy)
+		Err(NotADirectory) => Err(NotADirectory)
+		Err(NotFound) => Err(NotFound)
+		Err(ReadFailed) => Err(ReadFailed)
+		Err(TooLarge) => Err(TooLarge)
+		Err(Unavailable) => Err(Unavailable)
+	}
+
+perform_metadata! : Resource.Authority, Str => Try(Files.Metadata, Files.MetadataError)
+perform_metadata! = |authority, path|
+	match Host.files_metadata!(authority, path) {
+		# closed error union to open error union
+		Ok(stat) =>
+		# The host normalizes the instant before it crosses, so the only
+		# way this fails is a host that is wrong about its own contract.
+		# Saying so is more use than reporting it as a filesystem error an
+		# app could act on.
+			match Time.Timestamp.from_parts({ seconds: stat.modified_seconds, nanosecond: stat.modified_nanosecond }) {
+				Ok(modified) => Ok({ kind: entry_kind(stat.kind), size_bytes: stat.size_bytes, modified: modified })
+				Err(InvalidNanosecond) => crash ("roc-ray: Files.Access.metadata! received a modification time the host had not normalized")
+			}
+		Err(NotFound) => Err(NotFound)
+		Err(PermissionDenied) => Err(PermissionDenied)
+		Err(ReadFailed) => Err(ReadFailed)
+		Err(Unavailable) => Err(Unavailable)
+	}
+
+perform_write_text! : Resource.Authority, Str, Str => Try({}, Files.WriteError)
+perform_write_text! = |authority, path, contents| lifted(Host.files_write_text!(authority, path, contents))
+
+perform_write_bytes! : Resource.Authority, Str, List(U8) => Try({}, Files.WriteError)
+perform_write_bytes! = |authority, path, bytes| lifted(Host.files_write_bytes!(authority, path, bytes))

--- a/platform/Host.roc
+++ b/platform/Host.roc
@@ -36,7 +36,7 @@
 ##
 ## Host-service interfaces:
 ##
-## > `App`: startup authority, process inputs, startup file reads, and exit.
+## > `App`: host authority, process inputs, and startup exit.
 ## > `Task`: sleeping, spawning, and delivery of one finished message.
 ## > `Time`: normalized wall-clock timestamps.
 ## > `Trace`: bounded diagnostic marks, zones, and numeric samples.
@@ -188,7 +188,7 @@ Host := [].{
 
 	## Get the default font during startup.
 	## Legal only in `init!`.
-	text_startup_default_font! : () => Try(Font, [AssetPathInvalid, AssetNotFound, AssetReadFailed, FontLoadFailed, ResourceLimit])
+	text_startup_default_font! : Resource.Authority => Try(Font, [PermissionDenied, AssetPathInvalid, AssetNotFound, AssetReadFailed, FontLoadFailed, ResourceLimit])
 
 	## Load a font from encoded bytes.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
@@ -292,11 +292,11 @@ Host := [].{
 	}
 
 	## Failures while opening and validating an asset store.
-	StoreOpenError : [AssetSetMismatch, ContentHashMismatch, ContentVersionMismatch, InvalidExpectedContentHash, InvalidRootPath, ManifestMalformed, ManifestMissing, ManifestUnreadable, ResourceLimit, RootNotDirectory, RootNotFound, RootUnreadable, SchemaMismatch]
+	StoreOpenError : [PermissionDenied, AssetSetMismatch, ContentHashMismatch, ContentVersionMismatch, InvalidExpectedContentHash, InvalidRootPath, ManifestMalformed, ManifestMissing, ManifestUnreadable, ResourceLimit, RootNotDirectory, RootNotFound, RootUnreadable, SchemaMismatch]
 
 	## Open a confined asset store.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	store_open! : StoreOpen => Try(Resource.Store, StoreOpenError)
+	store_open! : Resource.Authority, StoreOpen => Try(Resource.Store, StoreOpenError)
 
 	## Mouse interface
 	## Apply the flattened cursor visibility and capture mode.
@@ -372,10 +372,10 @@ Host := [].{
 	AudioGenerateSoundError : [ResourceLimit, SoundGenerationFailed]
 
 	## Failures while loading a sound.
-	AudioLoadSoundError : [ResourceLimit, SoundLoadFailed]
+	AudioLoadSoundError : [PermissionDenied, ResourceLimit, SoundLoadFailed]
 
 	## Failures while loading a music stream.
-	AudioLoadMusicError : [MusicLoadFailed, ResourceLimit]
+	AudioLoadMusicError : [PermissionDenied, MusicLoadFailed, ResourceLimit]
 
 	## Parameters for a generated sound envelope.
 	AudioGenSound : {
@@ -400,11 +400,11 @@ Host := [].{
 
 	## Load a sound from a file.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	audio_load_sound! : Str => Try(Resource.Sound, AudioLoadSoundError)
+	audio_load_sound! : Resource.Authority, Str => Try(Resource.Sound, AudioLoadSoundError)
 
 	## Load a music stream from a file.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	audio_load_music! : Str => Try(Resource.Music, AudioLoadMusicError)
+	audio_load_music! : Resource.Authority, Str => Try(Resource.Music, AudioLoadMusicError)
 
 	## Play a sound.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
@@ -492,13 +492,13 @@ Host := [].{
 
 	## Files interface
 	## Failures while reading a file as validated UTF-8.
-	FilesReadTextError : [Busy, NotFound, NotUtf8, ReadFailed, TooLarge, Unavailable]
+	FilesReadTextError : [PermissionDenied, Busy, NotFound, NotUtf8, ReadFailed, TooLarge, Unavailable]
 
 	## Failures while reading a file as bytes.
-	FilesReadBytesError : [Busy, NotFound, ReadFailed, TooLarge, Unavailable]
+	FilesReadBytesError : [PermissionDenied, Busy, NotFound, ReadFailed, TooLarge, Unavailable]
 
 	## Failures while listing one directory.
-	FilesListError : [Busy, NotADirectory, NotFound, ReadFailed, TooLarge, Unavailable]
+	FilesListError : [PermissionDenied, Busy, NotADirectory, NotFound, ReadFailed, TooLarge, Unavailable]
 
 	## One `stat`. Modification time uses the normalized `Time.Timestamp` parts.
 	FilesMetadata : {
@@ -513,19 +513,19 @@ Host := [].{
 
 	## Read bounded, validated UTF-8.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	files_read_text! : Str => Try(Str, FilesReadTextError)
+	files_read_text! : Resource.Authority, Str => Try(Str, FilesReadTextError)
 
 	## Stat one path, following symbolic links.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	files_metadata! : Str => Try(FilesMetadata, FilesMetadataError)
+	files_metadata! : Resource.Authority, Str => Try(FilesMetadata, FilesMetadataError)
 
 	## Read bounded bytes without copying the payload.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	files_read_bytes! : Str => Try(List(U8), FilesReadBytesError)
+	files_read_bytes! : Resource.Authority, Str => Try(List(U8), FilesReadBytesError)
 
 	## List one directory into the encoded form `Files` decodes.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	files_list! : Str => Try(List(U8), FilesListError)
+	files_list! : Resource.Authority, Str => Try(List(U8), FilesListError)
 
 	## Failures while replacing a whole file.
 	##
@@ -535,11 +535,11 @@ Host := [].{
 
 	## Replace a file with UTF-8.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	files_write_text! : Str, Str => Try({}, FilesWriteError)
+	files_write_text! : Resource.Authority, Str, Str => Try({}, FilesWriteError)
 
 	## Replace a file with bytes; the same failures as a text write.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	files_write_bytes! : Str, List(U8) => Try({}, FilesWriteError)
+	files_write_bytes! : Resource.Authority, Str, List(U8) => Try({}, FilesWriteError)
 
 	## Http interface
 	## One ordered HTTP header.
@@ -576,11 +576,11 @@ Host := [].{
 	##
 	## `Other` carries the host's own description, so a host that learns to
 	## distinguish a new failure still reports something an app can print.
-	HttpSendError : [MalformedResponse, NetworkError, Other(Str), Timeout]
+	HttpSendError : [PermissionDenied, MalformedResponse, NetworkError, Other(Str), Timeout]
 
 	## Send one request and wait for the whole response.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	http_send! : HttpRequestToHost => Try(HttpResponseFromHost, HttpSendError)
+	http_send! : Resource.Authority, HttpRequestToHost => Try(HttpResponseFromHost, HttpSendError)
 
 	## Cmd interface
 	## One child-process environment variable.
@@ -631,28 +631,28 @@ Host := [].{
 
 	## Start one child process and wait for it to finish.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	cmd_run! : CmdRunArgs => Try(CmdOutput, CmdRunError)
+	cmd_run! : Resource.Authority, CmdRunArgs => Try(CmdOutput, CmdRunError)
 
 	## Stdio interface
 	## Failures while queueing one atomic write.
 	##
 	## `TooLarge` is a payload past the whole ring and can never be queued;
 	## `BufferFull` is one that does not fit right now.
-	StdioWriteError : [BufferFull, TooLarge, Unavailable]
+	StdioWriteError : [PermissionDenied, BufferFull, TooLarge, Unavailable]
 
 	## Queue UTF-8 atomically.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	stdio_write_text! : U8, Str => Try({}, StdioWriteError)
+	stdio_write_text! : Resource.Authority, U8, Str => Try({}, StdioWriteError)
 
 	## Queue UTF-8 and a newline as one reservation.
 	##
 	## Host-side appending avoids a copy and prevents interleaved writes.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	stdio_write_line! : U8, Str => Try({}, StdioWriteError)
+	stdio_write_line! : Resource.Authority, U8, Str => Try({}, StdioWriteError)
 
 	## Queue bytes atomically; the same failures as a text write.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	stdio_write_bytes! : U8, List(U8) => Try({}, StdioWriteError)
+	stdio_write_bytes! : Resource.Authority, U8, List(U8) => Try({}, StdioWriteError)
 
 	## Udp interface
 	## Bind a dotted-quad IPv4 literal; port `0` requests an assigned port.
@@ -705,7 +705,7 @@ Host := [].{
 
 	## Open and bind one IPv4 UDP socket.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	udp_bind! : UdpBindArgs => Try(UdpBound, UdpBindError)
+	udp_bind! : Resource.Authority, UdpBindArgs => Try(UdpBound, UdpBindError)
 
 	## Failures while handing one datagram to the kernel.
 	## `NoRoute` is what `Udp` exposes as `Unreachable`; it is spelled
@@ -722,8 +722,8 @@ Host := [].{
 	udp_receive! : UdpReceiveArgs => Try(UdpBatch, UdpReceiveError)
 
 	## App interface
-	## Zero-sized startup authority minted by the adapter.
-	AppStartup : {}
+	## Private application-lifetime authority supplied by the host.
+	AppIo : Resource.Authority
 
 	## Stop after `init!` returns.
 	## Legal only in `init!`.
@@ -735,11 +735,7 @@ Host := [].{
 
 	## Read an environment variable.
 	## Legal only in `init!`.
-	app_read_env! : Str => Try(Str, [NotFound])
-
-	## Read a whole UTF-8 file during startup.
-	## Legal only in `init!`.
-	app_read_text! : Str => Try(Str, [NotFound, ReadFailed])
+	app_read_env! : Resource.Authority, Str => Try(Str, [PermissionDenied, NotFound])
 
 	## Random interface
 	## Draw from operating-system entropy.
@@ -759,15 +755,15 @@ Host := [].{
 
 	## Window interface
 	## Failures while reading the system clipboard as text.
-	WindowClipboardError : [Busy, TooLarge, Unavailable]
+	WindowClipboardError : [PermissionDenied, Busy, TooLarge, Unavailable]
 
 	## Get clipboard text.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	window_read_clipboard! : () => Try(Str, WindowClipboardError)
+	window_read_clipboard! : Resource.Authority => Try(Str, WindowClipboardError)
 
 	## Replace the clipboard with UTF-8 text.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	window_set_clipboard_text! : Str => {}
+	window_set_clipboard_text! : Resource.Authority, Str => Try({}, [PermissionDenied])
 
 	## Suggest a logical size; `NotSupported` means a fixed-size target.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
@@ -918,7 +914,7 @@ Host := [].{
 	}
 
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	tilemap_load_tmx! : Str => Try(TilemapMap, [NotFound, ParseFailed, ReadFailed, Unsupported])
+	tilemap_load_tmx! : Resource.Authority, Str => Try(TilemapMap, [PermissionDenied, NotFound, ParseFailed, ReadFailed, Unsupported])
 
 	## Legal in `render!` only.
 	tilemap_draw! : TilemapRenderRequest => {}
@@ -954,7 +950,7 @@ Host := [].{
 	SqliteFailure : { code : I64, message : Str }
 
 	## Failures while opening a connection.
-	SqliteOpenError : [SqliteErr(SqliteFailure), TooManyConnections]
+	SqliteOpenError : [PermissionDenied, SqliteErr(SqliteFailure), TooManyConnections]
 
 	## Failures with nothing to report but the failure itself.
 	SqliteStatusError : [SqliteErr(SqliteFailure)]
@@ -984,7 +980,7 @@ Host := [].{
 	## Open or create a database. `mode` is `0` read/write/create, `1`
 	## read/write, `2` read-only.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	sqlite_open! : Str, U8, U64, U64 => Try(Resource.Db, SqliteOpenError)
+	sqlite_open! : Resource.Authority, Str, U8, U64, U64 => Try(Resource.Db, SqliteOpenError)
 
 	## Close early; final handle release remains the fallback.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
@@ -1237,7 +1233,7 @@ Host := [].{
 	}
 
 	## Failures while finalizing a running recording.
-	CaptureStopError : [BudgetExceeded, Busy, NotRecording, ReadbackFailed, TargetUnavailable, Unavailable]
+	CaptureStopError : [PermissionDenied, BudgetExceeded, Busy, NotRecording, ReadbackFailed, TargetUnavailable, Unavailable]
 
 	## Scripted pointer state; inactive returns control to hardware.
 	CaptureVirtualMouse : {
@@ -1269,22 +1265,22 @@ Host := [].{
 	capture_set_virtual_text! : List(U32) => {}
 
 	## Failures while arming a recording.
-	CaptureStartError : [AlreadyRecording, Busy, PathEscapesOutputDir, PathInvalid, Unavailable, UnsupportedFormat, WriteFailed]
+	CaptureStartError : [PermissionDenied, AlreadyRecording, Busy, PathEscapesOutputDir, PathInvalid, Unavailable, UnsupportedFormat, WriteFailed]
 
 	## Arm recording and latch its result for the next `Input`.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	capture_start_recording! : CaptureStartRecording => Try({}, CaptureStartError)
+	capture_start_recording! : Resource.Authority, CaptureStartRecording => Try({}, CaptureStartError)
 
 	## Finalize the running recording and write its file.
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	capture_stop_recording! : () => Try(CaptureStopped, CaptureStopError)
+	capture_stop_recording! : Resource.Authority => Try(CaptureStopped, CaptureStopError)
 
 	## Failures while writing one framebuffer as PNG.
-	CaptureScreenshotError : [AlreadyPending, Busy, PathEscapesOutputDir, PathInvalid, Unavailable, WriteFailed]
+	CaptureScreenshotError : [PermissionDenied, AlreadyPending, Busy, PathEscapesOutputDir, PathInvalid, Unavailable, WriteFailed]
 
 	## Write the next framebuffer as PNG, parking until complete.
 	## Legal only in a task, where it parks the task; refused in `init!`, `update!`, and `render!`.
-	capture_screenshot! : Str => Try({}, CaptureScreenshotError)
+	capture_screenshot! : Resource.Authority, Str => Try({}, CaptureScreenshotError)
 
 	## A render target and output path.
 	CaptureTextureShot : {
@@ -1293,11 +1289,11 @@ Host := [].{
 	}
 
 	## Failures while exporting one render target as PNG.
-	CaptureTextureShotError : [BudgetExceeded, Busy, OutOfMemory, PathEscapesOutputDir, PathInvalid, ReadbackFailed, TargetUnavailable, Unavailable, WriteFailed]
+	CaptureTextureShotError : [PermissionDenied, BudgetExceeded, Busy, OutOfMemory, PathEscapesOutputDir, PathInvalid, ReadbackFailed, TargetUnavailable, Unavailable, WriteFailed]
 
 	## Read back a target, then park while encoding and writing its PNG.
 	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the task; refused in `update!` and `render!`.
-	capture_screenshot_texture! : CaptureTextureShot => Try({}, CaptureTextureShotError)
+	capture_screenshot_texture! : Resource.Authority, CaptureTextureShot => Try({}, CaptureTextureShotError)
 
 	## Flattened screen-or-target source.
 	##

--- a/platform/Http.roc
+++ b/platform/Http.roc
@@ -17,17 +17,18 @@
 ## import http.Request
 ## ```
 ##
-## `Http.get!` and `Http.get_utf8!` take a URL and hand back decoded data, so
+## `Http.Client.get!` and `Http.Client.get_utf8!` take a URL and hand back decoded data, so
 ## an app that uses only those needs no package dependency of its own.
 ##
-## `Http.send!` waits, so it belongs inside `Task.spawn!`:
+## `Http.Client.send!` waits, so it belongs inside `Task.spawn!`:
 ##
 ## ```roc
-## update! = |model, input| {
+## update! = |model, input, io| {
 ##     if input.devices.key_pressed(KeyR) {
+##         http = io.http()
 ##         Task.spawn!(
 ##             input,
-##             || match Http.get_utf8!("http://127.0.0.1:8000/data.json") {
+##             || match http.get_utf8!("http://127.0.0.1:8000/data.json") {
 ##                 Ok(body) => Loaded(body)
 ##                 Err(InvalidUrl(_)) => Failed("that is not a URL this platform will fetch")
 ##                 Err(HttpErr(Timeout)) => Failed("the request timed out")
@@ -66,6 +67,7 @@
 ## HTTPS verifies peers with the operating system's certificate store. Custom
 ## certificate authorities and disabling verification are not supported.
 import Host
+import Resource
 import Url
 import http.Request
 import http.Response
@@ -120,57 +122,6 @@ Http := [].{
 		max_response_bytes: 8 * 1024 * 1024,
 	}
 
-	## Validate and send an HTTP request under `default_config`.
-	##
-	## The request URI must be an absolute HTTP or HTTPS URL accepted by `Url`.
-	## An invalid URL answers `InvalidUrl` before any host effect occurs.
-	## Fragments are removed, because they are client-side identifiers and are
-	## not sent.
-	##
-	## The method must be one of the nine RFC methods. `QUERY` and any
-	## `Unknown(ext)` method fail as `HttpErr(Other(...))` naming the method,
-	## also before any host effect occurs: the host's method type has no
-	## representation for either, and reporting it as `Other` keeps an app's
-	## exhaustive match over `TransportErr` from breaking over a request no
-	## host could send.
-	##
-	## Legal in `init!`, where it blocks startup, and in tasks, where it parks
-	## the task; refused in `update!` and `render!`.
-	##
-	## ```roc
-	## request = Request.from_method(GET).with_uri("https://www.roc-lang.org")
-	## response = Http.send!(request)?
-	## ```
-	send! : Request => Try(Response, [InvalidUrl(Url.ParseErr), HttpErr(TransportErr), ..])
-	send! = |request| send_with!(default_config, request)
-
-	## Validate and send an HTTP request under explicit limits.
-	##
-	## The same validation, the same phases, and the same outcomes as `send!`;
-	## only the deadline and the body cap differ.
-	##
-	## ```roc
-	## slow = { ..Http.default_config, timeout_ms: 2_000 }
-	## response = Http.send_with!(slow, request)?
-	## ```
-	##
-	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the
-	## task; refused in `update!` and `render!`.
-	send_with! : Config, Request => Try(Response, [InvalidUrl(Url.ParseErr), HttpErr(TransportErr), ..])
-	send_with! = |config, request| {
-		check_method(Request.method(request)) ? HttpErr
-		url = Url.parse(Request.uri(request)) ? InvalidUrl
-		canonical = Url.without_fragment(url)
-		# closed error union to open error union
-		match Host.http_send!(to_host_request(config, request, Url.to_str(canonical))) {
-			Ok(raw) => Ok(from_host_response(raw))
-			Err(MalformedResponse) => Err(HttpErr(MalformedResponse))
-			Err(NetworkError) => Err(HttpErr(NetworkError))
-			Err(Other(message)) => Err(HttpErr(Other(Str.to_utf8(message))))
-			Err(Timeout) => Err(HttpErr(Timeout))
-		}
-	}
-
 	## Encode a value as JSON and set it as the request body.
 	##
 	## This uses Roc's builtin JSON encoder, so the value's type determines the
@@ -187,43 +138,6 @@ Http := [].{
 		)
 	}
 
-	## Encode a value as JSON, attach it to the request body, and send it.
-	##
-	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the
-	## task; refused in `update!` and `render!`.
-	send_json! : Request, _ => Try(Response, [JsonErr(_), InvalidUrl(Url.ParseErr), HttpErr(TransportErr), ..])
-	send_json! = |request, value| {
-		json_request = with_json_body(request, value)?
-
-		send!(json_request)
-	}
-
-	## Perform an HTTP GET and decode the response body as a UTF-8 `Str`.
-	##
-	## The argument is a validated `Url`. Quoted literals work through
-	## `Url.from_quote`, so a URL written out in the source is checked at compile
-	## time; a string built at runtime goes through `Url.parse`.
-	##
-	## A body that is not valid UTF-8 answers `BadBody(Str)`. That is this
-	## function's own decoding failure, and is not the transport's
-	## `MalformedResponse`: the reply arrived and was a well-formed HTTP
-	## response, it just is not text. The status is not inspected, so an error
-	## page comes back as the `Str` the server sent.
-	##
-	## ```roc
-	## hello_str = Http.get_utf8!("http://localhost:8000")?
-	## ```
-	##
-	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the
-	## task; refused in `update!` and `render!`.
-	get_utf8! : Url.Url => Try(Str, [BadBody(Str), InvalidUrl(Url.ParseErr), HttpErr(TransportErr), ..])
-	get_utf8! = |url| {
-		response = send!(Request.from_method(GET).with_uri(Url.to_str(url)))?
-		body = Str.from_utf8(Response.body(response)) ? |_| BadBody("get_utf8!: response body was not valid UTF-8")
-
-		Ok(body)
-	}
-
 	## Decode a response body as JSON.
 	##
 	## This uses Roc's builtin JSON parser, so the expected result type
@@ -236,25 +150,98 @@ Http := [].{
 		Ok(decoded)
 	}
 
-	## Perform an HTTP GET and decode the response body as JSON.
-	##
-	## The expected result type selects the parser through static dispatch. The
-	## status is not inspected, so a JSON error page decodes if it happens to fit
-	## the expected shape. Same phases as `send!`.
-	##
-	## ```roc
-	## payload : Try({ foo : Str }, _)
-	## payload = Http.get!("http://localhost:8000")
-	## ```
-	##
-	## Legal in `init!`, where it blocks startup, and in tasks, where it parks the
-	## task; refused in `update!` and `render!`.
-	get! : Url.Url => Try(_, [BadBody(Str), InvalidUrl(Url.ParseErr), HttpErr(TransportErr), JsonErr(_), ..])
-	get! = |url| {
-		response = send!(Request.from_method(GET).with_uri(Url.to_str(url)))?
+	## Opaque http authority supplied by App.Io. Effects return PermissionDenied when external access is disabled.
+	Client :: Resource.Authority.{
 
-		decode_json_response(response)
+		## Private platform construction; no application can manufacture the argument.
+		for_host : Resource.Authority -> Client
+		for_host = |authority| Client.(authority)
+
+		## Validate and send an HTTP request under `default_config`.
+		##
+		## The request URI must be an absolute HTTP or HTTPS URL accepted by `Url`.
+		## An invalid URL answers `InvalidUrl` before any host effect occurs.
+		## Fragments are removed, because they are client-side identifiers and are
+		## not sent.
+		##
+		## The method must be one of the nine RFC methods. `QUERY` and any
+		## `Unknown(ext)` method fail as `HttpErr(Other(...))` naming the method,
+		## also before any host effect occurs: the host's method type has no
+		## representation for either, and reporting it as `Other` keeps an app's
+		## exhaustive match over `TransportErr` from breaking over a request no
+		## host could send.
+		##
+		## Legal in `init!`, where it blocks startup, and in tasks, where it parks
+		## the task; refused in `update!` and `render!`.
+		##
+		## ```roc
+		## request = Request.from_method(GET).with_uri("https://www.roc-lang.org")
+		## response = io.http().send!(request)?
+		## ```
+		send! : Client, Request => Try(Response, [PermissionDenied, InvalidUrl(Url.ParseErr), HttpErr(TransportErr), ..])
+		send! = |Client.(authority), request| perform_send!(authority, request)
+
+		## Validate and send an HTTP request under explicit limits.
+		##
+		## The same validation, the same phases, and the same outcomes as `send!`;
+		## only the deadline and the body cap differ.
+		##
+		## ```roc
+		## slow = { ..Http.default_config, timeout_ms: 2_000 }
+		## response = io.http().send_with!(slow, request)?
+		## ```
+		##
+		## Legal in `init!`, where it blocks startup, and in tasks, where it parks the
+		## task; refused in `update!` and `render!`.
+		send_with! : Client, Config, Request => Try(Response, [PermissionDenied, InvalidUrl(Url.ParseErr), HttpErr(TransportErr), ..])
+		send_with! = |Client.(authority), config, request| perform_send_with!(authority, config, request)
+
+		## Encode a value as JSON, attach it to the request body, and send it.
+		##
+		## Legal in `init!`, where it blocks startup, and in tasks, where it parks the
+		## task; refused in `update!` and `render!`.
+		send_json! : Client, Request, _ => Try(Response, [PermissionDenied, JsonErr(_), InvalidUrl(Url.ParseErr), HttpErr(TransportErr), ..])
+		send_json! = |Client.(authority), request, value| perform_send_json!(authority, request, value)
+
+		## Perform an HTTP GET and decode the response body as a UTF-8 `Str`.
+		##
+		## The argument is a validated `Url`. Quoted literals work through
+		## `Url.from_quote`, so a URL written out in the source is checked at compile
+		## time; a string built at runtime goes through `Url.parse`.
+		##
+		## A body that is not valid UTF-8 answers `BadBody(Str)`. That is this
+		## function's own decoding failure, and is not the transport's
+		## `MalformedResponse`: the reply arrived and was a well-formed HTTP
+		## response, it just is not text. The status is not inspected, so an error
+		## page comes back as the `Str` the server sent.
+		##
+		## ```roc
+		## hello_str = io.http().get_utf8!("http://localhost:8000")?
+		## ```
+		##
+		## Legal in `init!`, where it blocks startup, and in tasks, where it parks the
+		## task; refused in `update!` and `render!`.
+		get_utf8! : Client, Url.Url => Try(Str, [PermissionDenied, BadBody(Str), InvalidUrl(Url.ParseErr), HttpErr(TransportErr), ..])
+		get_utf8! = |Client.(authority), url| perform_get_utf8!(authority, url)
+
+		## Perform an HTTP GET and decode the response body as JSON.
+		##
+		## The expected result type selects the parser through static dispatch. The
+		## status is not inspected, so a JSON error page decodes if it happens to fit
+		## the expected shape. Same phases as `send!`.
+		##
+		## ```roc
+		## payload : Try({ foo : Str }, _)
+		## payload = io.http().get!("http://localhost:8000")
+		## ```
+		##
+		## Legal in `init!`, where it blocks startup, and in tasks, where it parks the
+		## task; refused in `update!` and `render!`.
+		get! : Client, Url.Url => Try(_, [PermissionDenied, BadBody(Str), InvalidUrl(Url.ParseErr), HttpErr(TransportErr), JsonErr(_), ..])
+		get! = |Client.(authority), url| perform_get!(authority, url)
+
 	}
+
 }
 
 ## Refuse a method this platform cannot put on the wire.
@@ -368,3 +355,45 @@ expect to_host_method_ext(GET) == ""
 # ordinary `Request.from_method(GET)` is never sent without one.
 expect to_host_timeout(NoTimeout, 30_000) == 30_000
 expect to_host_timeout(TimeoutMilliseconds(250), 30_000) == 250
+
+## Private authority-taking implementations.
+perform_send! : Resource.Authority, Request => Try(Response, [PermissionDenied, InvalidUrl(Url.ParseErr), HttpErr(Http.TransportErr), ..])
+perform_send! = |authority, request| perform_send_with!(authority, Http.default_config, request)
+
+perform_send_with! : Resource.Authority, Http.Config, Request => Try(Response, [PermissionDenied, InvalidUrl(Url.ParseErr), HttpErr(Http.TransportErr), ..])
+perform_send_with! = |authority, config, request| {
+	check_method(Request.method(request)) ? HttpErr
+	url = Url.parse(Request.uri(request)) ? InvalidUrl
+	canonical = Url.without_fragment(url)
+	# closed error union to open error union
+	match Host.http_send!(authority, to_host_request(config, request, Url.to_str(canonical))) {
+		Ok(raw) => Ok(from_host_response(raw))
+		Err(PermissionDenied) => Err(PermissionDenied)
+		Err(MalformedResponse) => Err(HttpErr(MalformedResponse))
+		Err(NetworkError) => Err(HttpErr(NetworkError))
+		Err(Other(message)) => Err(HttpErr(Other(Str.to_utf8(message))))
+		Err(Timeout) => Err(HttpErr(Timeout))
+	}
+}
+
+perform_send_json! : Resource.Authority, Request, _ => Try(Response, [PermissionDenied, JsonErr(_), InvalidUrl(Url.ParseErr), HttpErr(Http.TransportErr), ..])
+perform_send_json! = |authority, request, value| {
+	json_request = Http.with_json_body(request, value)?
+
+	perform_send!(authority, json_request)
+}
+
+perform_get_utf8! : Resource.Authority, Url.Url => Try(Str, [PermissionDenied, BadBody(Str), InvalidUrl(Url.ParseErr), HttpErr(Http.TransportErr), ..])
+perform_get_utf8! = |authority, url| {
+	response = perform_send!(authority, Request.from_method(GET).with_uri(Url.to_str(url)))?
+	body = Str.from_utf8(Response.body(response)) ? |_| BadBody("perform_get_utf8!: response body was not valid UTF-8")
+
+	Ok(body)
+}
+
+perform_get! : Resource.Authority, Url.Url => Try(_, [PermissionDenied, BadBody(Str), InvalidUrl(Url.ParseErr), HttpErr(Http.TransportErr), JsonErr(_), ..])
+perform_get! = |authority, url| {
+	response = perform_send!(authority, Request.from_method(GET).with_uri(Url.to_str(url)))?
+
+	Http.decode_json_response(response)
+}

--- a/platform/Resource.roc
+++ b/platform/Resource.roc
@@ -1,6 +1,15 @@
 ## Private typed ARC identities shared by public adapters and hosted declarations.
 ## Only the host creates live resources; the public APIs supply resource-free stubs.
 Resource := [].{
+
+	## Host-issued application-lifetime authority. Its representation never escapes the platform.
+	Authority :: U64.{
+
+		## Inert value for pure tests; never accepted by the host.
+		stub : Authority
+		stub = Authority.(0)
+	}
+
 	Handle(_resource) :: Box(U64).{
 		is_eq : Handle(_resource), Handle(_resource) -> Bool
 		is_eq = |Handle.(a), Handle.(b)| Box.unbox(a) == Box.unbox(b)

--- a/platform/Sqlite.roc
+++ b/platform/Sqlite.roc
@@ -95,7 +95,7 @@ Sqlite := [].{
 	##
 	## `TooManyConnections` means eight are already open; releasing a `Db` the
 	## app no longer needs frees a slot.
-	OpenErr : [SqliteErr(ErrCode, Str), TooManyConnections]
+	OpenErr : [PermissionDenied, SqliteErr(ErrCode, Str), TooManyConnections]
 
 	## Why a statement was not prepared.
 	##
@@ -174,40 +174,6 @@ Sqlite := [].{
 	## Keep it in the model, copy it freely, and let the last reference close
 	## it.
 	Db :: Resource.Db.{
-
-		## Open or create a database under `default_config`.
-		##
-		## The parent directory must already exist. Unlike `Files.write_text!`,
-		## which builds the tree on its way, opening a database does not create
-		## one: a database file is normally placed beside an application rather
-		## than into a directory the application is inventing, and a mistyped
-		## path should be `SqliteErr(CanNotOpen, _)` rather than a new empty
-		## tree. Create it with a write if the app owns that decision.
-		##
-		## Legal in `init!`, where it blocks startup, and in tasks, where it
-		## parks the task; refused in `update!` and `render!`.
-		open! : Str => Try(Db, OpenErr)
-		open! = |path| Db.open_with!(path, default_config)
-
-		## Open a database with explicit limits and access mode.
-		##
-		## Legal in `init!`, where it blocks startup, and in tasks, where it
-		## parks the task; refused in `update!` and `render!`.
-		open_with! : Str, Config => Try(Db, OpenErr)
-		open_with! = |path, config| {
-			result = Host.sqlite_open!(
-				path,
-				mode_code(config.mode),
-				config.busy_timeout_ms,
-				config.max_result_bytes,
-			)
-			# closed error union to open error union
-			match result {
-				Ok(db) => Ok(Db.(db))
-				Err(TooManyConnections) => Err(TooManyConnections)
-				Err(SqliteErr(failure)) => Err(sqlite_err(failure))
-			}
-		}
 
 		## Close this connection now rather than when its last handle is
 		## released.
@@ -517,6 +483,37 @@ Sqlite := [].{
 			Done => "Done: the statement has finished"
 			Unknown(other) => "Unknown: result code ${I64.to_str(other)}"
 		}
+
+	## Opaque sqlite authority supplied by App.Io. Effects return PermissionDenied when external access is disabled.
+	Service :: Resource.Authority.{
+
+		## Private platform construction; no application can manufacture the argument.
+		for_host : Resource.Authority -> Service
+		for_host = |authority| Service.(authority)
+
+		## Open or create a database under `default_config`.
+		##
+		## The parent directory must already exist. Unlike `Files.Access.write_text!`,
+		## which builds the tree on its way, opening a database does not create
+		## one: a database file is normally placed beside an application rather
+		## than into a directory the application is inventing, and a mistyped
+		## path should be `SqliteErr(CanNotOpen, _)` rather than a new empty
+		## tree. Create it with a write if the app owns that decision.
+		##
+		## Legal in `init!`, where it blocks startup, and in tasks, where it
+		## parks the task; refused in `update!` and `render!`.
+		open! : Service, Str => Try(Db, OpenErr)
+		open! = |Service.(authority), path| perform_open!(authority, path)
+
+		## Open a database with explicit limits and access mode.
+		##
+		## Legal in `init!`, where it blocks startup, and in tasks, where it
+		## parks the task; refused in `update!` and `render!`.
+		open_with! : Service, Str, Config => Try(Db, OpenErr)
+		open_with! = |Service.(authority), path, config| perform_open_with!(authority, path, config)
+
+	}
+
 }
 
 ## Access mode as the host numbers it. Mirrored in `src/sqlite_effect.zig`.
@@ -835,3 +832,25 @@ expect Sqlite.Row.bytes(Sqlite.Row.for_tests(["b"], [Bytes([1, 2])]), "b") == Ok
 expect Sqlite.Row.names(Sqlite.Row.for_tests(["a", "b"], [Integer(1), Integer(2)])) == ["a", "b"]
 
 expect Sqlite.Row.values(Sqlite.Row.for_tests(["a"], [Integer(1)])) == [Integer(1)]
+
+## Private authority-taking implementations.
+perform_open! : Resource.Authority, Str => Try(Sqlite.Db, Sqlite.OpenErr)
+perform_open! = |authority, path| perform_open_with!(authority, path, Sqlite.default_config)
+
+perform_open_with! : Resource.Authority, Str, Sqlite.Config => Try(Sqlite.Db, Sqlite.OpenErr)
+perform_open_with! = |authority, path, config| {
+	result = Host.sqlite_open!(
+		authority,
+		path,
+		mode_code(config.mode),
+		config.busy_timeout_ms,
+		config.max_result_bytes,
+	)
+	# closed error union to open error union
+	match result {
+		Ok(db) => Ok(Sqlite.Db.(db))
+		Err(PermissionDenied) => Err(PermissionDenied)
+		Err(TooManyConnections) => Err(TooManyConnections)
+		Err(SqliteErr(failure)) => Err(sqlite_err(failure))
+	}
+}

--- a/platform/Stderr.roc
+++ b/platform/Stderr.roc
@@ -10,6 +10,7 @@
 ## reported. Ordering against compiler `dbg`, `expect`, and crash output is
 ## undefined.
 import Host
+import Resource
 
 Stderr := [].{
 
@@ -23,34 +24,44 @@ Stderr := [].{
 	## which no amount of draining will ever fit. `Unavailable` is there being
 	## no queue to write into: the reader on the other end has gone away, which
 	## is an ordinary way for a pipeline to end, or the host is shutting down.
-	WriteError : [BufferFull, TooLarge, Unavailable]
+	WriteError : [PermissionDenied, BufferFull, TooLarge, Unavailable]
 
-	## Write a string and then a newline.
-	##
-	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	##
-	## The newline is always a single `\n`, on every platform. The text and its
-	## terminator are queued together, so nothing else can land between them. At
-	## most 256 kibibytes cross per call, counting the string's UTF-8 bytes and
-	## the newline; a longer string is `TooLarge` and nothing is queued.
-	line! : Str => Try({}, WriteError)
-	line! = |text| lifted(Host.stdio_write_line!(2, text))
+	## Opaque stderr authority supplied by App.Io. Effects return PermissionDenied when external access is disabled.
+	Writer :: Resource.Authority.{
 
-	## Write a string with no newline after it. Bounded exactly as `line!` is.
-	##
-	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	write! : Str => Try({}, WriteError)
-	write! = |text| lifted(Host.stdio_write_text!(2, text))
+		## Private platform construction; no application can manufacture the argument.
+		for_host : Resource.Authority -> Writer
+		for_host = |authority| Writer.(authority)
 
-	## Write bytes that are not necessarily text.
-	##
-	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	##
-	## The bytes are passed through as they are: no encoding validation, no
-	## newline, no translation. Bounded exactly as `line!` is, counting the length
-	## of the list.
-	write_bytes! : List(U8) => Try({}, WriteError)
-	write_bytes! = |bytes| lifted(Host.stdio_write_bytes!(2, bytes))
+		## Write a string and then a newline.
+		##
+		## Legal in `init!`, `update!`, and tasks; refused in `render!`.
+		##
+		## The newline is always a single `\n`, on every platform. The text and its
+		## terminator are queued together, so nothing else can land between them. At
+		## most 256 kibibytes cross per call, counting the string's UTF-8 bytes and
+		## the newline; a longer string is `TooLarge` and nothing is queued.
+		line! : Writer, Str => Try({}, WriteError)
+		line! = |Writer.(authority), text| perform_line!(authority, text)
+
+		## Write a string with no newline after it. Bounded exactly as `line!` is.
+		##
+		## Legal in `init!`, `update!`, and tasks; refused in `render!`.
+		write! : Writer, Str => Try({}, WriteError)
+		write! = |Writer.(authority), text| perform_write!(authority, text)
+
+		## Write bytes that are not necessarily text.
+		##
+		## Legal in `init!`, `update!`, and tasks; refused in `render!`.
+		##
+		## The bytes are passed through as they are: no encoding validation, no
+		## newline, no translation. Bounded exactly as `line!` is, counting the length
+		## of the list.
+		write_bytes! : Writer, List(U8) => Try({}, WriteError)
+		write_bytes! = |Writer.(authority), bytes| perform_write_bytes!(authority, bytes)
+
+	}
+
 }
 
 ## Re-lift a queued write's closed error union onto the open one this module
@@ -59,7 +70,18 @@ lifted : Try({}, Host.StdioWriteError) -> Try({}, WriteError)
 lifted = |result|
 	match result {
 		Ok({}) => Ok({})
+		Err(PermissionDenied) => Err(PermissionDenied)
 		Err(BufferFull) => Err(BufferFull)
 		Err(TooLarge) => Err(TooLarge)
 		Err(Unavailable) => Err(Unavailable)
 	}
+
+## Private authority-taking implementations.
+perform_line! : Resource.Authority, Str => Try({}, Stderr.WriteError)
+perform_line! = |authority, text| lifted(Host.stdio_write_line!(authority, 2, text))
+
+perform_write! : Resource.Authority, Str => Try({}, Stderr.WriteError)
+perform_write! = |authority, text| lifted(Host.stdio_write_text!(authority, 2, text))
+
+perform_write_bytes! : Resource.Authority, List(U8) => Try({}, Stderr.WriteError)
+perform_write_bytes! = |authority, bytes| lifted(Host.stdio_write_bytes!(authority, 2, bytes))

--- a/platform/Stdout.roc
+++ b/platform/Stdout.roc
@@ -9,6 +9,7 @@
 ## order and are drained during orderly shutdown, but eventual delivery is not
 ## reported. Ordering against `dbg`, `expect`, and crash output is undefined.
 import Host
+import Resource
 
 Stdout := [].{
 
@@ -22,34 +23,44 @@ Stdout := [].{
 	## which no amount of draining will ever fit. `Unavailable` is there being
 	## no queue to write into: the reader on the other end has gone away, which
 	## is an ordinary way for a pipeline to end, or the host is shutting down.
-	WriteError : [BufferFull, TooLarge, Unavailable]
+	WriteError : [PermissionDenied, BufferFull, TooLarge, Unavailable]
 
-	## Write a string and then a newline.
-	##
-	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	##
-	## The newline is always a single `\n`, on every platform. The text and its
-	## terminator are queued together, so nothing else can land between them. At
-	## most 256 kibibytes cross per call, counting the string's UTF-8 bytes and
-	## the newline; a longer string is `TooLarge` and nothing is queued.
-	line! : Str => Try({}, WriteError)
-	line! = |text| lifted(Host.stdio_write_line!(1, text))
+	## Opaque stdout authority supplied by App.Io. Effects return PermissionDenied when external access is disabled.
+	Writer :: Resource.Authority.{
 
-	## Write a string with no newline after it. Bounded exactly as `line!` is.
-	##
-	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	write! : Str => Try({}, WriteError)
-	write! = |text| lifted(Host.stdio_write_text!(1, text))
+		## Private platform construction; no application can manufacture the argument.
+		for_host : Resource.Authority -> Writer
+		for_host = |authority| Writer.(authority)
 
-	## Write bytes that are not necessarily text.
-	##
-	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	##
-	## The bytes are passed through as they are: no encoding validation, no
-	## newline, no translation. Bounded exactly as `line!` is, counting the length
-	## of the list.
-	write_bytes! : List(U8) => Try({}, WriteError)
-	write_bytes! = |bytes| lifted(Host.stdio_write_bytes!(1, bytes))
+		## Write a string and then a newline.
+		##
+		## Legal in `init!`, `update!`, and tasks; refused in `render!`.
+		##
+		## The newline is always a single `\n`, on every platform. The text and its
+		## terminator are queued together, so nothing else can land between them. At
+		## most 256 kibibytes cross per call, counting the string's UTF-8 bytes and
+		## the newline; a longer string is `TooLarge` and nothing is queued.
+		line! : Writer, Str => Try({}, WriteError)
+		line! = |Writer.(authority), text| perform_line!(authority, text)
+
+		## Write a string with no newline after it. Bounded exactly as `line!` is.
+		##
+		## Legal in `init!`, `update!`, and tasks; refused in `render!`.
+		write! : Writer, Str => Try({}, WriteError)
+		write! = |Writer.(authority), text| perform_write!(authority, text)
+
+		## Write bytes that are not necessarily text.
+		##
+		## Legal in `init!`, `update!`, and tasks; refused in `render!`.
+		##
+		## The bytes are passed through as they are: no encoding validation, no
+		## newline, no translation. Bounded exactly as `line!` is, counting the length
+		## of the list.
+		write_bytes! : Writer, List(U8) => Try({}, WriteError)
+		write_bytes! = |Writer.(authority), bytes| perform_write_bytes!(authority, bytes)
+
+	}
+
 }
 
 ## Re-lift a queued write's closed error union onto the open one this module
@@ -58,7 +69,18 @@ lifted : Try({}, Host.StdioWriteError) -> Try({}, WriteError)
 lifted = |result|
 	match result {
 		Ok({}) => Ok({})
+		Err(PermissionDenied) => Err(PermissionDenied)
 		Err(BufferFull) => Err(BufferFull)
 		Err(TooLarge) => Err(TooLarge)
 		Err(Unavailable) => Err(Unavailable)
 	}
+
+## Private authority-taking implementations.
+perform_line! : Resource.Authority, Str => Try({}, Stdout.WriteError)
+perform_line! = |authority, text| lifted(Host.stdio_write_line!(authority, 1, text))
+
+perform_write! : Resource.Authority, Str => Try({}, Stdout.WriteError)
+perform_write! = |authority, text| lifted(Host.stdio_write_text!(authority, 1, text))
+
+perform_write_bytes! : Resource.Authority, List(U8) => Try({}, Stdout.WriteError)
+perform_write_bytes! = |authority, bytes| lifted(Host.stdio_write_bytes!(authority, 1, bytes))

--- a/platform/Task.roc
+++ b/platform/Task.roc
@@ -5,7 +5,7 @@
 ## serially on the frame thread, so pure computation still blocks frames.
 ##
 ## ```roc
-## update! = |model, input| {
+## update! = |model, input, io| {
 ##     if input.devices.key_pressed(KeyEnter) {
 ##         Task.spawn!(
 ##             input,

--- a/platform/Tilemap.roc
+++ b/platform/Tilemap.roc
@@ -5,7 +5,7 @@
 ## in the model. Drawing requires `Draw.Frame` and is legal only in `render!`.
 ##
 ## ```roc
-## raw = Tilemap.load_tmx!("assets/level.tmx")?
+## raw = io.tilemaps().load_tmx!("assets/level.tmx")?
 ## tilemap = Tilemap.from_raw(raw)
 ##     .with_origin({ x: 0, y: 0 })
 ##     .with_tileset_texture(1, tiles)
@@ -27,6 +27,7 @@ import Camera
 import Draw
 import Math
 import Host
+import Resource
 
 TilemapRawProperty : Host.TilemapProperty
 
@@ -261,26 +262,6 @@ Tilemap :: {
 		render_layers: [],
 		render_tilesets: [],
 	}
-
-	## Parse a Tiled TMX map.
-	##
-	## The returned data is an allocation-efficient set of flat lists with index
-	## ranges for nested properties, objects, and tile data.
-	##
-	## Legal in `init!`, where it blocks startup, and in tasks, where it parks
-	## the task; refused in `update!` and `render!`. A map is more than one
-	## file: an external tileset is read the same way, so a map spread across
-	## several files parks once per file and parses in between.
-	load_tmx! : Str => Try(TilemapRawMap, [NotFound, ReadFailed, ParseFailed, Unsupported, ..])
-	load_tmx! = |path|
-	# closed error union to open error union
-		match Host.tilemap_load_tmx!(path) {
-			Ok(map) => Ok(map)
-			Err(NotFound) => Err(NotFound)
-			Err(ReadFailed) => Err(ReadFailed)
-			Err(ParseFailed) => Err(ParseFailed)
-			Err(Unsupported) => Err(Unsupported)
-		}
 
 	## Begin configuring a drawable and queryable tilemap from parsed TMX data.
 	from_raw : TilemapRawMap -> TilemapBuilder
@@ -607,6 +588,28 @@ Tilemap :: {
 		without_d = if without_v >= 536_870_912 without_v - 536_870_912 else without_v
 		if without_d >= 268_435_456 without_d - 268_435_456 else without_d
 	}
+
+	## Opaque tilemaps authority supplied by App.Io. Effects return PermissionDenied when external access is disabled.
+	Loader :: Resource.Authority.{
+
+		## Private platform construction; no application can manufacture the argument.
+		for_host : Resource.Authority -> Loader
+		for_host = |authority| Loader.(authority)
+
+		## Parse a Tiled TMX map.
+		##
+		## The returned data is an allocation-efficient set of flat lists with index
+		## ranges for nested properties, objects, and tile data.
+		##
+		## Legal in `init!`, where it blocks startup, and in tasks, where it parks
+		## the task; refused in `update!` and `render!`. A map is more than one
+		## file: an external tileset is read the same way, so a map spread across
+		## several files parks once per file and parses in between.
+		load_tmx! : Loader, Str => Try(TilemapRawMap, [PermissionDenied, NotFound, ReadFailed, ParseFailed, Unsupported, ..])
+		load_tmx! = |Loader.(authority), path| perform_load_tmx!(authority, path)
+
+	}
+
 }
 
 layer_role_for_rules : List(TilemapLayerRoleRule), Str -> TilemapLayerRole
@@ -1192,3 +1195,16 @@ expect {
 	camera = Camera.follow({ x: 100, y: 200 }, { screen: { x: 800, y: 600 }, zoom: 2 })
 	Tilemap.viewport_for_camera(camera, { x: 800, y: 600 }) == Math.rect(-100, 50, 400, 300)
 }
+
+## Private authority-taking implementations.
+perform_load_tmx! : Resource.Authority, Str => Try(TilemapRawMap, [PermissionDenied, NotFound, ReadFailed, ParseFailed, Unsupported, ..])
+perform_load_tmx! = |authority, path|
+# closed error union to open error union
+	match Host.tilemap_load_tmx!(authority, path) {
+		Ok(map) => Ok(map)
+		Err(PermissionDenied) => Err(PermissionDenied)
+		Err(NotFound) => Err(NotFound)
+		Err(ReadFailed) => Err(ReadFailed)
+		Err(ParseFailed) => Err(ParseFailed)
+		Err(Unsupported) => Err(Unsupported)
+	}

--- a/platform/Udp.roc
+++ b/platform/Udp.roc
@@ -10,7 +10,7 @@
 ## ```roc
 ## Msg : [Arrived(List(Udp.Datagram)), ReceiveFailed(Udp.ReceiveError)]
 ##
-## update! = |model, input| {
+## update! = |model, input, io| {
 ##     socket = model.socket
 ##     if !model.listening {
 ##         Task.spawn!(
@@ -124,29 +124,6 @@ Udp := [].{
 	max_datagram_bytes : U64
 	max_datagram_bytes = 65507
 
-	## Bind a socket to a local address.
-	##
-	## `{ ip: "0.0.0.0", port: 0 }` takes any interface and lets the operating
-	## system choose the port; the returned socket's `local_address` reports
-	## what it chose. Bind once, in `init!` or when the app decides to start
-	## networking, and keep the socket in the model -- binding per frame would
-	## exhaust the eight-socket ceiling and change the port every time.
-	##
-	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	bind! : Address => Try(Socket, BindError)
-	bind! = |address| {
-		# closed error union to open error union
-		match Host.udp_bind!({ ip: address.ip, port: address.port }) {
-			Ok(bound) => Ok(Socket.({ handle: bound.handle, local: { ip: format_ip(bound.ip), port: bound.port } }))
-			Err(AddressInUse) => Err(AddressInUse)
-			Err(AddressUnavailable) => Err(AddressUnavailable)
-			Err(InvalidAddress) => Err(InvalidAddress)
-			Err(PermissionDenied) => Err(PermissionDenied)
-			Err(ResourceLimit) => Err(ResourceLimit)
-			Err(Unavailable) => Err(Unavailable)
-		}
-	}
-
 	## An open datagram socket.
 	##
 	## The handle is reference counted: copy it freely, and when the last copy
@@ -232,6 +209,28 @@ Udp := [].{
 		stub : Socket
 		stub = Socket.({ handle: Resource.Handle.stub, local: { ip: "0.0.0.0", port: 0 } })
 	}
+
+	## Opaque udp authority supplied by App.Io. Effects return PermissionDenied when external access is disabled.
+	Network :: Resource.Authority.{
+
+		## Private platform construction; no application can manufacture the argument.
+		for_host : Resource.Authority -> Network
+		for_host = |authority| Network.(authority)
+
+		## Bind a socket to a local address.
+		##
+		## `{ ip: "0.0.0.0", port: 0 }` takes any interface and lets the operating
+		## system choose the port; the returned socket's `local_address` reports
+		## what it chose. Bind once, in `init!` or when the app decides to start
+		## networking, and keep the socket in the model -- binding per frame would
+		## exhaust the eight-socket ceiling and change the port every time.
+		##
+		## Legal in `init!`, `update!`, and tasks; refused in `render!`.
+		bind! : Network, Address => Try(Socket, BindError)
+		bind! = |Network.(authority), address| perform_bind!(authority, address)
+
+	}
+
 }
 
 ## Rebuild the datagrams from the flat batch the host delivered.
@@ -277,3 +276,18 @@ expect {
 }
 
 expect decode_batch([], []) == []
+
+## Private authority-taking implementations.
+perform_bind! : Resource.Authority, Udp.Address => Try(Udp.Socket, Udp.BindError)
+perform_bind! = |authority, address| {
+	# closed error union to open error union
+	match Host.udp_bind!(authority, { ip: address.ip, port: address.port }) {
+		Ok(bound) => Ok(Udp.Socket.({ handle: bound.handle, local: { ip: format_ip(bound.ip), port: bound.port } }))
+		Err(AddressInUse) => Err(AddressInUse)
+		Err(AddressUnavailable) => Err(AddressUnavailable)
+		Err(InvalidAddress) => Err(InvalidAddress)
+		Err(PermissionDenied) => Err(PermissionDenied)
+		Err(ResourceLimit) => Err(ResourceLimit)
+		Err(Unavailable) => Err(Unavailable)
+	}
+}

--- a/platform/Url.roc
+++ b/platform/Url.roc
@@ -7,7 +7,7 @@
 ## references.
 ##
 ## ```roc
-## body = Http.get_utf8!("http://127.0.0.1:8000/data.json")?
+## body = io.http().get_utf8!("http://127.0.0.1:8000/data.json")?
 ## ```
 ##
 ## Parsing is deliberately stricter than a browser's. Hosts must be ASCII DNS

--- a/platform/Window.roc
+++ b/platform/Window.roc
@@ -11,6 +11,7 @@
 ## decline; a later `Snapshot` is authoritative. `set_*` effects change state
 ## controlled by the host.
 import Host
+import Resource
 
 Window := [].{
 
@@ -65,25 +66,7 @@ Window := [].{
 	## `Unavailable` is an empty clipboard, non-text content, or a backend that
 	## refused. `TooLarge` is content past what the host will copy into a `Str`,
 	## and `Busy` is another process holding the clipboard.
-	ClipboardReadError : [Unavailable, TooLarge, Busy]
-
-	## Read the system clipboard as text.
-	##
-	## Legal in `init!`, `update!`, and tasks; refused in `render!`. The windowing
-	## backend only answers on the thread that owns the window, and the read is a
-	## pointer copy rather than I/O, so this does not wait.
-	##
-	## Content that is not text, or is larger than the host will copy into a
-	## `Str`, is refused rather than truncated.
-	read_clipboard! : () => Try(Str, ClipboardReadError)
-	read_clipboard! = ||
-		match Host.window_read_clipboard!() {
-			# closed error union to open error union
-			Ok(contents) => Ok(contents)
-			Err(Busy) => Err(Busy)
-			Err(TooLarge) => Err(TooLarge)
-			Err(Unavailable) => Err(Unavailable)
-		}
+	ClipboardReadError : [PermissionDenied, Unavailable, TooLarge, Busy]
 
 	## Set raylib's CPU-side frame-rate cap.
 	##
@@ -93,14 +76,6 @@ Window := [].{
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
 	set_target_fps! : I32 => {}
 	set_target_fps! = |fps| Host.window_set_target_fps!(fps)
-
-	## Replace the system clipboard contents.
-	##
-	## Read it back with `Window.read_clipboard!`.
-	##
-	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
-	set_clipboard_text! : Str => {}
-	set_clipboard_text! = |text| Host.window_set_clipboard_text!(text)
 
 	## How many framebuffer pixels one logical unit is, per axis.
 	##
@@ -161,6 +136,35 @@ Window := [].{
 	## Legal in `init!`, `update!`, and tasks; refused in `render!`.
 	suggest_monitor! : I32 => {}
 	suggest_monitor! = |index| Host.window_suggest_monitor!(index)
+
+	## Opaque clipboard authority supplied by App.Io. Effects return PermissionDenied when external access is disabled.
+	Clipboard :: Resource.Authority.{
+
+		## Private platform construction; no application can manufacture the argument.
+		for_host : Resource.Authority -> Clipboard
+		for_host = |authority| Clipboard.(authority)
+
+		## Read the system clipboard as text.
+		##
+		## Legal in `init!`, `update!`, and tasks; refused in `render!`. The windowing
+		## backend only answers on the thread that owns the window, and the read is a
+		## pointer copy rather than I/O, so this does not wait.
+		##
+		## Content that is not text, or is larger than the host will copy into a
+		## `Str`, is refused rather than truncated.
+		read_text! : Clipboard => Try(Str, ClipboardReadError)
+		read_text! = |Clipboard.(authority)| perform_read_clipboard!(authority)
+
+		## Replace the system clipboard contents.
+		##
+		## Read it back with `Window.Clipboard.read_text!`.
+		##
+		## Legal in `init!`, `update!`, and tasks; refused in `render!`.
+		set_text! : Clipboard, Str => Try({}, [PermissionDenied, ..])
+		set_text! = |Clipboard.(authority), text| perform_set_clipboard_text!(authority, text)
+
+	}
+
 }
 
 ## Group the host's flat monitor record into the shape applications read.
@@ -176,4 +180,22 @@ monitor_from_host = |info| {
 expect {
 	monitor = monitor_from_host({ index: 1, name: "HDMI-1", width: 2560, height: 1440, x: 1920, y: 0, refresh_hz: 144 })
 	monitor.size == { width: 2560, height: 1440 } and monitor.position == { x: 1920, y: 0 }
+}
+
+## Private authority-taking implementations.
+perform_read_clipboard! : Resource.Authority => Try(Str, Window.ClipboardReadError)
+perform_read_clipboard! = |authority|
+	match Host.window_read_clipboard!(authority) {
+		# closed error union to open error union
+		Ok(contents) => Ok(contents)
+		Err(PermissionDenied) => Err(PermissionDenied)
+		Err(Busy) => Err(Busy)
+		Err(TooLarge) => Err(TooLarge)
+		Err(Unavailable) => Err(Unavailable)
+	}
+
+perform_set_clipboard_text! : Resource.Authority, Str => Try({}, [PermissionDenied, ..])
+perform_set_clipboard_text! = |authority, text| match Host.window_set_clipboard_text!(authority, text) {
+	Ok({}) => Ok({})
+	Err(PermissionDenied) => Err(PermissionDenied)
 }

--- a/platform/main-wayland.roc
+++ b/platform/main-wayland.roc
@@ -2,8 +2,13 @@
 ## Roc applications.
 ##
 ## An app provides `init!`, `update!`, and `render!`. `init!` creates the first
-## model. Each host cycle, `update!` folds one `App.Input` into the next model;
+## model with `App.Io` authority. Each host cycle, `update!` receives that same
+## authority and folds one `App.Input` into the next model;
 ## `render!` may then draw that model through a `Draw.Frame`.
+##
+## Select external services with receivers such as `io.files()` and `io.http()`.
+## External effects return `PermissionDenied` unless the launcher grants
+## `--host-caps-allow-all`. Phase rules and resource bounds still apply.
 ##
 ## Host-state effects are legal in `init!`, `update!`, and tasks. Drawing is
 ## legal only in `render!`. Waiting effects are legal in `init!`, where they
@@ -29,10 +34,10 @@
 ## program = { init!, update!, render! }
 ##
 ## init! : App.Init(Model, [])
-## init! = App.init(App.default.with_title("Hello"), |_startup| Ok({ frames: 0 }))
+## init! = App.init(App.default.with_title("Hello"), |_io| Ok({ frames: 0 }))
 ##
-## update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-## update! = |model, input|
+## update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+## update! = |model, input, _io|
 ##     if input.devices.key_pressed(KeyEscape) {
 ##         Err(Exit(0))
 ##     } else {
@@ -52,9 +57,9 @@ platform ""
 		[Model : model, Msg : msg] for program : {
 			init! : {
 				config : List(Str) -> App.Config,
-				run! : App.Startup => Try(model, [Exit(I64), ..]),
+				run! : App.Io => Try(model, [Exit(I64), ..]),
 			},
-			update! : model, App.Input(msg) => Try(model, [Exit(I64), ..]),
+			update! : model, App.Input(msg), App.Io => Try(model, [Exit(I64), ..]),
 			render! : model, Draw.Frame => Try({}, [Exit(I64), ..]),
 		}
 	}
@@ -154,7 +159,6 @@ platform ""
 		"roc_app_exit": Host.app_exit!,
 		"roc_app_args": Host.app_args!,
 		"roc_app_read_env": Host.app_read_env!,
-		"roc_app_read_text_raw": Host.app_read_text!,
 		"roc_random_entropy": Host.random_entropy!,
 		"roc_random_i32": Host.random_i32!,
 		"roc_keys_set_exit_key": Host.keys_set_exit_key!,
@@ -342,9 +346,9 @@ app_input_from_raw = |devices, window, time, capture, messages, dropped, dropped
 ## Run the app's startup callback with the platform's startup authority.
 ##
 ## No input, window, or timing observations have been sampled at this point.
-init_for_host! : () => Try(Box(Model), I64)
-init_for_host! = ||
-	match (program.init!.run!)(App.Startup.for_host({})) {
+init_for_host! : Host.AppIo => Try(Box(Model), I64)
+init_for_host! = |authority|
+	match (program.init!.run!)(App.Io.for_host(authority)) {
 		Ok(model) => Ok(Box.box(model))
 		Err(Exit(code)) => Err(code)
 		Err(_) => Err(-1)
@@ -364,12 +368,12 @@ init_for_host! = ||
 ## referenced and mutates them rather than copying. `test/model_inplace` holds
 ## that to under a hundred bytes per frame for a million-element `List(F32)`,
 ## under `scripts/test_model_allocation.py`.
-update_for_host! : Box(Model), InputFromHostCycle(Msg) => Try(Box(Model), I64)
-update_for_host! = |boxed_model, { devices, window, time, task_results, capture, dropped, dropped_overflow }| {
+update_for_host! : Box(Model), InputFromHostCycle(Msg), Host.AppIo => Try(Box(Model), I64)
+update_for_host! = |boxed_model, { devices, window, time, task_results, capture, dropped, dropped_overflow }, authority| {
 	messages = receive_task_results(task_results)
 	input = app_input_from_raw(devices, window, time, capture, messages, dropped, dropped_overflow)
 	model = Box.unbox(boxed_model)
-	match (program.update!)(model, input) {
+	match (program.update!)(model, input, App.Io.for_host(authority)) {
 		Ok(next) => Ok(Box.box(next))
 		Err(Exit(code)) => Err(code)
 		Err(_) => Err(-1)

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -2,8 +2,13 @@
 ## Roc applications.
 ##
 ## An app provides `init!`, `update!`, and `render!`. `init!` creates the first
-## model. Each host cycle, `update!` folds one `App.Input` into the next model;
+## model with `App.Io` authority. Each host cycle, `update!` receives that same
+## authority and folds one `App.Input` into the next model;
 ## `render!` may then draw that model through a `Draw.Frame`.
+##
+## Select external services with receivers such as `io.files()` and `io.http()`.
+## External effects return `PermissionDenied` unless the launcher grants
+## `--host-caps-allow-all`. Phase rules and resource bounds still apply.
 ##
 ## Host-state effects are legal in `init!`, `update!`, and tasks. Drawing is
 ## legal only in `render!`. Waiting effects are legal in `init!`, where they
@@ -29,10 +34,10 @@
 ## program = { init!, update!, render! }
 ##
 ## init! : App.Init(Model, [])
-## init! = App.init(App.default.with_title("Hello"), |_startup| Ok({ frames: 0 }))
+## init! = App.init(App.default.with_title("Hello"), |_io| Ok({ frames: 0 }))
 ##
-## update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-## update! = |model, input|
+## update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+## update! = |model, input, _io|
 ##     if input.devices.key_pressed(KeyEscape) {
 ##         Err(Exit(0))
 ##     } else {
@@ -52,9 +57,9 @@ platform ""
 		[Model : model, Msg : msg] for program : {
 			init! : {
 				config : List(Str) -> App.Config,
-				run! : App.Startup => Try(model, [Exit(I64), ..]),
+				run! : App.Io => Try(model, [Exit(I64), ..]),
 			},
-			update! : model, App.Input(msg) => Try(model, [Exit(I64), ..]),
+			update! : model, App.Input(msg), App.Io => Try(model, [Exit(I64), ..]),
 			render! : model, Draw.Frame => Try({}, [Exit(I64), ..]),
 		}
 	}
@@ -154,7 +159,6 @@ platform ""
 		"roc_app_exit": Host.app_exit!,
 		"roc_app_args": Host.app_args!,
 		"roc_app_read_env": Host.app_read_env!,
-		"roc_app_read_text_raw": Host.app_read_text!,
 		"roc_random_entropy": Host.random_entropy!,
 		"roc_random_i32": Host.random_i32!,
 		"roc_keys_set_exit_key": Host.keys_set_exit_key!,
@@ -345,9 +349,9 @@ app_input_from_raw = |devices, window, time, capture, messages, dropped, dropped
 ## Run the app's startup callback with the platform's startup authority.
 ##
 ## No input, window, or timing observations have been sampled at this point.
-init_for_host! : () => Try(Box(Model), I64)
-init_for_host! = ||
-	match (program.init!.run!)(App.Startup.for_host({})) {
+init_for_host! : Host.AppIo => Try(Box(Model), I64)
+init_for_host! = |authority|
+	match (program.init!.run!)(App.Io.for_host(authority)) {
 		Ok(model) => Ok(Box.box(model))
 		Err(Exit(code)) => Err(code)
 		Err(_) => Err(-1)
@@ -367,12 +371,12 @@ init_for_host! = ||
 ## referenced and mutates them rather than copying. `test/model_inplace` holds
 ## that to under a hundred bytes per frame for a million-element `List(F32)`,
 ## under `scripts/test_model_allocation.py`.
-update_for_host! : Box(Model), InputFromHostCycle(Msg) => Try(Box(Model), I64)
-update_for_host! = |boxed_model, { devices, window, time, task_results, capture, dropped, dropped_overflow }| {
+update_for_host! : Box(Model), InputFromHostCycle(Msg), Host.AppIo => Try(Box(Model), I64)
+update_for_host! = |boxed_model, { devices, window, time, task_results, capture, dropped, dropped_overflow }, authority| {
 	messages = receive_task_results(task_results)
 	input = app_input_from_raw(devices, window, time, capture, messages, dropped, dropped_overflow)
 	model = Box.unbox(boxed_model)
-	match (program.update!)(model, input) {
+	match (program.update!)(model, input, App.Io.for_host(authority)) {
 		Ok(next) => Ok(Box.box(next))
 		Err(Exit(code)) => Err(code)
 		Err(_) => Err(-1)

--- a/scripts/all_tests.py
+++ b/scripts/all_tests.py
@@ -208,6 +208,7 @@ def run_headless_examples(
             [
                 str(executable),
                 "--host-headless",
+                *([] if name == "hello_world" else ["--host-caps-allow-all"]),
                 f"--host-headless-frames={frames}",
             ],
             f"headless run {name}",
@@ -296,7 +297,7 @@ def _check_windowed_case(
         for stale in root.glob(expect_png["glob"]):
             stale.unlink()
 
-    cmd = [str(executable), "--host-hidden", f"--host-frames={frames}"]
+    cmd = [str(executable), "--host-hidden", "--host-caps-allow-all", f"--host-frames={frames}"]
     if "keys" in case:
         cmd.append(f"--host-keys={case['keys']}")
     if "text" in case:
@@ -437,7 +438,7 @@ def run_graphical_observatory_probe(
     graphical_run = subprocess.run(
         [
             str(executable),
-            "--host-hidden",
+            "--host-hidden", "--host-caps-allow-all",
             "--host-frames=3",
             f"--host-stats-output={capture}",
             "--host-stats-detail=full",
@@ -524,6 +525,35 @@ def run_graphical_observatory_probe(
     return failures
 
 
+def run_capability_probe(root: Path, packages: local_bundles.ServedPackages, verbose: bool) -> list[str]:
+    """The same app must deny by default and admit explicitly granted work."""
+    staged = local_bundles.stage_app(
+        root / "test/capabilities/main.roc", packages, packages.scratch_dir / "capabilities"
+    )
+    if not run_cmd(["roc", "build", *ROC_BUILD_ARGS, staged.name, *LIMITS],
+                   "build capability probe", verbose, cwd=staged.parent):
+        return ["build capability probe"]
+    failures = []
+    for allowed in (False, True):
+        cwd = staged.parent / ("allowed" if allowed else "denied")
+        cwd.mkdir()
+        command = [str(executable_for(staged)), "--host-headless", "--host-headless-frames=200"]
+        if allowed:
+            command.extend(["--host-caps-allow-all", "--expect-allowed"])
+        result = subprocess.run(command, cwd=cwd, capture_output=True, text=True, timeout=60)
+        if result.returncode or "DENIED_OUTPUT_LEAK" in result.stdout + result.stderr:
+            failures.append(f"capability probe allowed={allowed}: {result.returncode} {result.stderr}")
+        if (cwd / "denied.txt").exists() or (cwd / "stub.txt").exists() or (cwd / "task.txt").exists() != allowed:
+            failures.append(f"capability probe touched unexpected files: allowed={allowed}")
+    crashed = subprocess.run(
+        [str(executable_for(staged)), "--host-headless", "--probe-crash"],
+        cwd=staged.parent, capture_output=True, text=True, timeout=60,
+    )
+    if crashed.returncode != 1 or "DENIED_OUTPUT_LEAK" in crashed.stdout + crashed.stderr:
+        failures.append("restricted crash diagnostics leaked a payload or lost the failure")
+    return failures
+
+
 def run_cli_args_integration(
     root: Path, packages: local_bundles.ServedPackages, verbose: bool
 ) -> list[str]:
@@ -543,7 +573,7 @@ def run_cli_args_integration(
     ok = run_cmd(
         [
             str(executable_for(staged)),
-            "--host-headless",
+            "--host-headless", "--host-caps-allow-all",
             "--host-headless-frames=3",
             "--cli-args-config",
             "--headless",
@@ -583,7 +613,7 @@ def run_task_delivery_probe(
     ok = run_cmd(
         [
             str(executable_for(staged)),
-            "--host-headless",
+            "--host-headless", "--host-caps-allow-all",
             "--host-headless-frames=200",
         ],
         "run task delivery probe",
@@ -614,7 +644,7 @@ def run_observatory_probe(
     recorded_run = subprocess.run(
         [
             str(executable_for(staged)),
-            "--host-headless",
+            "--host-headless", "--host-caps-allow-all",
             "--host-headless-frames=8",
             f"--host-stats-output={capture}",
             "--host-stats-detail=standard",
@@ -645,7 +675,7 @@ def run_observatory_probe(
     unwritable = subprocess.run(
         [
             str(executable_for(staged)),
-            "--host-headless",
+            "--host-headless", "--host-caps-allow-all",
             "--host-headless-frames=8",
             f"--host-stats-output={staged.parent / 'missing-parent' / 'capture.rrstats'}",
         ],
@@ -665,7 +695,7 @@ def run_observatory_probe(
     refusal = subprocess.run(
         [
             str(executable_for(staged)),
-            "--host-headless",
+            "--host-headless", "--host-caps-allow-all",
             "--host-headless-frames=8",
             f"--host-stats-output={capture}",
             "--host-stats-detail=standard",
@@ -684,7 +714,7 @@ def run_observatory_probe(
     race_capture = staged.parent / "race.rrstats"
     race_command = [
         str(executable_for(staged)),
-        "--host-headless",
+        "--host-headless", "--host-caps-allow-all",
         "--host-headless-frames=8",
         f"--host-stats-output={race_capture}",
         "--host-stats-detail=summary",
@@ -943,7 +973,7 @@ def run_observatory_probe(
         process = subprocess.Popen(
             [
                 str(executable_for(abrupt_staged)),
-                "--host-headless",
+                "--host-headless", "--host-caps-allow-all",
                 "--host-headless-frames=1000000000",
                 f"--host-stats-output={abrupt_capture}",
                 "--host-stats-detail=summary",
@@ -1037,7 +1067,7 @@ def run_task_cap_probe(
     ok = run_cmd(
         [
             str(executable_for(staged)),
-            "--host-headless",
+            "--host-headless", "--host-caps-allow-all",
             "--host-headless-frames=400",
         ],
         "run task cap probe",
@@ -1079,7 +1109,7 @@ def run_file_write_probe(
     ok = run_cmd(
         [
             str(executable_for(staged)),
-            "--host-headless",
+            "--host-headless", "--host-caps-allow-all",
             "--host-headless-frames=200",
             f"--host-stats-output={staged.parent / 'file-privacy.rrstats'}",
             "--host-stats-detail=full",
@@ -1123,7 +1153,7 @@ def run_cmd_probe(
     ok = run_cmd(
         [
             str(executable_for(staged)),
-            "--host-headless",
+            "--host-headless", "--host-caps-allow-all",
             "--host-headless-frames=400",
             f"--host-stats-output={staged.parent / 'cmd-privacy.rrstats'}",
             "--host-stats-detail=full",
@@ -1178,7 +1208,7 @@ def run_udp_probe(
         ok = run_cmd(
             [
                 str(executable_for(staged)),
-                "--host-headless",
+                "--host-headless", "--host-caps-allow-all",
                 "--host-headless-frames=300",
                 *extra,
             ],
@@ -1218,7 +1248,7 @@ def run_virtual_keys_probe(
         return ["build virtual keys probe"]
 
     ok = run_cmd(
-        [str(executable_for(staged)), "--host-headless", "--host-headless-frames=8", f"--host-stats-output={staged.parent / 'input-privacy.rrstats'}", "--host-stats-detail=full"],
+        [str(executable_for(staged)), "--host-headless", "--host-caps-allow-all", "--host-headless-frames=8", f"--host-stats-output={staged.parent / 'input-privacy.rrstats'}", "--host-stats-detail=full"],
         "run virtual keys probe",
         verbose,
         cwd=staged.parent,
@@ -1259,7 +1289,7 @@ def run_sqlite_probe(
     ok = run_cmd(
         [
             str(executable_for(staged)),
-            "--host-headless",
+            "--host-headless", "--host-caps-allow-all",
             "--host-headless-frames=200",
             f"--host-stats-output={staged.parent / 'sqlite-privacy.rrstats'}",
             "--host-stats-detail=full",
@@ -1846,6 +1876,7 @@ def _run_example_stages(
         failed.extend(run_graphical_observatory_probe(root, built, args.verbose))
 
     if not (args.skip_runtime or args.skip_roc_build):
+        failed.extend(run_capability_probe(root, packages, args.verbose))
         failed.extend(run_cli_args_integration(root, packages, args.verbose))
         failed.extend(run_observatory_probe(root, packages, args.verbose))
         failed.extend(run_task_delivery_probe(root, packages, args.verbose))

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -59,7 +59,7 @@ PHASE_SENTENCES = (
     "Legal in any callback, `render!` included.",
     # One-way diagnostic annotations, the deliberate render exception.
     "Legal in `init!`, `update!`, `render!`, and tasks.",
-    # One-off startup work, holding an `App.Startup`.
+    # One-off startup work, holding an `App.Io`.
     "Legal only in `init!`.",
     # Hands the host deferred work.
     "Legal in `update!` and in tasks; refused in `init!` and `render!`.",

--- a/scripts/test_app_transport_privacy.py
+++ b/scripts/test_app_transport_privacy.py
@@ -27,6 +27,9 @@ ROOT = Path(__file__).resolve().parent.parent
 # ask for plain text explicitly rather than inheriting it.
 ROC_ENV = {**os.environ, "NO_COLOR": "1"}
 CASES = (
+    (ROOT / "test/compile_fail/io_manufacture.roc", ("cannot use opaque nominal type", "instance of App.Io")),
+    (ROOT / "test/compile_fail/http_client_manufacture.roc", ("cannot use opaque nominal type", "instance of Http.Client")),
+    (ROOT / "test/compile_fail/service_kind_confusion.roc", ("type mismatch", "Http.Client", "Files.Access")),
     (
         ROOT / "test" / "compile_fail" / "host_module.roc",
         ("package module is private", "`rr.Host`"),

--- a/scripts/test_effect_scope_audit.py
+++ b/scripts/test_effect_scope_audit.py
@@ -24,10 +24,10 @@ ALLOWLIST = {
 
 def function_blocks(source: str):
     """Yield (name, body) for Zig functions using brace-depth parsing."""
-    # Boundary effects consistently use the `hosted` prefix and single-line
+    # Boundary effects use `hosted` or `caps` prefixes and single-line
     # signatures. Restricting the audit to that production convention avoids
     # mistaking braces in arbitrary Zig return types for function bodies.
-    for match in re.finditer(r"(?m)^fn\s+(hosted[A-Za-z0-9_]+)\s*\([^\n]*\)\s*(?:callconv\([^\n]*\)\s*)?[^\n]*\{", source):
+    for match in re.finditer(r"(?m)^fn\s+((?:hosted|caps)[A-Za-z0-9_]+)\s*\([^\n]*\)\s*(?:callconv\([^\n]*\)\s*)?[^\n]*\{", source):
         opening = source.rfind("{", match.start(), match.end())
         if opening < 0:
             continue

--- a/scripts/test_http_client.py
+++ b/scripts/test_http_client.py
@@ -111,7 +111,7 @@ def _run_case(
     """Run one probe invocation; return a failure description or None."""
     command = [
         str(executable),
-        "--host-headless",
+        "--host-headless", "--host-caps-allow-all",
         f"--host-headless-frames={FRAMES}",
         *args,
     ]

--- a/scripts/test_model_allocation.py
+++ b/scripts/test_model_allocation.py
@@ -114,7 +114,7 @@ def measure(root: Path, pattern: str, frames: int, warmup: int) -> list[dict[str
         "ROC_RAY_MODEL_PATTERN": pattern,
     }
     result = subprocess.run(
-        [str(binary), "--host-headless", f"--host-headless-frames={frames}"],
+        [str(binary), "--host-headless", "--host-caps-allow-all", f"--host-headless-frames={frames}"],
         cwd=root,
         capture_output=True,
         text=True,

--- a/src/host_native.zig
+++ b/src/host_native.zig
@@ -7939,11 +7939,8 @@ fn hostedAppReadEnvWindows(roc_host: *RocHost, key_arg: abi.RocStr) callconv(.c)
     const effect = EffectScope.begin("App.Environment.read!", key_arg.asSlice().len);
     defer effect.end();
     // Windows doesn't link libc, so env var reading is not yet supported
-    var result: AppReadEnvResult = undefined;
-    result.tag = .Err;
-
-    key_arg.decref(roc_host);
-    return result;
+    defer key_arg.decref(roc_host);
+    return abiTryErr(AppReadEnvResult, abi.HostApp_read_envErr.not_found);
 }
 
 fn exportedAppReadEnvWindows(key_arg: abi.RocStr) callconv(.c) AppReadEnvResult {
@@ -7954,21 +7951,29 @@ fn hostedAppReadEnvPosix(roc_host: *RocHost, key_arg: abi.RocStr) callconv(.c) A
     enforcePhase("App.Environment.read!", during_startup);
     const effect = EffectScope.begin("App.Environment.read!", key_arg.asSlice().len);
     defer effect.end();
-    var result: AppReadEnvResult = undefined;
-    const key = key_arg.asSlice();
-    const value = hostGetEnv(key);
+    defer key_arg.decref(roc_host);
 
-    if (value) |v| {
-        result.payload = .{ .ok = abi.RocStr.fromSlice(v, roc_host) };
-        result.tag = .Ok;
-    } else {
-        result.tag = .Err;
+    const value = hostGetEnv(key_arg.asSlice()) orelse
+        return abiTryErr(AppReadEnvResult, abi.HostApp_read_envErr.not_found);
+    return abiTryOk(AppReadEnvResult, abi.RocStr.fromSlice(value, roc_host));
+}
+
+test "environment absence initializes the NotFound payload on both host paths" {
+    var roc_env = abi.RocEnv{ .allocator = std.testing.allocator, .roc_io = abi.RocIo.freestanding() };
+    var roc_host = abi.makeRocHost(&roc_env);
+    const phase = PhaseScope.enter(.startup);
+    defer phase.leave();
+    const previous_environ = host_environ;
+    host_environ = &.{};
+    defer host_environ = previous_environ;
+
+    // Exercise the Windows fallback even on POSIX CI. This long key also
+    // verifies that both outcomes consume the transferred string allocation.
+    inline for (.{ hostedAppReadEnvWindows, hostedAppReadEnvPosix }) |read_env| {
+        const result = read_env(&roc_host, abi.RocStr.fromSlice("ROC_RAY_ABSENT_ENVIRONMENT_REGRESSION_PROBE", &roc_host));
+        try std.testing.expectEqual(.Err, result.tag);
+        try std.testing.expectEqual(abi.HostApp_read_envErr.not_found, result.payload_err());
     }
-
-    // Roc transfers ownership of refcounted args to the hosted fn; release them.
-    // `key` (a slice into key_arg) is fully consumed above before key_arg is dropped.
-    key_arg.decref(roc_host);
-    return result;
 }
 
 fn exportedAppReadEnvPosix(key_arg: abi.RocStr) callconv(.c) AppReadEnvResult {

--- a/src/host_native.zig
+++ b/src/host_native.zig
@@ -61,7 +61,6 @@ const FontMetrics = abi.FontMetrics;
 // union of RocStr/err-ptr) is the correct 32-byte layout for it.
 const Color = abi.ColorRgba;
 const AppReadEnvResult = abi.HostApp_read_envResult;
-const AppReadTextResult = abi.HostApp_read_textResult;
 const TilemapLoadTmxResult = abi.HostTilemap_load_tmxResult;
 const AppConfig = abi.App_config_for_host;
 // One cycle of observations handed to update. Unions do not cross this
@@ -88,7 +87,7 @@ const TilemapRawTileset = abi.HostTilemap_load_tmxOkTilesets;
 /// application can say whether its installation or one optional asset failed.
 const MAX_ASSET_FILE_BYTES: usize = 128 * 1024 * 1024;
 const MAX_ASSET_MANIFEST_BYTES: usize = 1024 * 1024;
-/// The largest file `Audio.load_sound!` and `Audio.load_music!` will read. It
+/// The largest file `Audio.Loader.load_sound!` and `Audio.Loader.load_music!` will read. It
 /// bounds host memory per resource, not per frame: a sound is decoded whole
 /// onto the device, and a music stream holds its encoded bytes for as long as
 /// it exists. A larger file fails to load rather than being read.
@@ -111,8 +110,8 @@ const MAX_FILE_READ_BYTES: usize = 16 * 1024 * 1024;
 const HEADLESS_CLIPBOARD_CAPACITY: usize = 4096;
 
 extern fn app_config_for_host() callconv(.c) AppConfig;
-extern fn init_for_host() callconv(.c) RocResult;
-extern fn update_for_host(arg0: RocBox, arg1: InputFromHost) callconv(.c) UpdateResult;
+extern fn init_for_host(authority: u64) callconv(.c) RocResult;
+extern fn update_for_host(arg0: RocBox, arg1: InputFromHost, authority: u64) callconv(.c) UpdateResult;
 extern fn render_for_host(arg0: RocBox) callconv(.c) RocResult;
 extern fn drop_model_for_host(arg0: RocBox) callconv(.c) void;
 extern fn run_task_for_host(arg0: abi.RocErasedCallable) callconv(.c) abi.RocErasedCallable;
@@ -166,8 +165,8 @@ const DIR_ENTRY_OTHER: u8 = 3;
 /// The most the host will copy into a Roc string in one operation.
 ///
 /// Converting the bytes into a `Str` allocates and copies, which is why only
-/// the reads that produce a string carry this limit: `Files.read_text!`
-/// reports `TooLarge` above it, while `Files.read_bytes!` transfers its
+/// the reads that produce a string carry this limit: `Files.Access.read_text!`
+/// reports `TooLarge` above it, while `Files.Access.read_bytes!` transfers its
 /// allocation as an owning Roc byte list without copying and is bounded by the
 /// much larger `MAX_FILE_READ_BYTES` instead.
 const MAX_INLINE_READ_BYTES: usize = 64 * 1024;
@@ -628,9 +627,9 @@ const Phase = enum {
 /// Callback phases in which an operation is valid.
 const PhaseSet = std.EnumSet(Phase);
 
-/// Startup-only operations: the `App.Startup` capabilities (blocking reads,
-/// the clipboard read, the random seed), which exist so that `init!` can do
-/// one-off setup work with the window already open.
+/// Startup-only operations: process arguments, environment, startup font,
+/// startup exit, and random seeds. Other Io receivers retain the phase sets
+/// of their corresponding host effects.
 const during_startup = PhaseSet.initOne(.startup);
 
 /// Drawing, and anything that changes how the draws after it are interpreted.
@@ -995,14 +994,14 @@ fn readFileWaiting(allocator: std.mem.Allocator, path: []const u8, limit: usize,
     };
 }
 
-/// `Files.read_text!`: read a bounded UTF-8 file into a `Str`.
+/// `Files.Access.read_text!`: read a bounded UTF-8 file into a `Str`.
 ///
 /// The whole file is copied into the string, so the ceiling is the small one:
 /// this is the only read whose cost on the frame thread is proportional to the
 /// file. A file that is not valid UTF-8 is reported rather than delivered,
 /// because `RocStr.fromSlice` only copies and every later string operation on
 /// an invalid one would be undefined.
-/// Name a read code in `Files.read_text!`'s vocabulary.
+/// Name a read code in `Files.Access.read_text!`'s vocabulary.
 fn filesReadTextError(code: u8) abi.HostFiles_read_textErr {
     return switch (code) {
         READ_ERR_NOT_FOUND => .not_found,
@@ -1016,8 +1015,8 @@ fn filesReadTextError(code: u8) abi.HostFiles_read_textErr {
 
 fn hostedFilesReadText(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c) abi.HostFiles_read_textResult {
     const Result = abi.HostFiles_read_textResult;
-    enforcePhase("Files.read_text!", during_wait);
-    var effect = EffectScope.begin("Files.read_text!", path_arg.asSlice().len);
+    enforcePhase("Files.Access.read_text!", during_wait);
+    var effect = EffectScope.begin("Files.Access.read_text!", path_arg.asSlice().len);
     defer effect.end();
     defer path_arg.decref(roc_host);
 
@@ -1050,14 +1049,14 @@ fn exportedFilesReadText(path_arg: abi.RocStr) callconv(.c) abi.HostFiles_read_t
     return hostedFilesReadText(activeHost(), path_arg);
 }
 
-/// `Files.read_bytes!`: read a bounded file without copying its payload.
+/// `Files.Access.read_bytes!`: read a bounded file without copying its payload.
 ///
 /// The buffer the read filled is the buffer Roc gets: it moves into the typed
 /// byte-list heap and out again as an owning seamless `List(U8)`, so a 16 MiB
 /// file costs one allocation and no copy. A delivery slot is reserved before
 /// any I/O starts, so a full heap answers `Busy` rather than reading a file and
 /// discarding it.
-/// Name a read code in `Files.read_bytes!`'s vocabulary.
+/// Name a read code in `Files.Access.read_bytes!`'s vocabulary.
 fn filesReadBytesError(code: u8) abi.HostFiles_read_bytesErr {
     return switch (code) {
         READ_ERR_NOT_FOUND => .not_found,
@@ -1070,8 +1069,8 @@ fn filesReadBytesError(code: u8) abi.HostFiles_read_bytesErr {
 
 fn hostedFilesReadBytes(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c) abi.HostFiles_read_bytesResult {
     const Result = abi.HostFiles_read_bytesResult;
-    enforcePhase("Files.read_bytes!", during_wait);
-    var effect = EffectScope.begin("Files.read_bytes!", path_arg.asSlice().len);
+    enforcePhase("Files.Access.read_bytes!", during_wait);
+    var effect = EffectScope.begin("Files.Access.read_bytes!", path_arg.asSlice().len);
     defer effect.end();
     defer path_arg.decref(roc_host);
     const result = readByteListWaiting(roc_host, path_arg.asSlice(), .read);
@@ -1087,12 +1086,12 @@ fn exportedFilesReadBytes(path_arg: abi.RocStr) callconv(.c) abi.HostFiles_read_
     return hostedFilesReadBytes(activeHost(), path_arg);
 }
 
-/// `Files.list!`: one directory's entries, encoded into the same byte list a
+/// `Files.Access.list!`: one directory's entries, encoded into the same byte list a
 /// read delivers and decoded by `Files`.
-/// Name a read code in `Files.list!`'s vocabulary.
+/// Name a read code in `Files.Access.list!`'s vocabulary.
 ///
 /// A listing is the only one of the three that can be refused for not being a
-/// directory, which is why it does not share `Files.read_bytes!`'s union.
+/// directory, which is why it does not share `Files.Access.read_bytes!`'s union.
 fn filesListError(code: u8) abi.HostFiles_listErr {
     return switch (code) {
         READ_ERR_NOT_FOUND => .not_found,
@@ -1106,8 +1105,8 @@ fn filesListError(code: u8) abi.HostFiles_listErr {
 
 fn hostedFilesList(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c) abi.HostFiles_listResult {
     const Result = abi.HostFiles_listResult;
-    enforcePhase("Files.list!", during_wait);
-    var effect = EffectScope.begin("Files.list!", path_arg.asSlice().len);
+    enforcePhase("Files.Access.list!", during_wait);
+    var effect = EffectScope.begin("Files.Access.list!", path_arg.asSlice().len);
     defer effect.end();
     defer path_arg.decref(roc_host);
     const result = readByteListWaiting(roc_host, path_arg.asSlice(), .list);
@@ -1176,7 +1175,7 @@ const StatOutcome = struct {
     found: abi.HostFiles_metadataOk,
 };
 
-/// Name a stat code in `Files.metadata!`'s vocabulary.
+/// Name a stat code in `Files.Access.metadata!`'s vocabulary.
 fn filesMetadataError(code: u8) abi.HostFiles_metadataErr {
     return switch (code) {
         READ_ERR_NOT_FOUND => .not_found,
@@ -1186,11 +1185,11 @@ fn filesMetadataError(code: u8) abi.HostFiles_metadataErr {
     };
 }
 
-/// `Files.metadata!`: what one path is, how big it is, and when it changed.
+/// `Files.Access.metadata!`: what one path is, how big it is, and when it changed.
 fn hostedFilesMetadata(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c) abi.HostFiles_metadataResult {
     const Result = abi.HostFiles_metadataResult;
-    enforcePhase("Files.metadata!", during_wait);
-    var effect = EffectScope.begin("Files.metadata!", path_arg.asSlice().len);
+    enforcePhase("Files.Access.metadata!", during_wait);
+    var effect = EffectScope.begin("Files.Access.metadata!", path_arg.asSlice().len);
     defer effect.end();
     defer path_arg.decref(roc_host);
     const scope = WaitScope.enter();
@@ -1252,10 +1251,10 @@ fn writeFileWaitingIn(base: std.Io.Dir, io: std.Io, path: []const u8, bytes: []c
     return 0;
 }
 
-/// `Files.write_text!`: replace a file's contents with a UTF-8 string.
+/// `Files.Access.write_text!`: replace a file's contents with a UTF-8 string.
 fn hostedFilesWriteTextCode(roc_host: *RocHost, path_arg: abi.RocStr, contents_arg: abi.RocStr) u8 {
-    enforcePhase("Files.write_text!", during_wait);
-    var effect = EffectScope.begin("Files.write_text!", path_arg.asSlice().len +| contents_arg.asSlice().len);
+    enforcePhase("Files.Access.write_text!", during_wait);
+    var effect = EffectScope.begin("Files.Access.write_text!", path_arg.asSlice().len +| contents_arg.asSlice().len);
     defer effect.end();
     defer path_arg.decref(roc_host);
     defer contents_arg.decref(roc_host);
@@ -1294,10 +1293,10 @@ fn exportedFilesWriteText(path_arg: abi.RocStr, contents_arg: abi.RocStr) callco
     return hostedFilesWriteText(activeHost(), path_arg, contents_arg);
 }
 
-/// `Files.write_bytes!`: replace a file's contents with the app's bytes.
+/// `Files.Access.write_bytes!`: replace a file's contents with the app's bytes.
 fn hostedFilesWriteBytesCode(roc_host: *RocHost, path_arg: abi.RocStr, bytes_arg: abi.RocListWith(u8, false)) u8 {
-    enforcePhase("Files.write_bytes!", during_wait);
-    var effect = EffectScope.begin("Files.write_bytes!", path_arg.asSlice().len +| bytes_arg.items().len);
+    enforcePhase("Files.Access.write_bytes!", during_wait);
+    var effect = EffectScope.begin("Files.Access.write_bytes!", path_arg.asSlice().len +| bytes_arg.items().len);
     defer effect.end();
     defer path_arg.decref(roc_host);
     defer bytes_arg.decref(roc_host);
@@ -1369,7 +1368,7 @@ fn queueStreamWrite(stream: u8, head: []const u8, tail: []const u8) u8 {
     return stdio_effect.write(streamRing(stream), head, tail);
 }
 
-/// `Stdout.write!` and `Stderr.write!`: the app's string, with nothing added.
+/// `Stdout.Writer.write!` and `Stderr.Writer.write!`: the app's string, with nothing added.
 /// Name a queued-write code in `Stdout`'s and `Stderr`'s vocabulary.
 fn stdioWriteResult(comptime Result: type, code: u8) Result {
     const Union = @typeInfo(@TypeOf(Result.payload_err)).@"fn".return_type.?;
@@ -1382,7 +1381,7 @@ fn stdioWriteResult(comptime Result: type, code: u8) Result {
 }
 
 fn hostedStdioWriteTextCode(roc_host: *RocHost, stream: u8, text_arg: abi.RocStr) u8 {
-    const name = if (stream == STDIO_STREAM_STDOUT) "Stdout.write!" else "Stderr.write!";
+    const name = if (stream == STDIO_STREAM_STDOUT) "Stdout.Writer.write!" else "Stderr.Writer.write!";
     enforcePhase(name, during_update);
     var effect = EffectScope.begin(name, text_arg.asSlice().len);
     defer effect.end();
@@ -1400,12 +1399,12 @@ fn exportedStdioWriteText(stream: u8, text_arg: abi.RocStr) callconv(.c) abi.Hos
     return hostedStdioWriteText(activeHost(), stream, text_arg);
 }
 
-/// `Stdout.line!` and `Stderr.line!`: the app's string and one newline.
+/// `Stdout.Writer.line!` and `Stderr.Writer.line!`: the app's string and one newline.
 ///
 /// The newline is the host's byte rather than a copy of the app's string with
 /// one appended, so a line costs no allocation and is queued as one payload.
 fn hostedStdioWriteLineCode(roc_host: *RocHost, stream: u8, text_arg: abi.RocStr) u8 {
-    const name = if (stream == STDIO_STREAM_STDOUT) "Stdout.line!" else "Stderr.line!";
+    const name = if (stream == STDIO_STREAM_STDOUT) "Stdout.Writer.line!" else "Stderr.Writer.line!";
     enforcePhase(name, during_update);
     var effect = EffectScope.begin(name, text_arg.asSlice().len);
     defer effect.end();
@@ -1423,9 +1422,9 @@ fn exportedStdioWriteLine(stream: u8, text_arg: abi.RocStr) callconv(.c) abi.Hos
     return hostedStdioWriteLine(activeHost(), stream, text_arg);
 }
 
-/// `Stdout.write_bytes!` and `Stderr.write_bytes!`: bytes, passed through.
+/// `Stdout.Writer.write_bytes!` and `Stderr.Writer.write_bytes!`: bytes, passed through.
 fn hostedStdioWriteBytesCode(roc_host: *RocHost, stream: u8, bytes_arg: abi.RocListWith(u8, false)) u8 {
-    const name = if (stream == STDIO_STREAM_STDOUT) "Stdout.write_bytes!" else "Stderr.write_bytes!";
+    const name = if (stream == STDIO_STREAM_STDOUT) "Stdout.Writer.write_bytes!" else "Stderr.Writer.write_bytes!";
     enforcePhase(name, during_update);
     var effect = EffectScope.begin(name, bytes_arg.items().len);
     defer effect.end();
@@ -1443,7 +1442,7 @@ fn exportedStdioWriteBytes(stream: u8, bytes_arg: abi.RocListWith(u8, false)) ca
     return hostedStdioWriteBytes(activeHost(), stream, bytes_arg);
 }
 
-/// `Capture.screenshot!`: one PNG of the frame the caller is waiting on.
+/// `Capture.Writer.screenshot!`: one PNG of the frame the caller is waiting on.
 ///
 /// The readback has to happen on the frame thread inside the drawing scope, so
 /// the effect registers the request, parks the task, and is woken by
@@ -1486,17 +1485,17 @@ fn hostedCaptureScreenshot(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c
     return captureWriteResult(abi.HostCapture_screenshotResult, hostedCaptureScreenshotCode(roc_host, path_arg));
 }
 
-fn hostedCaptureScreenshotTexture(roc_host: *RocHost, args: abi.HostCapture_screenshot_textureArgs) callconv(.c) abi.HostCapture_screenshot_textureResult {
+fn hostedCaptureScreenshotTexture(roc_host: *RocHost, args: abi.HostCapture_screenshot_textureArg1) callconv(.c) abi.HostCapture_screenshot_textureResult {
     return captureWriteResult(abi.HostCapture_screenshot_textureResult, hostedCaptureScreenshotTextureCode(roc_host, args));
 }
 
-fn hostedCaptureStartRecording(roc_host: *RocHost, args: abi.HostCapture_start_recordingArgs) callconv(.c) abi.HostCapture_start_recordingResult {
+fn hostedCaptureStartRecording(roc_host: *RocHost, args: abi.HostCapture_start_recordingArg1) callconv(.c) abi.HostCapture_start_recordingResult {
     return captureWriteResult(abi.HostCapture_start_recordingResult, hostedCaptureStartRecordingCode(roc_host, args));
 }
 
 fn hostedCaptureScreenshotCode(roc_host: *RocHost, path_arg: abi.RocStr) u8 {
-    enforcePhase("Capture.screenshot!", during_frame_wait);
-    var effect = EffectScope.begin("Capture.screenshot!", path_arg.asSlice().len);
+    enforcePhase("Capture.Writer.screenshot!", during_frame_wait);
+    var effect = EffectScope.begin("Capture.Writer.screenshot!", path_arg.asSlice().len);
     defer effect.end();
     defer path_arg.decref(roc_host);
     const path = path_arg.asSlice();
@@ -1587,17 +1586,17 @@ fn exportedCaptureScreenshot(path_arg: abi.RocStr) callconv(.c) abi.HostCapture_
     return hostedCaptureScreenshot(activeHost(), path_arg);
 }
 
-/// `Capture.screenshot_texture!`: one PNG of what a render target holds.
+/// `Capture.Writer.screenshot_texture!`: one PNG of what a render target holds.
 ///
 /// Unlike a screenshot this waits for nothing on the frame loop. The readback
 /// needs the graphics context, which lives on this thread, and Roc only ever
 /// runs on this thread -- so the pixels are taken synchronously, here, from
 /// whatever the last completed `render!` left in the target. Only the encode
 /// and the write park, on zio's blocking pool, which is why `init!` is a legal
-/// place to call this and is not for `Capture.screenshot!`.
-fn hostedCaptureScreenshotTextureCode(roc_host: *RocHost, args: abi.HostCapture_screenshot_textureArgs) u8 {
-    enforcePhase("Capture.screenshot_texture!", during_wait);
-    var effect = EffectScope.begin("Capture.screenshot_texture!", 0);
+/// place to call this and is not for `Capture.Writer.screenshot!`.
+fn hostedCaptureScreenshotTextureCode(roc_host: *RocHost, args: abi.HostCapture_screenshot_textureArg1) u8 {
+    enforcePhase("Capture.Writer.screenshot_texture!", during_wait);
+    var effect = EffectScope.begin("Capture.Writer.screenshot_texture!", 0);
     defer effect.end();
     defer args.path.decref(roc_host);
     const path = args.path.asSlice();
@@ -1623,7 +1622,7 @@ fn hostedCaptureScreenshotTextureCode(roc_host: *RocHost, args: abi.HostCapture_
 
         // A headless render target has no pixels at all -- every draw into it
         // was a no-op -- so there is nothing to write. Answering `Ok` with no
-        // file is what `Capture.screenshot!` does for the same reason, and it
+        // file is what `Capture.Writer.screenshot!` does for the same reason, and it
         // keeps an exporting app runnable under `--host-headless`.
         const target = switch (resource.*) {
             .headless => break :readback capture.err_none,
@@ -1691,7 +1690,7 @@ fn hostedCaptureScreenshotTextureCode(roc_host: *RocHost, args: abi.HostCapture_
     return blocking.join();
 }
 
-fn exportedCaptureScreenshotTexture(args: abi.HostCapture_screenshot_textureArgs) callconv(.c) abi.HostCapture_screenshot_textureResult {
+fn exportedCaptureScreenshotTexture(args: abi.HostCapture_screenshot_textureArg1) callconv(.c) abi.HostCapture_screenshot_textureResult {
     return hostedCaptureScreenshotTexture(activeHost(), args);
 }
 
@@ -1830,7 +1829,7 @@ fn resolveReadbackSource(source: abi.HostCapture_pixel_atArg0Source, err: *u8) ?
     }
 
     // The target's own dimensions rather than the ones the Roc value carries,
-    // for the reason `Capture.screenshot_texture!` gives: the readback is
+    // for the reason `Capture.Writer.screenshot_texture!` gives: the readback is
     // sized by what the GPU holds. A target too large for the whole budget and
     // one that would fit but for other work in flight are both `err_busy`
     // here; a readback reports one "not now" and the difference between them
@@ -1914,7 +1913,7 @@ fn exportedCapturePixelAt(args: abi.HostCapture_pixel_atArgs) callconv(.c) abi.H
 /// The order of the checks is the point. A region no source could satisfy is
 /// refused before anything is read, and a delivery slot is reserved before the
 /// readback, so the expensive part never runs for a read that has nowhere to
-/// put its answer -- the same admission `Files.read_bytes!` does before it
+/// put its answer -- the same admission `Files.Access.read_bytes!` does before it
 /// opens a path, and for the same reason.
 fn hostedCaptureReadRegion(roc_host: *RocHost, args: abi.HostCapture_read_regionArgs) abi.HostCapture_read_regionResult {
     enforcePhase("Capture.read_region!", during_update);
@@ -2032,7 +2031,7 @@ fn installReadBytes(allocator: std.mem.Allocator, bytes: []u8) ByteListOutcome {
     return .{ .err = 0, .bytes = seamlessByteList(resource, bytes) };
 }
 
-/// `Http.send!`: run one HTTP exchange, parking the task while it waits.
+/// `Http.Client.send!`: run one HTTP exchange, parking the task while it waits.
 ///
 /// The phase handling mirrors `hostedTaskSleep`: the request parks this
 /// coroutine, the frame loop runs in between and sets phases of its own, and
@@ -2040,8 +2039,8 @@ fn installReadBytes(allocator: std.mem.Allocator, bytes: []u8) ByteListOutcome {
 fn hostedHttpSend(request: http_effect.Request) callconv(.c) abi.HostHttp_sendResult {
     const Result = abi.HostHttp_sendResult;
     const Union = abi.HostHttp_sendErr;
-    enforcePhase("Http.send!", during_wait);
-    var effect = EffectScope.begin("Http.send!", 0);
+    enforcePhase("Http.Client.send!", during_wait);
+    var effect = EffectScope.begin("Http.Client.send!", 0);
     defer effect.end();
     const roc_host = activeHost();
     const resume_phase = active_phase;
@@ -2083,7 +2082,7 @@ fn hostedHttpSend(request: http_effect.Request) callconv(.c) abi.HostHttp_sendRe
 
 /// This process's own environment, as `std.process.Environ`.
 ///
-/// `Cmd.run!` needs it twice over: it is where a bare program name is resolved
+/// `Cmd.Runner.run!` needs it twice over: it is where a bare program name is resolved
 /// against `PATH`, and it is what a child inherits unless the command replaces
 /// it. `host_environ` is what `platform_main` captured off the process stack;
 /// under `zig test` no `platform_main` ran, so the libc-linked test binary
@@ -2104,7 +2103,7 @@ fn hostProcessEnviron() std.process.Environ {
     return .empty;
 }
 
-/// Name a run code in `Cmd.run!`'s vocabulary.
+/// Name a run code in `Cmd.Runner.run!`'s vocabulary.
 ///
 /// `Timeout` is absent: it is the one variant carrying the output captured
 /// before the deadline, so only the caller holding that output can build it.
@@ -2132,7 +2131,7 @@ fn cmdRunFailure(code: u8) abi.HostCmd_runResult {
 /// worker may not read a Roc value. Everything it needs -- the program, the
 /// arguments, the environment pairs, the working directory -- is duplicated
 /// into an arena the frame thread owns and discards when the run returns.
-fn copyCmdSpec(arena: std.mem.Allocator, args: abi.HostCmd_runArgs) ?cmd_effect.Spec {
+fn copyCmdSpec(arena: std.mem.Allocator, args: abi.HostCmd_runArg1) ?cmd_effect.Spec {
     const program = arena.dupe(u8, args.program.asSlice()) catch return null;
     const working_dir = arena.dupe(u8, args.working_dir.asSlice()) catch return null;
 
@@ -2163,7 +2162,7 @@ fn copyCmdSpec(arena: std.mem.Allocator, args: abi.HostCmd_runArgs) ?cmd_effect.
     };
 }
 
-/// `Cmd.run!`: start one child process and park until it has finished.
+/// `Cmd.Runner.run!`: start one child process and park until it has finished.
 ///
 /// A child slot is reserved before anything is copied or started, so a
 /// terminal `Busy` means precisely that no process was created.
@@ -2178,10 +2177,10 @@ fn copyCmdSpec(arena: std.mem.Allocator, args: abi.HostCmd_runArgs) ?cmd_effect.
 /// Both streams cross as ordinary copies rather than through the byte-list
 /// transfer path. A run produces two payloads where that path hands over one
 /// allocation per slot, and both are already bounded by limits the app stated.
-fn hostedCmdRun(roc_host: *RocHost, args: abi.HostCmd_runArgs) callconv(.c) abi.HostCmd_runResult {
+fn hostedCmdRun(roc_host: *RocHost, args: abi.HostCmd_runArg1) callconv(.c) abi.HostCmd_runResult {
     const Result = abi.HostCmd_runResult;
-    enforcePhase("Cmd.run!", during_wait);
-    var effect = EffectScope.begin("Cmd.run!", 0);
+    enforcePhase("Cmd.Runner.run!", during_wait);
+    var effect = EffectScope.begin("Cmd.Runner.run!", 0);
     defer effect.end();
     defer args.decref(roc_host);
 
@@ -2245,7 +2244,7 @@ fn hostedCmdRun(roc_host: *RocHost, args: abi.HostCmd_runArgs) callconv(.c) abi.
     return abiTryOk(Result, captured);
 }
 
-fn exportedCmdRun(args: abi.HostCmd_runArgs) callconv(.c) abi.HostCmd_runResult {
+fn exportedCmdRun(args: abi.HostCmd_runArg1) callconv(.c) abi.HostCmd_runResult {
     return hostedCmdRun(activeHost(), args);
 }
 
@@ -2258,7 +2257,7 @@ fn exportedCmdRun(args: abi.HostCmd_runArgs) callconv(.c) abi.HostCmd_runResult 
 /// can hand a turn to the executor, which runs other tasks' Roc code; the
 /// `PhaseScope` restore is what keeps the rest of this `update!` in the right
 /// phase afterwards, exactly as `Task.spawn!` does.
-fn hostedUdpBind(host: *RocHost, args: abi.HostUdp_bindArgs) callconv(.c) abi.HostUdp_bindResult {
+fn hostedUdpBind(host: *RocHost, args: abi.HostUdp_bindArg1) callconv(.c) abi.HostUdp_bindResult {
     enforcePhase("Udp.bind!", during_load);
     var effect = EffectScope.begin("Udp.bind!", args.ip.asSlice().len);
     defer effect.end();
@@ -2297,7 +2296,7 @@ fn hostedUdpBind(host: *RocHost, args: abi.HostUdp_bindArgs) callconv(.c) abi.Ho
     });
 }
 
-fn exportedUdpBind(args: abi.HostUdp_bindArgs) callconv(.c) abi.HostUdp_bindResult {
+fn exportedUdpBind(args: abi.HostUdp_bindArg1) callconv(.c) abi.HostUdp_bindResult {
     return hostedUdpBind(activeHost(), args);
 }
 
@@ -2542,8 +2541,8 @@ fn hostedSqliteOpen(
     max_result_bytes: u64,
 ) callconv(.c) abi.HostSqlite_openResult {
     const Result = abi.HostSqlite_openResult;
-    enforcePhase("Sqlite.Db.open!", during_wait);
-    var effect = EffectScope.begin("Sqlite.Db.open!", path_arg.asSlice().len);
+    enforcePhase("Sqlite.Service.open!", during_wait);
+    var effect = EffectScope.begin("Sqlite.Service.open!", path_arg.asSlice().len);
     defer effect.end();
     const roc_host = activeHost();
     defer path_arg.decref(roc_host);
@@ -2746,7 +2745,7 @@ fn enforcePhase(operation: []const u8, allowed: PhaseSet) void {
         describePhases(allowed, &buffer),
         active_phase.label(),
         if (allowed.eql(during_startup))
-            " It is an App.Startup capability: call it in init! and keep what it returns in your model."
+            " It is an App.Io capability: call it in init! and keep what it returns in your model."
         else if (allowed.eql(during_update))
             " It changes host state rather than drawing: call it from init!, update!, or a task, not from render!."
         else if (allowed.eql(during_render))
@@ -3254,7 +3253,7 @@ test "full draw detail names map to stable non-payload categories" {
     try std.testing.expectEqual(@as(?u8, 3), drawDetailKind("Draw.with_shader!"));
     try std.testing.expectEqual(@as(?u8, 4), drawDetailKind("Capture.read_region!"));
     try std.testing.expectEqual(@as(?u8, 5), drawDetailKind("Draw.with_render_texture!"));
-    try std.testing.expect(drawDetailKind("Http.send!") == null);
+    try std.testing.expect(drawDetailKind("Http.Client.send!") == null);
     try std.testing.expectEqual(@as(u64, 12), drawByteCount(u32, 3));
     try std.testing.expectEqual(@as(u64, 4), drawByteCount(abi.ColorRgba, 1));
 
@@ -3615,7 +3614,7 @@ var capture_recording_path_len: usize = 0;
 var capture_screenshot_path: [capture.path_capacity]u8 = undefined;
 var capture_screenshot_path_len: usize = 0;
 var capture_screenshot_pending: bool = false;
-/// The task waiting for `Capture.screenshot!` to finish, and its answer.
+/// The task waiting for `Capture.Writer.screenshot!` to finish, and its answer.
 ///
 /// One slot, because the host reads the framebuffer back once per frame and
 /// keeps one pending path. A second concurrent screenshot is `AlreadyPending`
@@ -3632,7 +3631,7 @@ const ScreenshotWait = struct {
     err: u8 = 0,
 };
 var screenshot_wait: ?*ScreenshotWait = null;
-/// Readback memory held by `Capture.screenshot_texture!` calls in flight.
+/// Readback memory held by `Capture.Writer.screenshot_texture!` calls in flight.
 ///
 /// Several tasks can export at once -- nothing serializes them the way the
 /// single end-of-frame readback serializes screenshots -- so this is what keeps
@@ -3964,7 +3963,7 @@ fn seamlessByteList(resource: *u64, bytes: []u8) abi.RocListWith(u8, false) {
 }
 
 /// Slots promised to reads that have started but have not yet handed their
-/// bytes over. `Files.read_bytes!` has to reserve one before it opens the
+/// bytes over. `Files.Access.read_bytes!` has to reserve one before it opens the
 /// path: otherwise a full heap could let `MAX_LIVE_FILE_BYTE_LISTS` large
 /// files be read only to discard each one when there is no slot to install it
 /// in, so the app would pay for the I/O and still get `Busy`.
@@ -4096,6 +4095,11 @@ fn activeHost() *RocHost {
 
 /// Custom dbg handler that sets flag and prints to stderr.
 fn nativeDbg(_: *RocHost, bytes: [*]const u8, len: usize) callconv(.c) void {
+    if (!external_caps_allowed) {
+        debug_or_expect_called.store(true, .release);
+        std.debug.print("roc-ray: debug message suppressed\n", .{});
+        return;
+    }
     debug_or_expect_called.store(true, .release);
     const msg = bytes[0..len];
     std.debug.print("\x1b[36m[ROC DBG]\x1b[0m {s}\n", .{msg});
@@ -4103,6 +4107,11 @@ fn nativeDbg(_: *RocHost, bytes: [*]const u8, len: usize) callconv(.c) void {
 
 /// Custom expect handler that sets flag and prints to stderr.
 fn nativeExpectFailed(_: *RocHost, bytes: [*]const u8, len: usize) callconv(.c) void {
+    if (!external_caps_allowed) {
+        debug_or_expect_called.store(true, .release);
+        std.debug.print("roc-ray: expectation failed (details suppressed)\n", .{});
+        return;
+    }
     debug_or_expect_called.store(true, .release);
     const msg = bytes[0..len];
     std.debug.print("\x1b[33m[ROC EXPECT]\x1b[0m {s}\n", .{msg});
@@ -4110,6 +4119,11 @@ fn nativeExpectFailed(_: *RocHost, bytes: [*]const u8, len: usize) callconv(.c) 
 
 /// Crash handler - prints to stderr and exits.
 fn nativeCrashed(_: *RocHost, bytes: [*]const u8, len: usize) callconv(.c) void {
+    if (!external_caps_allowed) {
+        debug_or_expect_called.store(true, .release);
+        std.debug.print("roc-ray: application crashed (details suppressed)\n", .{});
+        std.process.exit(1);
+    }
     const msg = bytes[0..len];
     std.debug.print("\x1b[31m[ROC CRASHED]\x1b[0m {s}\n", .{msg});
     std.process.exit(1);
@@ -4398,13 +4412,13 @@ fn abiTryErr(comptime Result: type, err: anytype) Result {
 }
 
 test "ABI Try constructors preserve typed success and error payloads" {
-    const ok = abiTryOk(AppReadTextResult, abi.RocStr.empty());
-    try std.testing.expectEqual(abi.HostApp_read_textResultTag.Ok, ok.tag);
+    const ok = abiTryOk(abi.HostFiles_read_textResult, abi.RocStr.empty());
+    try std.testing.expectEqual(abi.HostFiles_read_textResultTag.Ok, ok.tag);
     try std.testing.expectEqualStrings("", ok.payload_ok().asSlice());
 
-    const err = abiTryErr(AppReadTextResult, abi.HostApp_read_textErr.not_found);
-    try std.testing.expectEqual(abi.HostApp_read_textResultTag.Err, err.tag);
-    try std.testing.expectEqual(abi.HostApp_read_textErr.not_found, err.payload_err());
+    const err = abiTryErr(abi.HostFiles_read_textResult, abi.HostFiles_read_textErr.not_found);
+    try std.testing.expectEqual(abi.HostFiles_read_textResultTag.Err, err.tag);
+    try std.testing.expectEqual(abi.HostFiles_read_textErr.not_found, err.payload_err());
 }
 
 fn tilemapLoadError(err: tmx_loader.LoadError) abi.HostTilemap_load_tmxErr {
@@ -5934,8 +5948,8 @@ fn releaseStartupFontHandle(host: *RocHost) void {
 fn configuredStartupFont(host: *RocHost) abi.HostText_startup_default_fontResult {
     const Result = abi.HostText_startup_default_fontResult;
     const Error = abi.HostText_startup_default_fontErr;
-    enforcePhase("App.Startup.default_font!", during_startup);
-    const effect = EffectScope.begin("App.Startup.default_font!", startup_font_config.path.len);
+    enforcePhase("App.Io.default_font!", during_startup);
+    const effect = EffectScope.begin("App.Io.default_font!", startup_font_config.path.len);
     defer effect.end();
     if (startup_font_config.path.len == 0) return abiTryOk(Result, completeFont(host, defaultFontHandle()));
     if (!isSafeStoreRelativePath(startup_font_config.path)) return abiTryErr(Result, Error.asset_path_invalid);
@@ -6136,6 +6150,7 @@ fn openStoreRootRelative(io: std.Io, base: std.Io.Dir, root: []const u8) !std.Io
 
 fn storeErrorDescription(err: abi.HostStore_openErr) []const u8 {
     return switch (err) {
+        .permission_denied => "external access was not granted",
         .root_not_found => "root directory was not found",
         .root_not_directory => "root is not a directory",
         .root_unreadable => "root directory is not readable",
@@ -6293,7 +6308,7 @@ fn matchAssetManifest(manifest: ParsedAssetManifest, asset_set: []const u8, sche
     return null;
 }
 
-fn expectedManifestHash(args: abi.HostStore_openArgs) union(enum) { any, hash: []const u8, invalid } {
+fn expectedManifestHash(args: abi.HostStore_openArg1) union(enum) { any, hash: []const u8, invalid } {
     const hash = args.content_hash.asSlice();
     return switch (args.content_hash_mode) {
         0 => if (hash.len == 0) .any else .invalid,
@@ -6302,7 +6317,7 @@ fn expectedManifestHash(args: abi.HostStore_openArgs) union(enum) { any, hash: [
     };
 }
 
-fn validateStoreManifest(allocator: std.mem.Allocator, root: *std.Io.Dir, args: abi.HostStore_openArgs) ?abi.HostStore_openErr {
+fn validateStoreManifest(allocator: std.mem.Allocator, root: *std.Io.Dir, args: abi.HostStore_openArg1) ?abi.HostStore_openErr {
     if (!args.manifest_required) return null;
     const bytes = switch (readDirFileWaiting(allocator, root.*, "roc-assets.manifest", MAX_ASSET_MANIFEST_BYTES)) {
         .failed => |err| return switch (err) {
@@ -6398,7 +6413,7 @@ test "asset store owns its directory capability through typed ARC" {
     try std.testing.expectEqual(@as(usize, 0), heap.active());
 }
 
-fn testStoreOpenArgs(host: *RocHost, root: []const u8, manifest_required: bool, content_hash_mode: u8, content_hash: []const u8) abi.HostStore_openArgs {
+fn testStoreOpenArgs(host: *RocHost, root: []const u8, manifest_required: bool, content_hash_mode: u8, content_hash: []const u8) abi.HostStore_openArg1 {
     return .{
         .asset_set = abi.RocStr.fromSlice("test-assets", host),
         .content_hash = abi.RocStr.fromSlice(content_hash, host),
@@ -6495,7 +6510,7 @@ test "opening a store and loading a texture from it wait rather than load" {
         last_phase_violation = null;
         _ = hostedStoreOpenRaw(&roc_host, testStoreOpenArgs(&roc_host, relative_root, false, 0, ""));
         const violation = last_phase_violation orelse return error.OperationWasNotRejected;
-        try std.testing.expectEqualStrings("Assets.Store.open!", violation.operation);
+        try std.testing.expectEqualStrings("Assets.Loader.open!", violation.operation);
         try std.testing.expect(violation.allowed.eql(during_wait));
         try std.testing.expectEqual(Phase.update, violation.actual);
     }
@@ -6587,16 +6602,16 @@ test "embedded texture and font bytes are consumed exactly once" {
     bad_font_bytes.decref(&roc_host);
 }
 
-/// `Assets.Store.open!`: open a store root and check its manifest.
+/// `Assets.Loader.open!`: open a store root and check its manifest.
 ///
 /// Opening a directory and reading a manifest are both filesystem work, so
 /// this waits: it parks a task and blocks `init!`. The validation that follows
 /// is pure and runs on the frame thread once the read has come back.
-fn hostedStoreOpenRaw(host: *RocHost, args: abi.HostStore_openArgs) callconv(.c) abi.HostStore_openResult {
+fn hostedStoreOpenRaw(host: *RocHost, args: abi.HostStore_openArg1) callconv(.c) abi.HostStore_openResult {
     const Result = abi.HostStore_openResult;
     const Error = abi.HostStore_openErr;
-    enforcePhase("Assets.Store.open!", during_wait);
-    const effect = EffectScope.begin("Assets.Store.open!", 0);
+    enforcePhase("Assets.Loader.open!", during_wait);
+    const effect = EffectScope.begin("Assets.Loader.open!", 0);
     defer effect.end();
     defer args.root.decref(host);
     defer args.asset_set.decref(host);
@@ -6635,7 +6650,7 @@ fn hostedStoreOpenRaw(host: *RocHost, args: abi.HostStore_openArgs) callconv(.c)
     return abiTryOk(Result, stored);
 }
 
-fn exportedStoreOpenRaw(args: abi.HostStore_openArgs) callconv(.c) abi.HostStore_openResult {
+fn exportedStoreOpenRaw(args: abi.HostStore_openArg1) callconv(.c) abi.HostStore_openResult {
     return hostedStoreOpenRaw(activeHost(), args);
 }
 
@@ -7894,8 +7909,8 @@ var exit_requested: ?i64 = null;
 var active_app_args: []const [*:0]u8 = &.{};
 
 fn hostedArgs(roc_host: *RocHost) callconv(.c) abi.RocList(abi.RocStr) {
-    enforcePhase("App.Startup.args!", during_load);
-    const effect = EffectScope.begin("App.Startup.args!", 0);
+    enforcePhase("App.Io.args!", during_load);
+    const effect = EffectScope.begin("App.Io.args!", 0);
     defer effect.end();
 
     const result = abi.RocList(abi.RocStr).allocate(active_app_args.len, roc_host);
@@ -7920,8 +7935,8 @@ fn exportedArgs() callconv(.c) abi.RocList(abi.RocStr) {
 }
 
 fn hostedAppReadEnvWindows(roc_host: *RocHost, key_arg: abi.RocStr) callconv(.c) AppReadEnvResult {
-    enforcePhase("App.Startup.read_env!", during_startup);
-    const effect = EffectScope.begin("App.Startup.read_env!", key_arg.asSlice().len);
+    enforcePhase("App.Environment.read!", during_startup);
+    const effect = EffectScope.begin("App.Environment.read!", key_arg.asSlice().len);
     defer effect.end();
     // Windows doesn't link libc, so env var reading is not yet supported
     var result: AppReadEnvResult = undefined;
@@ -7936,8 +7951,8 @@ fn exportedAppReadEnvWindows(key_arg: abi.RocStr) callconv(.c) AppReadEnvResult 
 }
 
 fn hostedAppReadEnvPosix(roc_host: *RocHost, key_arg: abi.RocStr) callconv(.c) AppReadEnvResult {
-    enforcePhase("App.Startup.read_env!", during_startup);
-    const effect = EffectScope.begin("App.Startup.read_env!", key_arg.asSlice().len);
+    enforcePhase("App.Environment.read!", during_startup);
+    const effect = EffectScope.begin("App.Environment.read!", key_arg.asSlice().len);
     defer effect.end();
     var result: AppReadEnvResult = undefined;
     const key = key_arg.asSlice();
@@ -7960,57 +7975,6 @@ fn exportedAppReadEnvPosix(key_arg: abi.RocStr) callconv(.c) AppReadEnvResult {
     return hostedAppReadEnvPosix(activeHost(), key_arg);
 }
 
-fn hostedAppReadText(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c) AppReadTextResult {
-    enforcePhase("App.Startup.read_text!", during_startup);
-    const effect = EffectScope.begin("App.Startup.read_text!", path_arg.asSlice().len);
-    defer effect.end();
-    defer path_arg.decref(roc_host);
-
-    const allocator = allocatorFromHost(roc_host);
-    const path = path_arg.asSlice();
-    const bytes = std.Io.Dir.cwd().readFileAlloc(mainThreadIo(), path, allocator, .limited(MAX_FILE_READ_BYTES)) catch |err| {
-        return abiTryErr(AppReadTextResult, switch (err) {
-            error.FileNotFound => abi.HostApp_read_textErr.not_found,
-            else => abi.HostApp_read_textErr.read_failed,
-        });
-    };
-    defer allocator.free(bytes);
-
-    return abiTryOk(AppReadTextResult, abi.RocStr.fromSlice(bytes, roc_host));
-}
-
-fn exportedAppReadText(path_arg: abi.RocStr) callconv(.c) AppReadTextResult {
-    return hostedAppReadText(activeHost(), path_arg);
-}
-
-test "startup text reads return typed success missing and read-failure outcomes" {
-    var roc_env = abi.RocEnv{ .allocator = std.testing.allocator, .roc_io = abi.RocIo.freestanding() };
-    var roc_host = abi.makeRocHost(&roc_env);
-    roc_host.roc_dealloc = &nativeRocDealloc;
-
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "startup.txt", .data = "startup contents" });
-
-    const startup = PhaseScope.enter(.startup);
-    defer startup.leave();
-
-    var path_buffer: [256]u8 = undefined;
-    const loaded = hostedAppReadText(&roc_host, tmpPathString(&roc_host, &path_buffer, &tmp.sub_path, "startup.txt"));
-    try std.testing.expectEqual(abi.HostApp_read_textResultTag.Ok, loaded.tag);
-    try std.testing.expectEqualStrings("startup contents", loaded.payload_ok().asSlice());
-    loaded.decref(&roc_host);
-
-    const missing = hostedAppReadText(&roc_host, tmpPathString(&roc_host, &path_buffer, &tmp.sub_path, "missing.txt"));
-    try std.testing.expectEqual(abi.HostApp_read_textResultTag.Err, missing.tag);
-    try std.testing.expectEqual(abi.HostApp_read_textErr.not_found, missing.payload_err());
-
-    const directory_path = std.fmt.bufPrint(&path_buffer, testing_tmp_prefix ++ "{s}", .{tmp.sub_path}) catch unreachable;
-    const unreadable = hostedAppReadText(&roc_host, abi.RocStr.fromSlice(directory_path, &roc_host));
-    try std.testing.expectEqual(abi.HostApp_read_textResultTag.Err, unreadable.tag);
-    try std.testing.expectEqual(abi.HostApp_read_textErr.read_failed, unreadable.payload_err());
-}
-
 /// Read one TMX or TSX file on the waiting path.
 ///
 /// The loader calls this once for the map and once more for every external
@@ -8024,13 +7988,13 @@ fn readTilemapFileWaiting(_: ?*anyopaque, allocator: std.mem.Allocator, path: []
     return bytes;
 }
 
-/// `Tilemap.load_tmx!`: read a Tiled map and parse it into flat records.
+/// `Tilemap.Loader.load_tmx!`: read a Tiled map and parse it into flat records.
 ///
 /// Every read waits -- parking a task, blocking `init!` -- and the XML parse
 /// and the conversion into Roc values run on the frame thread between them.
 fn hostedTilemapLoadTmxRaw(roc_host: *RocHost, path_arg: abi.RocStr) callconv(.c) TilemapLoadTmxResult {
-    enforcePhase("Tilemap.load_tmx!", during_wait);
-    const effect = EffectScope.begin("Tilemap.load_tmx!", path_arg.asSlice().len);
+    enforcePhase("Tilemap.Loader.load_tmx!", during_wait);
+    const effect = EffectScope.begin("Tilemap.Loader.load_tmx!", path_arg.asSlice().len);
     defer effect.end();
     defer path_arg.decref(roc_host);
 
@@ -8119,8 +8083,8 @@ fn exportedTilemapDrawRaw(args: abi.HostTilemap_drawArgs) callconv(.c) void {
 }
 
 fn hostedExit(code: i32) callconv(.c) void {
-    enforcePhase("App.Startup.exit!", during_update);
-    const effect = EffectScope.begin("App.Startup.exit!", 0);
+    enforcePhase("App.Io.exit!", during_update);
+    const effect = EffectScope.begin("App.Io.exit!", 0);
     defer effect.end();
     exit_requested = @as(i64, code);
 }
@@ -8340,7 +8304,7 @@ fn prepareCapturePath(buffer: []u8, path: []const u8) ?[]const u8 {
 /// Write one captured image to a validated path, returning a capture error code.
 ///
 /// `bytes_out`, when given, receives the size of the file that was written --
-/// the encoded size, not the pixel count, since that is what `Capture.stop!`
+/// the encoded size, not the pixel count, since that is what `Capture.Writer.stop!`
 /// reports as the recording's size on disk.
 fn writeCaptureImage(image: raylib.CaptureImage, path: []const u8, bytes_out: ?*u64) u8 {
     var path_storage: [capture.path_capacity]u8 = undefined;
@@ -8374,13 +8338,13 @@ fn framePathForIndex(buffer: []u8, path: []const u8, index: u64) ?[]const u8 {
     return std.fmt.bufPrint(buffer, "{s}_{d:0>5}{s}", .{ stem, index, extension }) catch null;
 }
 
-/// `Capture.start!`: begin a recording.
+/// `Capture.Writer.start!`: begin a recording.
 ///
 /// Refusals are latched in the session for the next `input.capture`. The return
 /// code preserves the hosted ABI and supports direct tests.
-fn hostedCaptureStartRecordingCode(roc_host: *RocHost, args: abi.HostCapture_start_recordingArgs) u8 {
-    enforcePhase("Capture.start!", during_update);
-    const effect = EffectScope.begin("Capture.start!", 0);
+fn hostedCaptureStartRecordingCode(roc_host: *RocHost, args: abi.HostCapture_start_recordingArg1) u8 {
+    enforcePhase("Capture.Writer.start!", during_update);
+    const effect = EffectScope.begin("Capture.Writer.start!", 0);
     defer effect.end();
     defer args.path.decref(roc_host);
     const result = startCaptureRecording(.{
@@ -8399,14 +8363,14 @@ fn hostedCaptureStartRecordingCode(roc_host: *RocHost, args: abi.HostCapture_sta
     return result;
 }
 
-fn exportedCaptureStartRecording(args: abi.HostCapture_start_recordingArgs) callconv(.c) abi.HostCapture_start_recordingResult {
+fn exportedCaptureStartRecording(args: abi.HostCapture_start_recordingArg1) callconv(.c) abi.HostCapture_start_recordingResult {
     return hostedCaptureStartRecording(activeHost(), args);
 }
 
 /// Validate a recording request and arm the session.
 ///
-/// Shared by the runtime effect and the startup config so a recording declared
-/// in `App.Config` is checked exactly as strictly as one started from `render!`.
+/// Called only through the authorized capture effect; a configuration is a
+/// description and does not start recording by itself.
 fn startCaptureRecording(request: capture.Request) u8 {
     // A recording that failed mid-run leaves its session latched and its sink
     // open, and retrying after observing `Failed` is the natural thing for an
@@ -8527,10 +8491,12 @@ fn captureErrorCode(err: gif_encoder.Error) u8 {
 /// left holding an unfinalized file and a live descriptor.
 ///
 /// This is also where the GPU downscale targets go. Every way a recording can
-/// end -- `Capture.stop!`, the frame cap, a failed session being restarted, and
+/// end -- `Capture.Writer.stop!`, the frame cap, a failed session being restarted, and
 /// shutdown -- funnels through here, and shutdown reaches it while the window
 /// is still open, which releasing GPU memory requires.
 fn closeCaptureSink(finished: bool) u8 {
+    // Headless sessions have no encoder or GPU sink to finalize.
+    if (headlessMode()) return capture.err_none;
     var result = capture.err_none;
 
     releaseCaptureDownscaler();
@@ -8697,8 +8663,8 @@ fn exportedCaptureSetVirtualText(text: abi.RocListWith(u32, false)) callconv(.c)
 
 fn hostedCaptureStopRecording() callconv(.c) abi.HostCapture_stop_recordingResult {
     const Result = abi.HostCapture_stop_recordingResult;
-    enforcePhase("Capture.stop!", during_update);
-    const effect = EffectScope.begin("Capture.stop!", 0);
+    enforcePhase("Capture.Writer.stop!", during_update);
+    const effect = EffectScope.begin("Capture.Writer.stop!", 0);
     defer effect.end();
     const frames = capture_session.captured_frames;
     const stop_result = capture_session.stop();
@@ -8742,7 +8708,7 @@ fn captureStateForStep() CaptureFromHost {
     };
 }
 
-/// `Window.read_clipboard!`: the clipboard as text, or why not.
+/// `Window.Clipboard.read_text!`: the clipboard as text, or why not.
 ///
 /// The windowing backend only answers on the thread that owns the window, and
 /// the read is a pointer copy rather than I/O, so there is nothing to move off
@@ -8755,9 +8721,9 @@ fn captureStateForStep() CaptureFromHost {
 /// reason.
 fn hostedReadClipboard(roc_host: *RocHost) callconv(.c) abi.HostWindow_read_clipboardResult {
     const Result = abi.HostWindow_read_clipboardResult;
-    const Error = abi.BusyOrTooLargeOrUnavailable;
-    enforcePhase("Window.read_clipboard!", during_update);
-    const effect = EffectScope.begin("Window.read_clipboard!", 0);
+    const Error = abi.HostWindow_read_clipboardErr;
+    enforcePhase("Window.Clipboard.read_text!", during_update);
+    const effect = EffectScope.begin("Window.Clipboard.read_text!", 0);
     defer effect.end();
 
     if (headlessMode()) {
@@ -8779,8 +8745,8 @@ fn exportedReadClipboard() callconv(.c) abi.HostWindow_read_clipboardResult {
 }
 
 fn hostedSetClipboardText(roc_host: *RocHost, text_arg: abi.RocStr) callconv(.c) void {
-    enforcePhase("Window.set_clipboard_text!", during_update);
-    const effect = EffectScope.begin("Window.set_clipboard_text!", text_arg.asSlice().len);
+    enforcePhase("Window.Clipboard.set_text!", during_update);
+    const effect = EffectScope.begin("Window.Clipboard.set_text!", text_arg.asSlice().len);
     defer effect.end();
     // Roc transfers ownership of refcounted args to the hosted fn; release it
     // on every path, including the early returns below.
@@ -8905,7 +8871,7 @@ test "headless clipboard round-trips text and refuses oversized writes" {
     try std.testing.expectEqualStrings("copied", unchanged.payload_ok().asSlice());
 }
 
-/// `App.Startup.entropy!`: one draw from the operating system's entropy.
+/// `App.Io.entropy!`: one draw from the operating system's entropy.
 ///
 /// The only thing in this host that makes a run differ from the last one by
 /// itself. It answers with real entropy in headless runs too: an app that must
@@ -8914,8 +8880,8 @@ test "headless clipboard round-trips text and refuses oversized writes" {
 /// making it. Obtaining it does not block, so this needs none of the parking
 /// machinery a waiting effect has.
 fn hostedEntropy() callconv(.c) u64 {
-    enforcePhase("App.Startup.entropy!", during_startup);
-    const effect = EffectScope.begin("App.Startup.entropy!", 0);
+    enforcePhase("App.Io.entropy!", during_startup);
+    const effect = EffectScope.begin("App.Io.entropy!", 0);
     defer effect.end();
     var bytes: [8]u8 = undefined;
     std.Io.random(waitingIo(), &bytes);
@@ -8923,8 +8889,8 @@ fn hostedEntropy() callconv(.c) u64 {
 }
 
 fn hostedRandomI32(min: i32, max: i32) callconv(.c) i32 {
-    enforcePhase("App.Startup.random_i32!", during_startup);
-    const effect = EffectScope.begin("App.Startup.random_i32!", 0);
+    enforcePhase("App.Io.random_i32!", during_startup);
+    const effect = EffectScope.begin("App.Io.random_i32!", 0);
     defer effect.end();
     if (active_headless) return headlessRandomI32(min, max);
     return raylib.getRandomValue(min, max);
@@ -8997,7 +8963,7 @@ fn audioFileTypeFromPath(path: []const u8, module_music: bool) ?[*:0]const u8 {
     return null;
 }
 
-/// `Audio.load_sound!`: read an audio file and decode it onto the device.
+/// `Audio.Loader.load_sound!`: read an audio file and decode it onto the device.
 ///
 /// The read waits -- it parks a task and blocks `init!` -- and the decode and
 /// the upload run on the frame thread once the bytes are back. Nothing of the
@@ -9005,8 +8971,8 @@ fn audioFileTypeFromPath(path: []const u8, module_music: bool) ?[*:0]const u8 {
 fn hostedAudioLoadSound(host: *RocHost, path_arg: abi.RocStr) callconv(.c) abi.HostAudio_load_soundResult {
     const Result = abi.HostAudio_load_soundResult;
     const Error = abi.HostAudio_load_soundErr;
-    enforcePhase("Audio.load_sound!", during_wait);
-    const effect = EffectScope.begin("Audio.load_sound!", path_arg.asSlice().len);
+    enforcePhase("Audio.Loader.load_sound!", during_wait);
+    const effect = EffectScope.begin("Audio.Loader.load_sound!", path_arg.asSlice().len);
     defer effect.end();
     defer path_arg.decref(host);
 
@@ -9033,7 +8999,7 @@ fn exportedAudioLoadSound(path_arg: abi.RocStr) callconv(.c) abi.HostAudio_load_
     return hostedAudioLoadSound(activeHost(), path_arg);
 }
 
-/// `Audio.load_music!`: read an audio file and open a stream over it.
+/// `Audio.Loader.load_music!`: read an audio file and open a stream over it.
 ///
 /// The read waits the same way `load_sound!` does, but the bytes are not
 /// released afterwards: raylib's memory decoders read out of that buffer for
@@ -9042,8 +9008,8 @@ fn exportedAudioLoadSound(path_arg: abi.RocStr) callconv(.c) abi.HostAudio_load_
 fn hostedAudioLoadMusic(host: *RocHost, path_arg: abi.RocStr) callconv(.c) abi.HostAudio_load_musicResult {
     const Result = abi.HostAudio_load_musicResult;
     const Error = abi.HostAudio_load_musicErr;
-    enforcePhase("Audio.load_music!", during_wait);
-    const effect = EffectScope.begin("Audio.load_music!", path_arg.asSlice().len);
+    enforcePhase("Audio.Loader.load_music!", during_wait);
+    const effect = EffectScope.begin("Audio.Loader.load_music!", path_arg.asSlice().len);
     defer effect.end();
     defer path_arg.decref(host);
 
@@ -9101,14 +9067,14 @@ test "the audio file loaders wait rather than load" {
         last_phase_violation = null;
         _ = hostedAudioLoadSound(&roc_host, abi.RocStr.fromSlice(path, &roc_host));
         const violation = last_phase_violation orelse return error.OperationWasNotRejected;
-        try std.testing.expectEqualStrings("Audio.load_sound!", violation.operation);
+        try std.testing.expectEqualStrings("Audio.Loader.load_sound!", violation.operation);
         try std.testing.expect(violation.allowed.eql(during_wait));
         try std.testing.expectEqual(Phase.update, violation.actual);
 
         last_phase_violation = null;
         _ = hostedAudioLoadMusic(&roc_host, abi.RocStr.fromSlice(path, &roc_host));
         const music_violation = last_phase_violation orelse return error.OperationWasNotRejected;
-        try std.testing.expectEqualStrings("Audio.load_music!", music_violation.operation);
+        try std.testing.expectEqualStrings("Audio.Loader.load_music!", music_violation.operation);
         try std.testing.expect(music_violation.allowed.eql(during_wait));
     }
 
@@ -9475,7 +9441,7 @@ comptime {
         @export(&exportedRocExpectFailed, .{ .name = "roc_expect_failed" });
         @export(&exportedRocCrashed, .{ .name = "roc_crashed" });
 
-        @export(&hostedSqliteOpen, .{ .name = "roc_sqlite_open" });
+        @export(&capsHostedSqliteOpen, .{ .name = "roc_sqlite_open" });
         @export(&hostedSqliteClose, .{ .name = "roc_sqlite_close" });
         @export(&hostedSqlitePrepare, .{ .name = "roc_sqlite_prepare" });
         @export(&hostedSqliteRunStmt, .{ .name = "roc_sqlite_run_stmt" });
@@ -9487,7 +9453,7 @@ comptime {
         @export(&hostedTraceSampleI64, .{ .name = "roc_trace_sample_i64" });
         @export(&hostedTraceSampleF64, .{ .name = "roc_trace_sample_f64" });
 
-        @export(&exportedStoreOpenRaw, .{ .name = "roc_store_open_raw" });
+        @export(&capsExportedStoreOpenRaw, .{ .name = "roc_store_open_raw" });
         @export(&exportedTextureLoadStoreRaw, .{ .name = "roc_texture_load_store_raw" });
         @export(&exportedTextureLoadBytesRaw, .{ .name = "roc_texture_load_bytes_raw" });
         @export(&hostedTextureGenerateColorRaw, .{ .name = "roc_texture_generate_color_raw" });
@@ -9498,8 +9464,8 @@ comptime {
         @export(&hostedTextureSetWrapRaw, .{ .name = "roc_texture_set_wrap_raw" });
         @export(&hostedAudioGenSound, .{ .name = "roc_audio_gen_sound_raw" });
         @export(&hostedAudioGenTone, .{ .name = "roc_audio_gen_tone_raw" });
-        @export(&exportedAudioLoadMusic, .{ .name = "roc_audio_load_music_raw" });
-        @export(&exportedAudioLoadSound, .{ .name = "roc_audio_load_sound_raw" });
+        @export(&capsExportedAudioLoadMusic, .{ .name = "roc_audio_load_music_raw" });
+        @export(&capsExportedAudioLoadSound, .{ .name = "roc_audio_load_sound_raw" });
         @export(&hostedAudioPauseMusic, .{ .name = "roc_audio_pause_music_raw" });
         @export(&hostedAudioPause, .{ .name = "roc_audio_pause_raw" });
         @export(&hostedAudioPlayMusic, .{ .name = "roc_audio_play_music_raw" });
@@ -9541,7 +9507,7 @@ comptime {
         @export(&hostedDrawEndShaderRaw, .{ .name = "roc_draw_end_shader_raw" });
         @export(&hostedDrawFps, .{ .name = "roc_draw_fps" });
         @export(&exportedTextDefaultFontRaw, .{ .name = "roc_text_default_font_raw" });
-        @export(&exportedTextStartupDefaultFontRaw, .{ .name = "roc_text_startup_default_font_raw" });
+        @export(&capsExportedTextStartupDefaultFontRaw, .{ .name = "roc_text_startup_default_font_raw" });
         @export(&hostedDrawFrameSizeRaw, .{ .name = "roc_draw_frame_size" });
         @export(&hostedDrawLineRaw, .{ .name = "roc_draw_line_raw" });
         @export(&exportedTextLoadFontRaw, .{ .name = "roc_text_load_font_raw" });
@@ -9572,26 +9538,26 @@ comptime {
         @export(&hostedEntropy, .{ .name = "roc_random_entropy" });
         @export(&hostedExit, .{ .name = "roc_app_exit" });
         @export(&hostedTaskSleep, .{ .name = "roc_task_sleep" });
-        @export(&exportedFilesReadText, .{ .name = "roc_files_read_text" });
-        @export(&exportedFilesReadBytes, .{ .name = "roc_files_read_bytes" });
-        @export(&exportedFilesList, .{ .name = "roc_files_list" });
-        @export(&exportedFilesMetadata, .{ .name = "roc_files_metadata" });
-        @export(&exportedFilesWriteText, .{ .name = "roc_files_write_text" });
-        @export(&exportedFilesWriteBytes, .{ .name = "roc_files_write_bytes" });
+        @export(&capsExportedFilesReadText, .{ .name = "roc_files_read_text" });
+        @export(&capsExportedFilesReadBytes, .{ .name = "roc_files_read_bytes" });
+        @export(&capsExportedFilesList, .{ .name = "roc_files_list" });
+        @export(&capsExportedFilesMetadata, .{ .name = "roc_files_metadata" });
+        @export(&capsExportedFilesWriteText, .{ .name = "roc_files_write_text" });
+        @export(&capsExportedFilesWriteBytes, .{ .name = "roc_files_write_bytes" });
         @export(&hostedTaskSpawn, .{ .name = "roc_task_spawn" });
-        @export(&exportedReadClipboard, .{ .name = "roc_window_read_clipboard" });
+        @export(&capsExportedReadClipboard, .{ .name = "roc_window_read_clipboard" });
         @export(&hostedRandomI32, .{ .name = "roc_random_i32" });
-        @export(if (builtin.os.tag == .windows) &exportedAppReadEnvWindows else &exportedAppReadEnvPosix, .{ .name = "roc_app_read_env" });
-        @export(&exportedAppReadText, .{ .name = "roc_app_read_text_raw" });
-        @export(&exportedSetClipboardText, .{ .name = "roc_window_set_clipboard_text" });
+        @export(if (builtin.os.tag == .windows) &capsExportedAppReadEnvWindows else &capsExportedAppReadEnvPosix, .{ .name = "roc_app_read_env" });
+
+        @export(&capsExportedSetClipboardText, .{ .name = "roc_window_set_clipboard_text" });
         @export(&hostedSetExitKey, .{ .name = "roc_keys_set_exit_key" });
-        @export(&exportedCaptureStartRecording, .{ .name = "roc_capture_start_recording" });
+        @export(&capsExportedCaptureStartRecording, .{ .name = "roc_capture_start_recording" });
         @export(&hostedCaptureSetVirtualMouse, .{ .name = "roc_capture_set_virtual_mouse" });
         @export(&exportedCaptureSetVirtualKeys, .{ .name = "roc_capture_set_virtual_keys" });
         @export(&exportedCaptureSetVirtualText, .{ .name = "roc_capture_set_virtual_text" });
-        @export(&hostedCaptureStopRecording, .{ .name = "roc_capture_stop_recording" });
-        @export(&exportedCaptureScreenshot, .{ .name = "roc_capture_screenshot" });
-        @export(&exportedCaptureScreenshotTexture, .{ .name = "roc_capture_screenshot_texture" });
+        @export(&capsHostedCaptureStopRecording, .{ .name = "roc_capture_stop_recording" });
+        @export(&capsExportedCaptureScreenshot, .{ .name = "roc_capture_screenshot" });
+        @export(&capsExportedCaptureScreenshotTexture, .{ .name = "roc_capture_screenshot_texture" });
         @export(&exportedCapturePixelAt, .{ .name = "roc_capture_pixel_at" });
         @export(&exportedCaptureReadRegion, .{ .name = "roc_capture_read_region" });
         @export(&hostedSuggestWindowSize, .{ .name = "roc_window_suggest_size" });
@@ -9604,22 +9570,23 @@ comptime {
         @export(&hostedMouseSetCursorModeRaw, .{ .name = "roc_mouse_set_cursor_mode_raw" });
         @export(&hostedMouseSetCursorRaw, .{ .name = "roc_mouse_set_cursor_raw" });
         @export(&exportedTilemapDrawRaw, .{ .name = "roc_tilemap_draw_raw" });
-        @export(&exportedTilemapLoadTmxRaw, .{ .name = "roc_tilemap_load_tmx_raw" });
-        @export(&hostedHttpSend, .{ .name = "roc_http_send" });
+        @export(&capsExportedTilemapLoadTmxRaw, .{ .name = "roc_tilemap_load_tmx_raw" });
+        @export(&capsHostedHttpSend, .{ .name = "roc_http_send" });
         @export(&hostedTimeNow, .{ .name = "roc_time_now" });
-        @export(&exportedStdioWriteText, .{ .name = "roc_stdio_write_text" });
-        @export(&exportedStdioWriteLine, .{ .name = "roc_stdio_write_line" });
-        @export(&exportedStdioWriteBytes, .{ .name = "roc_stdio_write_bytes" });
-        @export(&exportedUdpBind, .{ .name = "roc_udp_bind" });
+        @export(&capsExportedStdioWriteText, .{ .name = "roc_stdio_write_text" });
+        @export(&capsExportedStdioWriteLine, .{ .name = "roc_stdio_write_line" });
+        @export(&capsExportedStdioWriteBytes, .{ .name = "roc_stdio_write_bytes" });
+        @export(&capsExportedUdpBind, .{ .name = "roc_udp_bind" });
         @export(&exportedUdpSend, .{ .name = "roc_udp_send" });
         @export(&exportedUdpReceive, .{ .name = "roc_udp_receive" });
-        @export(&exportedCmdRun, .{ .name = "roc_cmd_run" });
+        @export(&capsExportedCmdRun, .{ .name = "roc_cmd_run" });
     }
 }
 
 const RuntimeOptions = struct {
     const StatsDetail = enum { summary, standard, full };
 
+    caps_allow_all: bool = false,
     headless: bool = false,
     headless_frames: u64 = DEFAULT_HEADLESS_FRAMES,
     /// Cycles a windowed run is allowed before it exits by itself, or null for
@@ -10014,6 +9981,7 @@ fn printUsage() void {
         \\           [--host-stats-buffer-mib=N] [--host-stats-max-mib=N]
         \\           [app arguments...]
         \\
+        \\  --host-caps-allow-all  allow external services under existing resource limits
         \\  --host-frames=N   exit after N cycles of a real windowed run
         \\  --host-hidden     open the real window hidden (needs a display server)
         \\  --host-keys=SCRIPT  hold keys on given cycles, e.g. "3:S,4:LEFT+X,10:32";
@@ -10295,7 +10263,9 @@ fn parseRuntimeOptions(allocator: std.mem.Allocator, argc: usize, argv: [*][*:0]
     var i: usize = 1;
     while (i < argc) : (i += 1) {
         const arg = std.mem.span(argv[i]);
-        if (std.mem.eql(u8, arg, "--host-headless")) {
+        if (std.mem.eql(u8, arg, "--host-caps-allow-all")) {
+            options.caps_allow_all = true;
+        } else if (std.mem.eql(u8, arg, "--host-headless")) {
             options.headless = true;
         } else if (std.mem.startsWith(u8, arg, "--host-headless-frames=")) {
             options.headless = true;
@@ -10391,6 +10361,7 @@ test "runtime options reserve host switches and preserve complete app argv" {
     var argv = [_][*:0]u8{
         @constCast("breakout"),
         @constCast("--record-demo"),
+        @constCast("--host-caps-allow-all"),
         @constCast("--host-headless"),
         @constCast("--host-headless-frames=7"),
         @constCast("--headless"),
@@ -10399,6 +10370,7 @@ test "runtime options reserve host switches and preserve complete app argv" {
     defer options.deinit(std.testing.allocator);
 
     try std.testing.expect(options.headless);
+    try std.testing.expect(options.caps_allow_all);
     try std.testing.expectEqual(@as(u64, 7), options.headless_frames);
     try std.testing.expectEqual(@as(usize, 3), options.app_args.len);
     try std.testing.expectEqualStrings("breakout", std.mem.span(options.app_args[0]));
@@ -10539,13 +10511,13 @@ fn updateOnce(boxed_model: *RocBox, input: InputFromHost) UpdateResult {
     // Off unless ROC_RAY_ALLOC_STATS asked for metering; one branch per frame.
     const metered = allocMeterMark();
     defer allocMeterRecordUpdate(metered);
-    return update_for_host(takeModel(boxed_model), input);
+    return update_for_host(takeModel(boxed_model), input, active_io_authority);
 }
 
 /// Apply the startup capture configuration once the window exists.
 ///
 /// A recording declared in `App.Config` goes through the same validation as
-/// `Capture.start!`, so a bad path or an over-budget request is reported the
+/// `Capture.Writer.start!`, so a bad path or an over-budget request is reported the
 /// same way rather than being trusted because it came from config.
 fn configureCapture(app_config: AppConfig) void {
     capture_session.reset();
@@ -10567,29 +10539,11 @@ fn configureCapture(app_config: AppConfig) void {
         std.log.warn("output directory path too long; capturing into the working directory", .{});
         capture_output_dir_len = 0;
     }
-
-    if (!app_config.record_enabled) return;
-
-    const result = startCaptureRecording(.{
-        .path = app_config.record_path.asSlice(),
-        .format = app_config.record_format,
-        .fps = app_config.record_fps,
-        .max_frames = app_config.record_max_frames,
-        .scale_numerator = app_config.record_scale_numerator,
-        .scale_denominator = app_config.record_scale_denominator,
-        .every_nth = app_config.record_every_nth,
-        .timing = app_config.record_timing,
-        .cursor = app_config.record_cursor,
-        .quality = app_config.record_quality,
-    });
-    if (result != capture.err_none) {
-        std.log.err("could not start the recording declared in App.Config (capture error {d})", .{result});
-    }
 }
 
 /// Finalize an unfinished recording at shutdown.
 ///
-/// Reaching the frame cap, calling `Capture.stop!`, and simply exiting all have
+/// Reaching the frame cap, calling `Capture.Writer.stop!`, and simply exiting all have
 /// to produce a complete file, so every exit path funnels through here.
 fn finalizeCapture() void {
     if (capture_session.status == capture.status_idle or
@@ -10705,7 +10659,7 @@ fn serviceCaptureRequests() void {
     finishRecordingAtFrameCap();
 }
 
-/// Copy the readback out for the task parked on `Capture.screenshot!`.
+/// Copy the readback out for the task parked on `Capture.Writer.screenshot!`.
 ///
 /// The pixels are copied rather than moved because the readback buffer belongs
 /// to the graphics backend, which frees it on this thread as soon as the
@@ -10743,7 +10697,7 @@ fn writeRecordingFrame(image: raylib.CaptureImage) void {
 
 /// Finalize a recording that has just written its last permitted frame.
 ///
-/// Reaching the frame cap finalizes the file, which is what `Capture.start!`
+/// Reaching the frame cap finalizes the file, which is what `Capture.Writer.start!`
 /// and `App.with_recording` both promise. Without this a capped recording stays
 /// `Active` forever, counts every later frame as dropped, and only reaches disk
 /// when the process exits.
@@ -11713,7 +11667,7 @@ test "completing a large read transfers the read's allocation without copying" {
     const small = installReadBytes(std.testing.allocator, small_bytes);
     try std.testing.expectEqual(large_cost, counter.allocated_bytes);
 
-    // The control. `Files.read_text!` copies its whole payload through the Roc
+    // The control. `Files.Access.read_text!` copies its whole payload through the Roc
     // allocator, so the number above is a result and not a broken meter.
     const inline_bytes = try std.testing.allocator.alloc(u8, MAX_INLINE_READ_BYTES);
     defer std.testing.allocator.free(inline_bytes);
@@ -12053,7 +12007,7 @@ test "an offscreen export called from update! is rejected" {
     });
 
     const violation = last_phase_violation orelse return error.OperationWasNotRejected;
-    try std.testing.expectEqualStrings("Capture.screenshot_texture!", violation.operation);
+    try std.testing.expectEqualStrings("Capture.Writer.screenshot_texture!", violation.operation);
     try std.testing.expect(violation.allowed.eql(during_wait));
     try std.testing.expectEqual(Phase.update, violation.actual);
 }
@@ -12133,7 +12087,7 @@ test "loading a map from a frame or an update is rejected, and from a task is no
         try std.testing.expectEqual(abi.HostTilemap_load_tmxResultTag.Err, result.tag);
 
         const violation = last_phase_violation orelse return error.OperationWasNotRejected;
-        try std.testing.expectEqualStrings("Tilemap.load_tmx!", violation.operation);
+        try std.testing.expectEqualStrings("Tilemap.Loader.load_tmx!", violation.operation);
         try std.testing.expect(violation.allowed.eql(during_wait));
         try std.testing.expectEqual(phase, violation.actual);
     }
@@ -12450,14 +12404,14 @@ test "an operation called from its own phase is not rejected" {
 
 /// Run the app's startup callback.
 ///
-/// It takes no snapshot: `App.Startup` is authority, not observation. Nothing
+/// It takes no snapshot: `App.Io` is authority, not observation. Nothing
 /// has been sampled when this runs, so there is nothing to hand over -- an app
 /// seeds its model with `Devices.empty` and waits for the first `App.Input`.
 fn initModel() RocResult {
     if (TRACE_HOST) std.log.debug("[HOST] Calling init_for_host...", .{});
     const phase = PhaseScope.enter(.startup);
     defer phase.leave();
-    const init_result = init_for_host();
+    const init_result = init_for_host(active_io_authority);
     if (TRACE_HOST) std.log.debug("[HOST] init returned, tag={d}", .{@intFromEnum(init_result.tag)});
     return init_result;
 }
@@ -13119,12 +13073,12 @@ fn runNormalApp(roc_host: *RocHost, allocator: std.mem.Allocator, app_config: Ap
         app_tasks.setObserver(taskObserver(session));
     }
     // Registered after the registry's own teardown, so LIFO runs it first:
-    // a task parked in `Cmd.run!` cannot be cancelled out of a child it is
+    // a task parked in `Cmd.Runner.run!` cannot be cancelled out of a child it is
     // waiting on, so every child is ended before the runtime tries to join
     // the worker holding one.
     defer cmd_effect.killLiveChildren();
     app_tasks.activate();
-    // `Http.send!` drives std.http.Client over the same runtime, so it needs
+    // `Http.Client.send!` drives std.http.Client over the same runtime, so it needs
     // the same handle the task registry holds. Withdrawn before the registry
     // tears the runtime down, so a late send reports a stopped app instead of
     // reaching a dead event loop.
@@ -13340,12 +13294,12 @@ fn runHeadlessApp(roc_host: *RocHost, app_config: AppConfig, frames: u64) c_int 
         app_tasks.setObserver(taskObserver(session));
     }
     // Registered after the registry's own teardown, so LIFO runs it first:
-    // a task parked in `Cmd.run!` cannot be cancelled out of a child it is
+    // a task parked in `Cmd.Runner.run!` cannot be cancelled out of a child it is
     // waiting on, so every child is ended before the runtime tries to join
     // the worker holding one.
     defer cmd_effect.killLiveChildren();
     app_tasks.activate();
-    // `Http.send!` drives std.http.Client over the same runtime, so it needs
+    // `Http.Client.send!` drives std.http.Client over the same runtime, so it needs
     // the same handle the task registry holds. Withdrawn before the registry
     // tears the runtime down, so a late send reports a stopped app instead of
     // reaching a dead event loop.
@@ -13523,6 +13477,9 @@ fn platform_main(argc: usize, argv: [*][*:0]u8) c_int {
         printUsage();
         return 0;
     }
+
+    beginIoLifetime(options.caps_allow_all);
+    defer endIoLifetime();
 
     // Capture envp on Linux. Roc links with -nostdlib, so glibc's
     // __libc_start_main (which normally initializes environ) doesn't run. We
@@ -13989,7 +13946,7 @@ test "writing to a stream is queued, so update! is allowed and render! is not" {
         const scope = PhaseScope.enter(phase);
         defer scope.leave();
         last_phase_violation = null;
-        enforcePhase("Stdout.line!", during_update);
+        enforcePhase("Stdout.Writer.line!", during_update);
         const violation = last_phase_violation orelse return error.StreamWriteWasNotRejected;
         try std.testing.expectEqual(phase, violation.actual);
     }
@@ -14000,7 +13957,7 @@ test "writing to a stream is queued, so update! is allowed and render! is not" {
         const scope = PhaseScope.enter(phase);
         defer scope.leave();
         last_phase_violation = null;
-        enforcePhase("Stdout.line!", during_update);
+        enforcePhase("Stdout.Writer.line!", during_update);
         try std.testing.expectEqual(@as(?PhaseViolation, null), last_phase_violation);
     }
 }
@@ -14415,4 +14372,489 @@ test "a pixel readback called from render! is rejected" {
     const region_violation = last_phase_violation orelse return error.OperationWasNotRejected;
     try std.testing.expectEqualStrings("Capture.read_region!", region_violation.operation);
     try std.testing.expect(region_violation.allowed.eql(during_update));
+}
+
+/// Authority owns no native resource. A private nominal scalar carries this
+/// application-lifetime identity; copying/accessing it allocates nothing.
+/// Zero denotes a test stub. The sequence prevents reuse across hosted lifetimes.
+var io_generation: u64 = 0;
+var active_io_authority: u64 = 0;
+var external_caps_allowed: bool = false;
+
+fn beginIoLifetime(allow_all: bool) void {
+    io_generation = std.math.add(u64, io_generation, 1) catch @panic("IO authority generation exhausted");
+    active_io_authority = io_generation;
+    external_caps_allowed = allow_all;
+}
+
+fn endIoLifetime() void {
+    active_io_authority = 0;
+    external_caps_allowed = false;
+}
+
+fn allowsExternal(authority: u64) bool {
+    return authority != 0 and authority == active_io_authority and external_caps_allowed;
+}
+
+/// Hosted calls consume their arguments even when admission is refused.
+fn releaseDeniedArgument(value: anytype) void {
+    const T = @TypeOf(value);
+    switch (@typeInfo(T)) {
+        .@"struct" => {
+            if (@hasDecl(T, "decref")) {
+                value.decref(activeHost());
+            } else {
+                inline for (std.meta.fields(T)) |field| releaseDeniedArgument(@field(value, field.name));
+            }
+        },
+        else => {},
+    }
+}
+
+/// Capability boundary for files_read_text!; the implementation below it is trusted host code.
+fn capsExportedFilesReadText(authority: u64, path_arg: abi.RocStr) callconv(.c) abi.HostFiles_read_textResult {
+    enforcePhase("Files.Access.read_text!", during_wait);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("Files.Access.read_text!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(path_arg);
+        return permissionDenied(abi.HostFiles_read_textResult);
+    }
+    return exportedFilesReadText(path_arg);
+}
+
+/// Capability boundary for files_read_bytes!; the implementation below it is trusted host code.
+fn capsExportedFilesReadBytes(authority: u64, path_arg: abi.RocStr) callconv(.c) abi.HostFiles_read_bytesResult {
+    enforcePhase("Files.Access.read_bytes!", during_wait);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("Files.Access.read_bytes!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(path_arg);
+        return permissionDenied(abi.HostFiles_read_bytesResult);
+    }
+    return exportedFilesReadBytes(path_arg);
+}
+
+/// Capability boundary for files_list!; the implementation below it is trusted host code.
+fn capsExportedFilesList(authority: u64, path_arg: abi.RocStr) callconv(.c) abi.HostFiles_listResult {
+    enforcePhase("Files.Access.list!", during_wait);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("Files.Access.list!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(path_arg);
+        return permissionDenied(abi.HostFiles_listResult);
+    }
+    return exportedFilesList(path_arg);
+}
+
+/// Capability boundary for files_metadata!; the implementation below it is trusted host code.
+fn capsExportedFilesMetadata(authority: u64, path_arg: abi.RocStr) callconv(.c) abi.HostFiles_metadataResult {
+    enforcePhase("Files.Access.metadata!", during_wait);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("Files.Access.metadata!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(path_arg);
+        return permissionDenied(abi.HostFiles_metadataResult);
+    }
+    return exportedFilesMetadata(path_arg);
+}
+
+/// Capability boundary for files_write_text!; the implementation below it is trusted host code.
+fn capsExportedFilesWriteText(authority: u64, path_arg: abi.RocStr, contents_arg: abi.RocStr) callconv(.c) abi.HostFiles_write_textResult {
+    enforcePhase("Files.Access.write_text!", during_wait);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("Files.Access.write_text!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(path_arg);
+        releaseDeniedArgument(contents_arg);
+        return permissionDenied(abi.HostFiles_write_textResult);
+    }
+    return exportedFilesWriteText(path_arg, contents_arg);
+}
+
+/// Capability boundary for files_write_bytes!; the implementation below it is trusted host code.
+fn capsExportedFilesWriteBytes(authority: u64, path_arg: abi.RocStr, bytes_arg: abi.RocListWith(u8, false)) callconv(.c) abi.HostFiles_write_bytesResult {
+    enforcePhase("Files.Access.write_bytes!", during_wait);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("Files.Access.write_bytes!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(path_arg);
+        releaseDeniedArgument(bytes_arg);
+        return permissionDenied(abi.HostFiles_write_bytesResult);
+    }
+    return exportedFilesWriteBytes(path_arg, bytes_arg);
+}
+
+/// Capability boundary for http_send!; the implementation below it is trusted host code.
+fn capsHostedHttpSend(authority: u64, request: http_effect.Request) callconv(.c) abi.HostHttp_sendResult {
+    enforcePhase("Http.Client.send!", during_wait);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("Http.Client.send!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(request);
+        return permissionDenied(abi.HostHttp_sendResult);
+    }
+    return hostedHttpSend(request);
+}
+
+/// Capability boundary for cmd_run!; the implementation below it is trusted host code.
+fn capsExportedCmdRun(authority: u64, args: abi.HostCmd_runArg1) callconv(.c) abi.HostCmd_runResult {
+    enforcePhase("Cmd.Runner.run!", during_wait);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("Cmd.Runner.run!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(args);
+        return permissionDenied(abi.HostCmd_runResult);
+    }
+    return exportedCmdRun(args);
+}
+
+/// Capability boundary for stdio_write_line!; the implementation below it is trusted host code.
+fn capsExportedStdioWriteLine(authority: u64, stream: u8, text_arg: abi.RocStr) callconv(.c) abi.HostStdio_write_lineResult {
+    const name = if (stream == STDIO_STREAM_STDOUT) "Stdout.Writer.line!" else "Stderr.Writer.line!";
+    enforcePhase(name, during_update);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin(name, 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(stream);
+        releaseDeniedArgument(text_arg);
+        return permissionDenied(abi.HostStdio_write_lineResult);
+    }
+    return exportedStdioWriteLine(stream, text_arg);
+}
+
+/// Capability boundary for stdio_write_text!; the implementation below it is trusted host code.
+fn capsExportedStdioWriteText(authority: u64, stream: u8, text_arg: abi.RocStr) callconv(.c) abi.HostStdio_write_textResult {
+    const name = if (stream == STDIO_STREAM_STDOUT) "Stdout.Writer.write!" else "Stderr.Writer.write!";
+    enforcePhase(name, during_update);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin(name, 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(stream);
+        releaseDeniedArgument(text_arg);
+        return permissionDenied(abi.HostStdio_write_textResult);
+    }
+    return exportedStdioWriteText(stream, text_arg);
+}
+
+/// Capability boundary for stdio_write_bytes!; the implementation below it is trusted host code.
+fn capsExportedStdioWriteBytes(authority: u64, stream: u8, bytes_arg: abi.RocListWith(u8, false)) callconv(.c) abi.HostStdio_write_bytesResult {
+    const name = if (stream == STDIO_STREAM_STDOUT) "Stdout.Writer.write_bytes!" else "Stderr.Writer.write_bytes!";
+    enforcePhase(name, during_update);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin(name, 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(stream);
+        releaseDeniedArgument(bytes_arg);
+        return permissionDenied(abi.HostStdio_write_bytesResult);
+    }
+    return exportedStdioWriteBytes(stream, bytes_arg);
+}
+
+/// Capability boundary for udp_bind!; the implementation below it is trusted host code.
+fn capsExportedUdpBind(authority: u64, args: abi.HostUdp_bindArg1) callconv(.c) abi.HostUdp_bindResult {
+    enforcePhase("Udp.Network.bind!", during_update);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("Udp.Network.bind!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(args);
+        return permissionDenied(abi.HostUdp_bindResult);
+    }
+    return exportedUdpBind(args);
+}
+
+/// Capability boundary for sqlite_open!; the implementation below it is trusted host code.
+fn capsHostedSqliteOpen(authority: u64, path_arg: abi.RocStr, mode: u8, busy_timeout_ms: u64, max_result_bytes: u64) callconv(.c) abi.HostSqlite_openResult {
+    enforcePhase("Sqlite.Service.open!", during_wait);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("Sqlite.Service.open!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(path_arg);
+        releaseDeniedArgument(mode);
+        releaseDeniedArgument(busy_timeout_ms);
+        releaseDeniedArgument(max_result_bytes);
+        return permissionDenied(abi.HostSqlite_openResult);
+    }
+    return hostedSqliteOpen(path_arg, mode, busy_timeout_ms, max_result_bytes);
+}
+
+/// Capability boundary for store_open!; the implementation below it is trusted host code.
+fn capsExportedStoreOpenRaw(authority: u64, args: abi.HostStore_openArg1) callconv(.c) abi.HostStore_openResult {
+    enforcePhase("Assets.Loader.open!", during_wait);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("Assets.Loader.open!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(args);
+        return permissionDenied(abi.HostStore_openResult);
+    }
+    return exportedStoreOpenRaw(args);
+}
+
+/// Capability boundary for audio_load_sound!; the implementation below it is trusted host code.
+fn capsExportedAudioLoadSound(authority: u64, path_arg: abi.RocStr) callconv(.c) abi.HostAudio_load_soundResult {
+    enforcePhase("Audio.Loader.load_sound!", during_wait);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("Audio.Loader.load_sound!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(path_arg);
+        return permissionDenied(abi.HostAudio_load_soundResult);
+    }
+    return exportedAudioLoadSound(path_arg);
+}
+
+/// Capability boundary for audio_load_music!; the implementation below it is trusted host code.
+fn capsExportedAudioLoadMusic(authority: u64, path_arg: abi.RocStr) callconv(.c) abi.HostAudio_load_musicResult {
+    enforcePhase("Audio.Loader.load_music!", during_wait);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("Audio.Loader.load_music!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(path_arg);
+        return permissionDenied(abi.HostAudio_load_musicResult);
+    }
+    return exportedAudioLoadMusic(path_arg);
+}
+
+/// Capability boundary for tilemap_load_tmx!; the implementation below it is trusted host code.
+fn capsExportedTilemapLoadTmxRaw(authority: u64, path_arg: abi.RocStr) callconv(.c) TilemapLoadTmxResult {
+    enforcePhase("Tilemap.Loader.load_tmx!", during_wait);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("Tilemap.Loader.load_tmx!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(path_arg);
+        return permissionDenied(TilemapLoadTmxResult);
+    }
+    return exportedTilemapLoadTmxRaw(path_arg);
+}
+
+/// Capability boundary for window_read_clipboard!; the implementation below it is trusted host code.
+fn capsExportedReadClipboard(authority: u64) callconv(.c) abi.HostWindow_read_clipboardResult {
+    enforcePhase("Window.Clipboard.read_text!", during_update);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("Window.Clipboard.read_text!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        return permissionDenied(abi.HostWindow_read_clipboardResult);
+    }
+    return exportedReadClipboard();
+}
+
+/// Capability boundary for window_set_clipboard_text!; the implementation below it is trusted host code.
+fn capsExportedSetClipboardText(authority: u64, text_arg: abi.RocStr) callconv(.c) abi.HostWindow_set_clipboard_textResult {
+    enforcePhase("Window.Clipboard.set_text!", during_update);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("Window.Clipboard.set_text!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(text_arg);
+        return permissionDenied(abi.HostWindow_set_clipboard_textResult);
+    }
+    exportedSetClipboardText(text_arg);
+    return .ok;
+}
+
+/// Capability boundary for capture_screenshot!; the implementation below it is trusted host code.
+fn capsExportedCaptureScreenshot(authority: u64, path_arg: abi.RocStr) callconv(.c) abi.HostCapture_screenshotResult {
+    enforcePhase("Capture.Writer.screenshot!", during_frame_wait);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("Capture.Writer.screenshot!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(path_arg);
+        return permissionDenied(abi.HostCapture_screenshotResult);
+    }
+    return exportedCaptureScreenshot(path_arg);
+}
+
+/// Capability boundary for capture_screenshot_texture!; the implementation below it is trusted host code.
+fn capsExportedCaptureScreenshotTexture(authority: u64, args: abi.HostCapture_screenshot_textureArg1) callconv(.c) abi.HostCapture_screenshot_textureResult {
+    enforcePhase("Capture.Writer.screenshot_texture!", during_wait);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("Capture.Writer.screenshot_texture!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(args);
+        return permissionDenied(abi.HostCapture_screenshot_textureResult);
+    }
+    return exportedCaptureScreenshotTexture(args);
+}
+
+/// Capability boundary for capture_start_recording!; the implementation below it is trusted host code.
+fn capsExportedCaptureStartRecording(authority: u64, args: abi.HostCapture_start_recordingArg1) callconv(.c) abi.HostCapture_start_recordingResult {
+    enforcePhase("Capture.Writer.start!", during_update);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("Capture.Writer.start!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(args);
+        return permissionDenied(abi.HostCapture_start_recordingResult);
+    }
+    return exportedCaptureStartRecording(args);
+}
+
+/// Capability boundary for capture_stop_recording!; the implementation below it is trusted host code.
+fn capsHostedCaptureStopRecording(authority: u64) callconv(.c) abi.HostCapture_stop_recordingResult {
+    enforcePhase("Capture.Writer.stop!", during_update);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("Capture.Writer.stop!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        return permissionDenied(abi.HostCapture_stop_recordingResult);
+    }
+    return hostedCaptureStopRecording();
+}
+
+/// Capability boundary for app_read_env!; the implementation below it is trusted host code.
+fn capsExportedAppReadEnvWindows(authority: u64, key_arg: abi.RocStr) callconv(.c) AppReadEnvResult {
+    enforcePhase("App.Environment.read!", during_startup);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("App.Environment.read!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(key_arg);
+        return permissionDenied(AppReadEnvResult);
+    }
+    return exportedAppReadEnvWindows(key_arg);
+}
+
+/// Capability boundary for app_read_env!; the implementation below it is trusted host code.
+fn capsExportedAppReadEnvPosix(authority: u64, key_arg: abi.RocStr) callconv(.c) AppReadEnvResult {
+    enforcePhase("App.Environment.read!", during_startup);
+    if (!allowsExternal(authority)) {
+        var effect = EffectScope.begin("App.Environment.read!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        releaseDeniedArgument(key_arg);
+        return permissionDenied(AppReadEnvResult);
+    }
+    return exportedAppReadEnvPosix(key_arg);
+}
+
+/// Capability boundary for text_startup_default_font!; the implementation below it is trusted host code.
+fn capsExportedTextStartupDefaultFontRaw(authority: u64) callconv(.c) abi.HostText_startup_default_fontResult {
+    enforcePhase("App.Io.default_font!", during_startup);
+    if (startup_font_config.path.len != 0 and !allowsExternal(authority)) {
+        var effect = EffectScope.begin("App.Io.default_font!", 0);
+        defer effect.end();
+        effect.setOutcome(.refused);
+        return permissionDenied(abi.HostText_startup_default_fontResult);
+    }
+    return exportedTextStartupDefaultFontRaw();
+}
+
+fn permissionDenied(comptime Result: type) Result {
+    if (@typeInfo(Result) == .@"enum") return .err;
+    const Error = @typeInfo(@TypeOf(Result.payload_err)).@"fn".return_type.?;
+    if (@typeInfo(Error) == .@"enum") return abiTryErr(Result, @as(Error, .permission_denied));
+    var err = std.mem.zeroes(Error);
+    err.tag = .PermissionDenied;
+    return abiTryErr(Result, err);
+}
+
+test "external authority is fixed for one lifetime and never accepts a stub or stale identity" {
+    try std.testing.expect(!(RuntimeOptions{}).caps_allow_all);
+    beginIoLifetime(false);
+    const denied = active_io_authority;
+    try std.testing.expect(!allowsExternal(denied));
+    endIoLifetime();
+    beginIoLifetime(true);
+    defer endIoLifetime();
+    try std.testing.expect(allowsExternal(active_io_authority));
+    try std.testing.expect(!allowsExternal(0));
+    try std.testing.expect(!allowsExternal(denied));
+    const granted = active_io_authority;
+    endIoLifetime();
+    try std.testing.expect(!allowsExternal(granted));
+}
+
+fn expectPermissionDenied(result: anytype) !void {
+    if (@typeInfo(@TypeOf(result)) == .@"enum") {
+        try std.testing.expectEqual(.err, result);
+    } else {
+        try std.testing.expectEqual(.Err, result.tag);
+        const err = result.payload_err();
+        if (@typeInfo(@TypeOf(err)) == .@"enum") {
+            try std.testing.expectEqual(.permission_denied, err);
+        } else {
+            try std.testing.expectEqual(.PermissionDenied, err.tag);
+        }
+    }
+}
+
+// A static resource reference is sufficient here: denial must release the
+// transferred reference without looking up a backend resource or doing I/O.
+var denied_test_resource = [_]u64{ 0, std.math.maxInt(u64) };
+fn deniedTestArgument(comptime T: type) T {
+    if (T == *u64) return &denied_test_resource[1];
+    if (@typeInfo(T) == .@"struct") {
+        var value: T = undefined;
+        inline for (std.meta.fields(T)) |field| @field(value, field.name) = deniedTestArgument(field.type);
+        return value;
+    }
+    return std.mem.zeroes(T);
+}
+
+test "every external entry point denies before touching the backend and consumes arguments" {
+    var roc_env = abi.RocEnv{ .allocator = std.testing.allocator, .roc_io = abi.RocIo.freestanding() };
+    var roc_host = abi.makeRocHost(&roc_env);
+    const previous_host = active_roc_host;
+    active_roc_host = &roc_host;
+    defer active_roc_host = previous_host;
+    beginIoLifetime(false);
+    defer endIoLifetime();
+    const previous_font = startup_font_config;
+    startup_font_config.path = "denied-font.ttf";
+    defer startup_font_config = previous_font;
+    const phase = PhaseScope.enter(.startup);
+    defer phase.leave();
+    try expectPermissionDenied(capsExportedFilesReadText(active_io_authority, abi.RocStr.fromSlice("denied argument longer than the small string representation", &roc_host)));
+    try expectPermissionDenied(capsExportedFilesReadBytes(active_io_authority, abi.RocStr.fromSlice("denied argument longer than the small string representation", &roc_host)));
+    try expectPermissionDenied(capsExportedFilesList(active_io_authority, abi.RocStr.fromSlice("denied argument longer than the small string representation", &roc_host)));
+    try expectPermissionDenied(capsExportedFilesMetadata(active_io_authority, abi.RocStr.fromSlice("denied argument longer than the small string representation", &roc_host)));
+    try expectPermissionDenied(capsExportedFilesWriteText(active_io_authority, abi.RocStr.fromSlice("denied argument longer than the small string representation", &roc_host), abi.RocStr.fromSlice("denied argument longer than the small string representation", &roc_host)));
+    try expectPermissionDenied(capsHostedHttpSend(active_io_authority, deniedTestArgument(http_effect.Request)));
+    try expectPermissionDenied(capsExportedCmdRun(active_io_authority, deniedTestArgument(abi.HostCmd_runArg1)));
+    try expectPermissionDenied(capsExportedStdioWriteLine(active_io_authority, deniedTestArgument(u8), abi.RocStr.fromSlice("denied argument longer than the small string representation", &roc_host)));
+    try expectPermissionDenied(capsExportedStdioWriteText(active_io_authority, deniedTestArgument(u8), abi.RocStr.fromSlice("denied argument longer than the small string representation", &roc_host)));
+    try expectPermissionDenied(capsExportedUdpBind(active_io_authority, deniedTestArgument(abi.HostUdp_bindArg1)));
+    try expectPermissionDenied(capsHostedSqliteOpen(active_io_authority, abi.RocStr.fromSlice("denied argument longer than the small string representation", &roc_host), deniedTestArgument(u8), deniedTestArgument(u64), deniedTestArgument(u64)));
+    try expectPermissionDenied(capsExportedStoreOpenRaw(active_io_authority, deniedTestArgument(abi.HostStore_openArg1)));
+    try expectPermissionDenied(capsExportedAudioLoadSound(active_io_authority, abi.RocStr.fromSlice("denied argument longer than the small string representation", &roc_host)));
+    try expectPermissionDenied(capsExportedAudioLoadMusic(active_io_authority, abi.RocStr.fromSlice("denied argument longer than the small string representation", &roc_host)));
+    try expectPermissionDenied(capsExportedTilemapLoadTmxRaw(active_io_authority, abi.RocStr.fromSlice("denied argument longer than the small string representation", &roc_host)));
+    try expectPermissionDenied(capsExportedReadClipboard(active_io_authority));
+    try expectPermissionDenied(capsExportedSetClipboardText(active_io_authority, abi.RocStr.fromSlice("denied argument longer than the small string representation", &roc_host)));
+    {
+        const task = PhaseScope.enter(.task);
+        defer task.leave();
+        try expectPermissionDenied(capsExportedCaptureScreenshot(active_io_authority, abi.RocStr.fromSlice("denied argument longer than the small string representation", &roc_host)));
+    }
+    try expectPermissionDenied(capsExportedCaptureScreenshotTexture(active_io_authority, deniedTestArgument(abi.HostCapture_screenshot_textureArg1)));
+    try expectPermissionDenied(capsExportedCaptureStartRecording(active_io_authority, deniedTestArgument(abi.HostCapture_start_recordingArg1)));
+    try expectPermissionDenied(capsHostedCaptureStopRecording(active_io_authority));
+    if (builtin.os.tag == .windows) {
+        try expectPermissionDenied(capsExportedAppReadEnvWindows(active_io_authority, abi.RocStr.fromSlice("denied argument longer than the small string representation", &roc_host)));
+    }
+    if (builtin.os.tag != .windows) {
+        try expectPermissionDenied(capsExportedAppReadEnvPosix(active_io_authority, abi.RocStr.fromSlice("denied argument longer than the small string representation", &roc_host)));
+    }
+    try expectPermissionDenied(capsExportedTextStartupDefaultFontRaw(active_io_authority));
+    try expectPermissionDenied(capsExportedFilesWriteBytes(active_io_authority, abi.RocStr.fromSlice("denied-long-file-name-never-opened", &roc_host), abi.RocListWith(u8, false).empty()));
+    try expectPermissionDenied(capsExportedStdioWriteBytes(active_io_authority, 0, abi.RocListWith(u8, false).empty()));
 }

--- a/src/http_effect.zig
+++ b/src/http_effect.zig
@@ -1,4 +1,4 @@
-//! The `Http.send!` effect: one HTTP exchange on the app's zio runtime.
+//! The `Http.Client.send!` effect: one HTTP exchange on the app's zio runtime.
 //!
 //! `std.http.Client` is handed `rt.io()`, so every socket wait it does parks
 //! the calling coroutine instead of blocking the thread. Inside `Task.spawn!`
@@ -32,7 +32,7 @@ const zio = @import("zio");
 const abi = @import("roc_platform_abi.zig");
 
 /// The flattened request `Http` hands the host, as `roc glue` generated it.
-pub const Request = abi.HostHttp_sendArgs;
+pub const Request = abi.HostHttp_sendArg1;
 
 /// A finished exchange, before it is named in the app's vocabulary.
 ///
@@ -170,7 +170,7 @@ pub fn send(roc_host: *abi.RocHost, allocator: std.mem.Allocator, args: Request)
     const rt = runtime orelse return failure(
         roc_host,
         ERR_OTHER,
-        "Http.send! is only available while the app is running",
+        "Http.Client.send! is only available while the app is running",
     );
 
     var arena_state = std.heap.ArenaAllocator.init(allocator);
@@ -334,7 +334,7 @@ fn copyHeaders(arena: std.mem.Allocator, head: std.http.Client.Response.Head) Ex
 /// any `Unknown(ext)` method cannot be put on the wire from here and are
 /// reported rather than silently rewritten.
 ///
-/// `Http.send_with!` refuses both before the effect runs, so this is kept as
+/// `Http.Client.send_with!` refuses both before the effect runs, so this is kept as
 /// defence rather than as the reachable path: the host is a separate trust
 /// boundary from the Roc code above it, and code `2` is the one the wire can
 /// still carry. `request.method_ext` names the method Roc meant; nothing here
@@ -526,7 +526,7 @@ test "a method code outside the nine standard methods is refused" {
     try std.testing.expectEqual(std.http.Method.GET, try methodFromCode(3));
     try std.testing.expectEqual(std.http.Method.POST, try methodFromCode(7));
     // 2 is basic-cli's code for QUERY and for every Unknown(ext) method.
-    // `Http.send_with!` refuses those first; this is the host's own guard.
+    // `Http.Client.send_with!` refuses those first; this is the host's own guard.
     try std.testing.expectError(error.UnsupportedMethod, methodFromCode(2));
 }
 

--- a/src/roc_platform_abi.zig
+++ b/src/roc_platform_abi.zig
@@ -6847,7 +6847,7 @@ pub const HostText_startup_default_fontResultTag = enum(u8) {
 
 /// Payload union for Try.
 pub const HostText_startup_default_fontResultPayload = extern union {
-    err: AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrResourceLimit,
+    err: AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrPermissionDeniedOrResourceLimit,
     ok: Font,
 };
 
@@ -6855,8 +6855,8 @@ pub const HostText_startup_default_fontResultPayload = extern union {
 pub const HostText_startup_default_fontResult = if (@sizeOf(usize) == 4) extern struct {
     payload: [40]u8 align(8),
     tag: HostText_startup_default_fontResultTag,
-    pub fn payload_err(self: *const @This()) AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrResourceLimit {
-        const ptr: *const AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrResourceLimit = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_err(self: *const @This()) AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrPermissionDeniedOrResourceLimit {
+        const ptr: *const AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrPermissionDeniedOrResourceLimit = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     pub fn payload_ok(self: *const @This()) Font {
@@ -6875,7 +6875,7 @@ pub const HostText_startup_default_fontResult = if (@sizeOf(usize) == 4) extern 
 } else extern struct {
     payload: HostText_startup_default_fontResultPayload,
     tag: HostText_startup_default_fontResultTag,
-    pub fn payload_err(self: *const @This()) AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrResourceLimit {
+    pub fn payload_err(self: *const @This()) AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrPermissionDeniedOrResourceLimit {
         return self.payload.err;
     }
     pub fn payload_ok(self: *const @This()) Font {
@@ -6905,13 +6905,14 @@ comptime {
     }
 }
 
-/// Tag union: AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrResourceLimit
-pub const AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrResourceLimit = enum(u8) {
+/// Tag union: AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrPermissionDeniedOrResourceLimit
+pub const AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrPermissionDeniedOrResourceLimit = enum(u8) {
     asset_not_found = 0,
     asset_path_invalid = 1,
     asset_read_failed = 2,
     font_load_failed = 3,
-    resource_limit = 4,
+    permission_denied = 4,
+    resource_limit = 5,
     /// Recursively decrement Roc-owned payloads.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         _ = self;
@@ -6927,12 +6928,12 @@ pub const AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrReso
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrResourceLimit) != 1) @compileError("AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrResourceLimit size mismatch");
-        if (@alignOf(AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrResourceLimit) != 1) @compileError("AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrResourceLimit alignment mismatch");
+        if (@sizeOf(AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrPermissionDeniedOrResourceLimit) != 1) @compileError("AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrPermissionDeniedOrResourceLimit size mismatch");
+        if (@alignOf(AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrPermissionDeniedOrResourceLimit) != 1) @compileError("AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrPermissionDeniedOrResourceLimit alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrResourceLimit) != 1) @compileError("AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrResourceLimit size mismatch");
-        if (@alignOf(AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrResourceLimit) != 1) @compileError("AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrResourceLimit alignment mismatch");
+        if (@sizeOf(AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrPermissionDeniedOrResourceLimit) != 1) @compileError("AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrPermissionDeniedOrResourceLimit size mismatch");
+        if (@alignOf(AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrPermissionDeniedOrResourceLimit) != 1) @compileError("AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrPermissionDeniedOrResourceLimit alignment mismatch");
     }
 }
 
@@ -7479,7 +7480,7 @@ pub const HostStore_openResultTag = enum(u8) {
 
 /// Payload union for Try.
 pub const HostStore_openResultPayload = extern union {
-    err: AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch,
+    err: AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrPermissionDeniedOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch,
     ok: *u64,
 };
 
@@ -7487,8 +7488,8 @@ pub const HostStore_openResultPayload = extern union {
 pub const HostStore_openResult = if (@sizeOf(usize) == 4) extern struct {
     payload: [4]u8 align(4),
     tag: HostStore_openResultTag,
-    pub fn payload_err(self: *const @This()) AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch {
-        const ptr: *const AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_err(self: *const @This()) AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrPermissionDeniedOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch {
+        const ptr: *const AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrPermissionDeniedOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     pub fn payload_ok(self: *const @This()) *u64 {
@@ -7507,7 +7508,7 @@ pub const HostStore_openResult = if (@sizeOf(usize) == 4) extern struct {
 } else extern struct {
     payload: HostStore_openResultPayload,
     tag: HostStore_openResultTag,
-    pub fn payload_err(self: *const @This()) AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch {
+    pub fn payload_err(self: *const @This()) AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrPermissionDeniedOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch {
         return self.payload.err;
     }
     pub fn payload_ok(self: *const @This()) *u64 {
@@ -7537,8 +7538,8 @@ comptime {
     }
 }
 
-/// Tag union: AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch
-pub const AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch = enum(u8) {
+/// Tag union: AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrPermissionDeniedOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch
+pub const AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrPermissionDeniedOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch = enum(u8) {
     asset_set_mismatch = 0,
     content_hash_mismatch = 1,
     content_version_mismatch = 2,
@@ -7547,11 +7548,12 @@ pub const AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalid
     manifest_malformed = 5,
     manifest_missing = 6,
     manifest_unreadable = 7,
-    resource_limit = 8,
-    root_not_directory = 9,
-    root_not_found = 10,
-    root_unreadable = 11,
-    schema_mismatch = 12,
+    permission_denied = 8,
+    resource_limit = 9,
+    root_not_directory = 10,
+    root_not_found = 11,
+    root_unreadable = 12,
+    schema_mismatch = 13,
     /// Recursively decrement Roc-owned payloads.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         _ = self;
@@ -7567,12 +7569,12 @@ pub const AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalid
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch) != 1) @compileError("AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch size mismatch");
-        if (@alignOf(AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch) != 1) @compileError("AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch alignment mismatch");
+        if (@sizeOf(AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrPermissionDeniedOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch) != 1) @compileError("AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrPermissionDeniedOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch size mismatch");
+        if (@alignOf(AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrPermissionDeniedOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch) != 1) @compileError("AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrPermissionDeniedOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch) != 1) @compileError("AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch size mismatch");
-        if (@alignOf(AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch) != 1) @compileError("AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch alignment mismatch");
+        if (@sizeOf(AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrPermissionDeniedOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch) != 1) @compileError("AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrPermissionDeniedOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch size mismatch");
+        if (@alignOf(AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrPermissionDeniedOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch) != 1) @compileError("AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrPermissionDeniedOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch alignment mismatch");
     }
 }
 
@@ -7678,7 +7680,7 @@ pub const HostAudio_load_soundResultTag = enum(u8) {
 
 /// Payload union for Try.
 pub const HostAudio_load_soundResultPayload = extern union {
-    err: ResourceLimitOrSoundLoadFailed,
+    err: PermissionDeniedOrResourceLimitOrSoundLoadFailed,
     ok: *u64,
 };
 
@@ -7686,8 +7688,8 @@ pub const HostAudio_load_soundResultPayload = extern union {
 pub const HostAudio_load_soundResult = if (@sizeOf(usize) == 4) extern struct {
     payload: [4]u8 align(4),
     tag: HostAudio_load_soundResultTag,
-    pub fn payload_err(self: *const @This()) ResourceLimitOrSoundLoadFailed {
-        const ptr: *const ResourceLimitOrSoundLoadFailed = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_err(self: *const @This()) PermissionDeniedOrResourceLimitOrSoundLoadFailed {
+        const ptr: *const PermissionDeniedOrResourceLimitOrSoundLoadFailed = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     pub fn payload_ok(self: *const @This()) *u64 {
@@ -7706,7 +7708,7 @@ pub const HostAudio_load_soundResult = if (@sizeOf(usize) == 4) extern struct {
 } else extern struct {
     payload: HostAudio_load_soundResultPayload,
     tag: HostAudio_load_soundResultTag,
-    pub fn payload_err(self: *const @This()) ResourceLimitOrSoundLoadFailed {
+    pub fn payload_err(self: *const @This()) PermissionDeniedOrResourceLimitOrSoundLoadFailed {
         return self.payload.err;
     }
     pub fn payload_ok(self: *const @This()) *u64 {
@@ -7736,10 +7738,11 @@ comptime {
     }
 }
 
-/// Tag union: ResourceLimitOrSoundLoadFailed
-pub const ResourceLimitOrSoundLoadFailed = enum(u8) {
-    resource_limit = 0,
-    sound_load_failed = 1,
+/// Tag union: PermissionDeniedOrResourceLimitOrSoundLoadFailed
+pub const PermissionDeniedOrResourceLimitOrSoundLoadFailed = enum(u8) {
+    permission_denied = 0,
+    resource_limit = 1,
+    sound_load_failed = 2,
     /// Recursively decrement Roc-owned payloads.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         _ = self;
@@ -7755,12 +7758,12 @@ pub const ResourceLimitOrSoundLoadFailed = enum(u8) {
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(ResourceLimitOrSoundLoadFailed) != 1) @compileError("ResourceLimitOrSoundLoadFailed size mismatch");
-        if (@alignOf(ResourceLimitOrSoundLoadFailed) != 1) @compileError("ResourceLimitOrSoundLoadFailed alignment mismatch");
+        if (@sizeOf(PermissionDeniedOrResourceLimitOrSoundLoadFailed) != 1) @compileError("PermissionDeniedOrResourceLimitOrSoundLoadFailed size mismatch");
+        if (@alignOf(PermissionDeniedOrResourceLimitOrSoundLoadFailed) != 1) @compileError("PermissionDeniedOrResourceLimitOrSoundLoadFailed alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(ResourceLimitOrSoundLoadFailed) != 1) @compileError("ResourceLimitOrSoundLoadFailed size mismatch");
-        if (@alignOf(ResourceLimitOrSoundLoadFailed) != 1) @compileError("ResourceLimitOrSoundLoadFailed alignment mismatch");
+        if (@sizeOf(PermissionDeniedOrResourceLimitOrSoundLoadFailed) != 1) @compileError("PermissionDeniedOrResourceLimitOrSoundLoadFailed size mismatch");
+        if (@alignOf(PermissionDeniedOrResourceLimitOrSoundLoadFailed) != 1) @compileError("PermissionDeniedOrResourceLimitOrSoundLoadFailed alignment mismatch");
     }
 }
 
@@ -7772,7 +7775,7 @@ pub const HostAudio_load_musicResultTag = enum(u8) {
 
 /// Payload union for Try.
 pub const HostAudio_load_musicResultPayload = extern union {
-    err: MusicLoadFailedOrResourceLimit,
+    err: MusicLoadFailedOrPermissionDeniedOrResourceLimit,
     ok: *u64,
 };
 
@@ -7780,8 +7783,8 @@ pub const HostAudio_load_musicResultPayload = extern union {
 pub const HostAudio_load_musicResult = if (@sizeOf(usize) == 4) extern struct {
     payload: [4]u8 align(4),
     tag: HostAudio_load_musicResultTag,
-    pub fn payload_err(self: *const @This()) MusicLoadFailedOrResourceLimit {
-        const ptr: *const MusicLoadFailedOrResourceLimit = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_err(self: *const @This()) MusicLoadFailedOrPermissionDeniedOrResourceLimit {
+        const ptr: *const MusicLoadFailedOrPermissionDeniedOrResourceLimit = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     pub fn payload_ok(self: *const @This()) *u64 {
@@ -7800,7 +7803,7 @@ pub const HostAudio_load_musicResult = if (@sizeOf(usize) == 4) extern struct {
 } else extern struct {
     payload: HostAudio_load_musicResultPayload,
     tag: HostAudio_load_musicResultTag,
-    pub fn payload_err(self: *const @This()) MusicLoadFailedOrResourceLimit {
+    pub fn payload_err(self: *const @This()) MusicLoadFailedOrPermissionDeniedOrResourceLimit {
         return self.payload.err;
     }
     pub fn payload_ok(self: *const @This()) *u64 {
@@ -7830,10 +7833,11 @@ comptime {
     }
 }
 
-/// Tag union: MusicLoadFailedOrResourceLimit
-pub const MusicLoadFailedOrResourceLimit = enum(u8) {
+/// Tag union: MusicLoadFailedOrPermissionDeniedOrResourceLimit
+pub const MusicLoadFailedOrPermissionDeniedOrResourceLimit = enum(u8) {
     music_load_failed = 0,
-    resource_limit = 1,
+    permission_denied = 1,
+    resource_limit = 2,
     /// Recursively decrement Roc-owned payloads.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         _ = self;
@@ -7849,12 +7853,12 @@ pub const MusicLoadFailedOrResourceLimit = enum(u8) {
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(MusicLoadFailedOrResourceLimit) != 1) @compileError("MusicLoadFailedOrResourceLimit size mismatch");
-        if (@alignOf(MusicLoadFailedOrResourceLimit) != 1) @compileError("MusicLoadFailedOrResourceLimit alignment mismatch");
+        if (@sizeOf(MusicLoadFailedOrPermissionDeniedOrResourceLimit) != 1) @compileError("MusicLoadFailedOrPermissionDeniedOrResourceLimit size mismatch");
+        if (@alignOf(MusicLoadFailedOrPermissionDeniedOrResourceLimit) != 1) @compileError("MusicLoadFailedOrPermissionDeniedOrResourceLimit alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(MusicLoadFailedOrResourceLimit) != 1) @compileError("MusicLoadFailedOrResourceLimit size mismatch");
-        if (@alignOf(MusicLoadFailedOrResourceLimit) != 1) @compileError("MusicLoadFailedOrResourceLimit alignment mismatch");
+        if (@sizeOf(MusicLoadFailedOrPermissionDeniedOrResourceLimit) != 1) @compileError("MusicLoadFailedOrPermissionDeniedOrResourceLimit size mismatch");
+        if (@alignOf(MusicLoadFailedOrPermissionDeniedOrResourceLimit) != 1) @compileError("MusicLoadFailedOrPermissionDeniedOrResourceLimit alignment mismatch");
     }
 }
 
@@ -7866,7 +7870,7 @@ pub const HostFiles_read_textResultTag = enum(u8) {
 
 /// Payload union for Try.
 pub const HostFiles_read_textResultPayload = extern union {
-    err: BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable,
+    err: BusyOrNotFoundOrNotUtf8OrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable,
     ok: RocStr,
 };
 
@@ -7874,8 +7878,8 @@ pub const HostFiles_read_textResultPayload = extern union {
 pub const HostFiles_read_textResult = if (@sizeOf(usize) == 4) extern struct {
     payload: [12]u8 align(4),
     tag: HostFiles_read_textResultTag,
-    pub fn payload_err(self: *const @This()) BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable {
-        const ptr: *const BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_err(self: *const @This()) BusyOrNotFoundOrNotUtf8OrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable {
+        const ptr: *const BusyOrNotFoundOrNotUtf8OrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     pub fn payload_ok(self: *const @This()) RocStr {
@@ -7894,7 +7898,7 @@ pub const HostFiles_read_textResult = if (@sizeOf(usize) == 4) extern struct {
 } else extern struct {
     payload: HostFiles_read_textResultPayload,
     tag: HostFiles_read_textResultTag,
-    pub fn payload_err(self: *const @This()) BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable {
+    pub fn payload_err(self: *const @This()) BusyOrNotFoundOrNotUtf8OrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable {
         return self.payload.err;
     }
     pub fn payload_ok(self: *const @This()) RocStr {
@@ -7924,14 +7928,15 @@ comptime {
     }
 }
 
-/// Tag union: BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable
-pub const BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable = enum(u8) {
+/// Tag union: BusyOrNotFoundOrNotUtf8OrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable
+pub const BusyOrNotFoundOrNotUtf8OrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable = enum(u8) {
     busy = 0,
     not_found = 1,
     not_utf8 = 2,
-    read_failed = 3,
-    too_large = 4,
-    unavailable = 5,
+    permission_denied = 3,
+    read_failed = 4,
+    too_large = 5,
+    unavailable = 6,
     /// Recursively decrement Roc-owned payloads.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         _ = self;
@@ -7947,12 +7952,12 @@ pub const BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable = enum(u8) 
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable size mismatch");
-        if (@alignOf(BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable alignment mismatch");
+        if (@sizeOf(BusyOrNotFoundOrNotUtf8OrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrNotUtf8OrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable size mismatch");
+        if (@alignOf(BusyOrNotFoundOrNotUtf8OrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrNotUtf8OrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable size mismatch");
-        if (@alignOf(BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable alignment mismatch");
+        if (@sizeOf(BusyOrNotFoundOrNotUtf8OrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrNotUtf8OrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable size mismatch");
+        if (@alignOf(BusyOrNotFoundOrNotUtf8OrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrNotUtf8OrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable alignment mismatch");
     }
 }
 
@@ -8060,7 +8065,7 @@ pub const HostFiles_read_bytesResultTag = enum(u8) {
 
 /// Payload union for Try.
 pub const HostFiles_read_bytesResultPayload = extern union {
-    err: BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable,
+    err: BusyOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable,
     ok: RocListWith(u8, false),
 };
 
@@ -8068,8 +8073,8 @@ pub const HostFiles_read_bytesResultPayload = extern union {
 pub const HostFiles_read_bytesResult = if (@sizeOf(usize) == 4) extern struct {
     payload: [12]u8 align(4),
     tag: HostFiles_read_bytesResultTag,
-    pub fn payload_err(self: *const @This()) BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable {
-        const ptr: *const BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_err(self: *const @This()) BusyOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable {
+        const ptr: *const BusyOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     pub fn payload_ok(self: *const @This()) RocListWith(u8, false) {
@@ -8088,7 +8093,7 @@ pub const HostFiles_read_bytesResult = if (@sizeOf(usize) == 4) extern struct {
 } else extern struct {
     payload: HostFiles_read_bytesResultPayload,
     tag: HostFiles_read_bytesResultTag,
-    pub fn payload_err(self: *const @This()) BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable {
+    pub fn payload_err(self: *const @This()) BusyOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable {
         return self.payload.err;
     }
     pub fn payload_ok(self: *const @This()) RocListWith(u8, false) {
@@ -8118,13 +8123,14 @@ comptime {
     }
 }
 
-/// Tag union: BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable
-pub const BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable = enum(u8) {
+/// Tag union: BusyOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable
+pub const BusyOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable = enum(u8) {
     busy = 0,
     not_found = 1,
-    read_failed = 2,
-    too_large = 3,
-    unavailable = 4,
+    permission_denied = 2,
+    read_failed = 3,
+    too_large = 4,
+    unavailable = 5,
     /// Recursively decrement Roc-owned payloads.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         _ = self;
@@ -8140,12 +8146,12 @@ pub const BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable = enum(u8) {
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable size mismatch");
-        if (@alignOf(BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable alignment mismatch");
+        if (@sizeOf(BusyOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable size mismatch");
+        if (@alignOf(BusyOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable size mismatch");
-        if (@alignOf(BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable alignment mismatch");
+        if (@sizeOf(BusyOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable size mismatch");
+        if (@alignOf(BusyOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable alignment mismatch");
     }
 }
 
@@ -8157,7 +8163,7 @@ pub const HostFiles_listResultTag = enum(u8) {
 
 /// Payload union for Try.
 pub const HostFiles_listResultPayload = extern union {
-    err: BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable,
+    err: BusyOrNotADirectoryOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable,
     ok: RocListWith(u8, false),
 };
 
@@ -8165,8 +8171,8 @@ pub const HostFiles_listResultPayload = extern union {
 pub const HostFiles_listResult = if (@sizeOf(usize) == 4) extern struct {
     payload: [12]u8 align(4),
     tag: HostFiles_listResultTag,
-    pub fn payload_err(self: *const @This()) BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable {
-        const ptr: *const BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_err(self: *const @This()) BusyOrNotADirectoryOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable {
+        const ptr: *const BusyOrNotADirectoryOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     pub fn payload_ok(self: *const @This()) RocListWith(u8, false) {
@@ -8185,7 +8191,7 @@ pub const HostFiles_listResult = if (@sizeOf(usize) == 4) extern struct {
 } else extern struct {
     payload: HostFiles_listResultPayload,
     tag: HostFiles_listResultTag,
-    pub fn payload_err(self: *const @This()) BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable {
+    pub fn payload_err(self: *const @This()) BusyOrNotADirectoryOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable {
         return self.payload.err;
     }
     pub fn payload_ok(self: *const @This()) RocListWith(u8, false) {
@@ -8215,14 +8221,15 @@ comptime {
     }
 }
 
-/// Tag union: BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable
-pub const BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable = enum(u8) {
+/// Tag union: BusyOrNotADirectoryOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable
+pub const BusyOrNotADirectoryOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable = enum(u8) {
     busy = 0,
     not_adirectory = 1,
     not_found = 2,
-    read_failed = 3,
-    too_large = 4,
-    unavailable = 5,
+    permission_denied = 3,
+    read_failed = 4,
+    too_large = 5,
+    unavailable = 6,
     /// Recursively decrement Roc-owned payloads.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         _ = self;
@@ -8238,12 +8245,12 @@ pub const BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable = enu
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable size mismatch");
-        if (@alignOf(BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable alignment mismatch");
+        if (@sizeOf(BusyOrNotADirectoryOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotADirectoryOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable size mismatch");
+        if (@alignOf(BusyOrNotADirectoryOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotADirectoryOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable size mismatch");
-        if (@alignOf(BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable alignment mismatch");
+        if (@sizeOf(BusyOrNotADirectoryOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotADirectoryOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable size mismatch");
+        if (@alignOf(BusyOrNotADirectoryOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrNotADirectoryOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable alignment mismatch");
     }
 }
 
@@ -8345,7 +8352,7 @@ pub const HostHttp_sendResultTag = enum(u8) {
 
 /// Payload union for Try.
 pub const HostHttp_sendResultPayload = extern union {
-    err: MalformedResponseOrNetworkErrorOrOtherOrTimeout,
+    err: MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout,
     ok: __AnonStruct_a14cd3b7d5755441,
 };
 
@@ -8353,8 +8360,8 @@ pub const HostHttp_sendResultPayload = extern union {
 pub const HostHttp_sendResult = if (@sizeOf(usize) == 4) extern struct {
     payload: [28]u8 align(4),
     tag: HostHttp_sendResultTag,
-    pub fn payload_err(self: *const @This()) MalformedResponseOrNetworkErrorOrOtherOrTimeout {
-        const ptr: *const MalformedResponseOrNetworkErrorOrOtherOrTimeout = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_err(self: *const @This()) MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout {
+        const ptr: *const MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     pub fn payload_ok(self: *const @This()) __AnonStruct_a14cd3b7d5755441 {
@@ -8373,7 +8380,7 @@ pub const HostHttp_sendResult = if (@sizeOf(usize) == 4) extern struct {
 } else extern struct {
     payload: HostHttp_sendResultPayload,
     tag: HostHttp_sendResultTag,
-    pub fn payload_err(self: *const @This()) MalformedResponseOrNetworkErrorOrOtherOrTimeout {
+    pub fn payload_err(self: *const @This()) MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout {
         return self.payload.err;
     }
     pub fn payload_ok(self: *const @This()) __AnonStruct_a14cd3b7d5755441 {
@@ -8403,66 +8410,68 @@ comptime {
     }
 }
 
-/// Tag discriminant for MalformedResponseOrNetworkErrorOrOtherOrTimeout.
-pub const MalformedResponseOrNetworkErrorOrOtherOrTimeoutTag = enum(u8) {
+/// Tag discriminant for MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout.
+pub const MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeoutTag = enum(u8) {
     MalformedResponse = 0,
     NetworkError = 1,
     Other = 2,
-    Timeout = 3,
+    PermissionDenied = 3,
+    Timeout = 4,
 };
 
-/// Payload union for MalformedResponseOrNetworkErrorOrOtherOrTimeout.
-pub const MalformedResponseOrNetworkErrorOrOtherOrTimeoutPayload = extern union {
+/// Payload union for MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout.
+pub const MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeoutPayload = extern union {
     malformed_response: [0]u8,
     network_error: [0]u8,
     other: RocStr,
+    permission_denied: [0]u8,
     timeout: [0]u8,
 };
 
-/// Tag union: MalformedResponseOrNetworkErrorOrOtherOrTimeout
-pub const MalformedResponseOrNetworkErrorOrOtherOrTimeout = if (@sizeOf(usize) == 4) extern struct {
+/// Tag union: MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout
+pub const MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout = if (@sizeOf(usize) == 4) extern struct {
     payload: [12]u8 align(4),
-    tag: MalformedResponseOrNetworkErrorOrOtherOrTimeoutTag,
+    tag: MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeoutTag,
     pub fn payload_other(self: *const @This()) RocStr {
         const ptr: *const RocStr = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     /// Recursively decrement Roc-owned payloads.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
-        decrefMalformedResponseOrNetworkErrorOrOtherOrTimeout(self, roc_host);
+        decrefMalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout(self, roc_host);
     }
 
     /// Increment Roc-owned payloads.
     pub fn incref(self: @This(), amount: isize) void {
-        increfMalformedResponseOrNetworkErrorOrOtherOrTimeout(self, amount);
+        increfMalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout(self, amount);
     }
 } else extern struct {
-    payload: MalformedResponseOrNetworkErrorOrOtherOrTimeoutPayload,
-    tag: MalformedResponseOrNetworkErrorOrOtherOrTimeoutTag,
+    payload: MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeoutPayload,
+    tag: MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeoutTag,
     pub fn payload_other(self: *const @This()) RocStr {
         return self.payload.other;
     }
     /// Recursively decrement Roc-owned payloads.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
-        decrefMalformedResponseOrNetworkErrorOrOtherOrTimeout(self, roc_host);
+        decrefMalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout(self, roc_host);
     }
 
     /// Increment Roc-owned payloads.
     pub fn incref(self: @This(), amount: isize) void {
-        increfMalformedResponseOrNetworkErrorOrOtherOrTimeout(self, amount);
+        increfMalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout(self, amount);
     }
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(MalformedResponseOrNetworkErrorOrOtherOrTimeout) != 32) @compileError("MalformedResponseOrNetworkErrorOrOtherOrTimeout size mismatch");
-        if (@alignOf(MalformedResponseOrNetworkErrorOrOtherOrTimeout) != 8) @compileError("MalformedResponseOrNetworkErrorOrOtherOrTimeout alignment mismatch");
-        if (@offsetOf(MalformedResponseOrNetworkErrorOrOtherOrTimeout, "tag") != 24) @compileError("MalformedResponseOrNetworkErrorOrOtherOrTimeout tag offset mismatch");
+        if (@sizeOf(MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout) != 32) @compileError("MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout size mismatch");
+        if (@alignOf(MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout) != 8) @compileError("MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout alignment mismatch");
+        if (@offsetOf(MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout, "tag") != 24) @compileError("MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout tag offset mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(MalformedResponseOrNetworkErrorOrOtherOrTimeout) != 16) @compileError("MalformedResponseOrNetworkErrorOrOtherOrTimeout size mismatch");
-        if (@alignOf(MalformedResponseOrNetworkErrorOrOtherOrTimeout) != 4) @compileError("MalformedResponseOrNetworkErrorOrOtherOrTimeout alignment mismatch");
-        if (@offsetOf(MalformedResponseOrNetworkErrorOrOtherOrTimeout, "tag") != 12) @compileError("MalformedResponseOrNetworkErrorOrOtherOrTimeout tag offset mismatch");
+        if (@sizeOf(MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout) != 16) @compileError("MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout size mismatch");
+        if (@alignOf(MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout) != 4) @compileError("MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout alignment mismatch");
+        if (@offsetOf(MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout, "tag") != 12) @compileError("MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout tag offset mismatch");
     }
 }
 
@@ -8611,7 +8620,7 @@ pub const HostStdio_write_textResultTag = enum(u8) {
 
 /// Payload union for Try.
 pub const HostStdio_write_textResultPayload = extern union {
-    err: BufferFullOrTooLargeOrUnavailable,
+    err: BufferFullOrPermissionDeniedOrTooLargeOrUnavailable,
     ok: [0]u8,
 };
 
@@ -8619,8 +8628,8 @@ pub const HostStdio_write_textResultPayload = extern union {
 pub const HostStdio_write_textResult = if (@sizeOf(usize) == 4) extern struct {
     payload: [1]u8 align(1),
     tag: HostStdio_write_textResultTag,
-    pub fn payload_err(self: *const @This()) BufferFullOrTooLargeOrUnavailable {
-        const ptr: *const BufferFullOrTooLargeOrUnavailable = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_err(self: *const @This()) BufferFullOrPermissionDeniedOrTooLargeOrUnavailable {
+        const ptr: *const BufferFullOrPermissionDeniedOrTooLargeOrUnavailable = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     /// Recursively decrement Roc-owned payloads.
@@ -8635,7 +8644,7 @@ pub const HostStdio_write_textResult = if (@sizeOf(usize) == 4) extern struct {
 } else extern struct {
     payload: HostStdio_write_textResultPayload,
     tag: HostStdio_write_textResultTag,
-    pub fn payload_err(self: *const @This()) BufferFullOrTooLargeOrUnavailable {
+    pub fn payload_err(self: *const @This()) BufferFullOrPermissionDeniedOrTooLargeOrUnavailable {
         return self.payload.err;
     }
     /// Recursively decrement Roc-owned payloads.
@@ -8662,11 +8671,12 @@ comptime {
     }
 }
 
-/// Tag union: BufferFullOrTooLargeOrUnavailable
-pub const BufferFullOrTooLargeOrUnavailable = enum(u8) {
+/// Tag union: BufferFullOrPermissionDeniedOrTooLargeOrUnavailable
+pub const BufferFullOrPermissionDeniedOrTooLargeOrUnavailable = enum(u8) {
     buffer_full = 0,
-    too_large = 1,
-    unavailable = 2,
+    permission_denied = 1,
+    too_large = 2,
+    unavailable = 3,
     /// Recursively decrement Roc-owned payloads.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         _ = self;
@@ -8682,12 +8692,12 @@ pub const BufferFullOrTooLargeOrUnavailable = enum(u8) {
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(BufferFullOrTooLargeOrUnavailable) != 1) @compileError("BufferFullOrTooLargeOrUnavailable size mismatch");
-        if (@alignOf(BufferFullOrTooLargeOrUnavailable) != 1) @compileError("BufferFullOrTooLargeOrUnavailable alignment mismatch");
+        if (@sizeOf(BufferFullOrPermissionDeniedOrTooLargeOrUnavailable) != 1) @compileError("BufferFullOrPermissionDeniedOrTooLargeOrUnavailable size mismatch");
+        if (@alignOf(BufferFullOrPermissionDeniedOrTooLargeOrUnavailable) != 1) @compileError("BufferFullOrPermissionDeniedOrTooLargeOrUnavailable alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(BufferFullOrTooLargeOrUnavailable) != 1) @compileError("BufferFullOrTooLargeOrUnavailable size mismatch");
-        if (@alignOf(BufferFullOrTooLargeOrUnavailable) != 1) @compileError("BufferFullOrTooLargeOrUnavailable alignment mismatch");
+        if (@sizeOf(BufferFullOrPermissionDeniedOrTooLargeOrUnavailable) != 1) @compileError("BufferFullOrPermissionDeniedOrTooLargeOrUnavailable size mismatch");
+        if (@alignOf(BufferFullOrPermissionDeniedOrTooLargeOrUnavailable) != 1) @compileError("BufferFullOrPermissionDeniedOrTooLargeOrUnavailable alignment mismatch");
     }
 }
 
@@ -8985,7 +8995,7 @@ pub const HostApp_read_envResultTag = enum(u8) {
 
 /// Payload union for Try.
 pub const HostApp_read_envResultPayload = extern union {
-    err: [0]u8,
+    err: NotFoundOrPermissionDenied,
     ok: RocStr,
 };
 
@@ -8993,6 +9003,10 @@ pub const HostApp_read_envResultPayload = extern union {
 pub const HostApp_read_envResult = if (@sizeOf(usize) == 4) extern struct {
     payload: [12]u8 align(4),
     tag: HostApp_read_envResultTag,
+    pub fn payload_err(self: *const @This()) NotFoundOrPermissionDenied {
+        const ptr: *const NotFoundOrPermissionDenied = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
     pub fn payload_ok(self: *const @This()) RocStr {
         const ptr: *const RocStr = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
@@ -9009,6 +9023,9 @@ pub const HostApp_read_envResult = if (@sizeOf(usize) == 4) extern struct {
 } else extern struct {
     payload: HostApp_read_envResultPayload,
     tag: HostApp_read_envResultTag,
+    pub fn payload_err(self: *const @This()) NotFoundOrPermissionDenied {
+        return self.payload.err;
+    }
     pub fn payload_ok(self: *const @This()) RocStr {
         return self.payload.ok;
     }
@@ -9036,76 +9053,10 @@ comptime {
     }
 }
 
-/// Tag discriminant for Try.
-pub const HostApp_read_textResultTag = enum(u8) {
-    Err = 0,
-    Ok = 1,
-};
-
-/// Payload union for Try.
-pub const HostApp_read_textResultPayload = extern union {
-    err: NotFoundOrReadFailed,
-    ok: RocStr,
-};
-
-/// Tag union: Try
-pub const HostApp_read_textResult = if (@sizeOf(usize) == 4) extern struct {
-    payload: [12]u8 align(4),
-    tag: HostApp_read_textResultTag,
-    pub fn payload_err(self: *const @This()) NotFoundOrReadFailed {
-        const ptr: *const NotFoundOrReadFailed = @ptrCast(@alignCast(&self.payload));
-        return ptr.*;
-    }
-    pub fn payload_ok(self: *const @This()) RocStr {
-        const ptr: *const RocStr = @ptrCast(@alignCast(&self.payload));
-        return ptr.*;
-    }
-    /// Recursively decrement Roc-owned payloads.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        decrefHostApp_read_textResult(self, roc_host);
-    }
-
-    /// Increment Roc-owned payloads.
-    pub fn incref(self: @This(), amount: isize) void {
-        increfHostApp_read_textResult(self, amount);
-    }
-} else extern struct {
-    payload: HostApp_read_textResultPayload,
-    tag: HostApp_read_textResultTag,
-    pub fn payload_err(self: *const @This()) NotFoundOrReadFailed {
-        return self.payload.err;
-    }
-    pub fn payload_ok(self: *const @This()) RocStr {
-        return self.payload.ok;
-    }
-    /// Recursively decrement Roc-owned payloads.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        decrefHostApp_read_textResult(self, roc_host);
-    }
-
-    /// Increment Roc-owned payloads.
-    pub fn incref(self: @This(), amount: isize) void {
-        increfHostApp_read_textResult(self, amount);
-    }
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostApp_read_textResult) != 32) @compileError("HostApp_read_textResult size mismatch");
-        if (@alignOf(HostApp_read_textResult) != 8) @compileError("HostApp_read_textResult alignment mismatch");
-        if (@offsetOf(HostApp_read_textResult, "tag") != 24) @compileError("HostApp_read_textResult tag offset mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostApp_read_textResult) != 16) @compileError("HostApp_read_textResult size mismatch");
-        if (@alignOf(HostApp_read_textResult) != 4) @compileError("HostApp_read_textResult alignment mismatch");
-        if (@offsetOf(HostApp_read_textResult, "tag") != 12) @compileError("HostApp_read_textResult tag offset mismatch");
-    }
-}
-
-/// Tag union: NotFoundOrReadFailed
-pub const NotFoundOrReadFailed = enum(u8) {
+/// Tag union: NotFoundOrPermissionDenied
+pub const NotFoundOrPermissionDenied = enum(u8) {
     not_found = 0,
-    read_failed = 1,
+    permission_denied = 1,
     /// Recursively decrement Roc-owned payloads.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         _ = self;
@@ -9121,12 +9072,12 @@ pub const NotFoundOrReadFailed = enum(u8) {
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(NotFoundOrReadFailed) != 1) @compileError("NotFoundOrReadFailed size mismatch");
-        if (@alignOf(NotFoundOrReadFailed) != 1) @compileError("NotFoundOrReadFailed alignment mismatch");
+        if (@sizeOf(NotFoundOrPermissionDenied) != 1) @compileError("NotFoundOrPermissionDenied size mismatch");
+        if (@alignOf(NotFoundOrPermissionDenied) != 1) @compileError("NotFoundOrPermissionDenied alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(NotFoundOrReadFailed) != 1) @compileError("NotFoundOrReadFailed size mismatch");
-        if (@alignOf(NotFoundOrReadFailed) != 1) @compileError("NotFoundOrReadFailed alignment mismatch");
+        if (@sizeOf(NotFoundOrPermissionDenied) != 1) @compileError("NotFoundOrPermissionDenied size mismatch");
+        if (@alignOf(NotFoundOrPermissionDenied) != 1) @compileError("NotFoundOrPermissionDenied alignment mismatch");
     }
 }
 
@@ -9138,7 +9089,7 @@ pub const HostWindow_read_clipboardResultTag = enum(u8) {
 
 /// Payload union for Try.
 pub const HostWindow_read_clipboardResultPayload = extern union {
-    err: BusyOrTooLargeOrUnavailable,
+    err: BusyOrPermissionDeniedOrTooLargeOrUnavailable,
     ok: RocStr,
 };
 
@@ -9146,8 +9097,8 @@ pub const HostWindow_read_clipboardResultPayload = extern union {
 pub const HostWindow_read_clipboardResult = if (@sizeOf(usize) == 4) extern struct {
     payload: [12]u8 align(4),
     tag: HostWindow_read_clipboardResultTag,
-    pub fn payload_err(self: *const @This()) BusyOrTooLargeOrUnavailable {
-        const ptr: *const BusyOrTooLargeOrUnavailable = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_err(self: *const @This()) BusyOrPermissionDeniedOrTooLargeOrUnavailable {
+        const ptr: *const BusyOrPermissionDeniedOrTooLargeOrUnavailable = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     pub fn payload_ok(self: *const @This()) RocStr {
@@ -9166,7 +9117,7 @@ pub const HostWindow_read_clipboardResult = if (@sizeOf(usize) == 4) extern stru
 } else extern struct {
     payload: HostWindow_read_clipboardResultPayload,
     tag: HostWindow_read_clipboardResultTag,
-    pub fn payload_err(self: *const @This()) BusyOrTooLargeOrUnavailable {
+    pub fn payload_err(self: *const @This()) BusyOrPermissionDeniedOrTooLargeOrUnavailable {
         return self.payload.err;
     }
     pub fn payload_ok(self: *const @This()) RocStr {
@@ -9196,11 +9147,12 @@ comptime {
     }
 }
 
-/// Tag union: BusyOrTooLargeOrUnavailable
-pub const BusyOrTooLargeOrUnavailable = enum(u8) {
+/// Tag union: BusyOrPermissionDeniedOrTooLargeOrUnavailable
+pub const BusyOrPermissionDeniedOrTooLargeOrUnavailable = enum(u8) {
     busy = 0,
-    too_large = 1,
-    unavailable = 2,
+    permission_denied = 1,
+    too_large = 2,
+    unavailable = 3,
     /// Recursively decrement Roc-owned payloads.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         _ = self;
@@ -9216,12 +9168,40 @@ pub const BusyOrTooLargeOrUnavailable = enum(u8) {
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(BusyOrTooLargeOrUnavailable) != 1) @compileError("BusyOrTooLargeOrUnavailable size mismatch");
-        if (@alignOf(BusyOrTooLargeOrUnavailable) != 1) @compileError("BusyOrTooLargeOrUnavailable alignment mismatch");
+        if (@sizeOf(BusyOrPermissionDeniedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrPermissionDeniedOrTooLargeOrUnavailable size mismatch");
+        if (@alignOf(BusyOrPermissionDeniedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrPermissionDeniedOrTooLargeOrUnavailable alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(BusyOrTooLargeOrUnavailable) != 1) @compileError("BusyOrTooLargeOrUnavailable size mismatch");
-        if (@alignOf(BusyOrTooLargeOrUnavailable) != 1) @compileError("BusyOrTooLargeOrUnavailable alignment mismatch");
+        if (@sizeOf(BusyOrPermissionDeniedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrPermissionDeniedOrTooLargeOrUnavailable size mismatch");
+        if (@alignOf(BusyOrPermissionDeniedOrTooLargeOrUnavailable) != 1) @compileError("BusyOrPermissionDeniedOrTooLargeOrUnavailable alignment mismatch");
+    }
+}
+
+/// Tag union: Try
+pub const HostWindow_set_clipboard_textResult = enum(u8) {
+    err = 0,
+    ok = 1,
+    /// Recursively decrement Roc-owned payloads.
+    pub fn decref(self: @This(), roc_host: *RocHost) void {
+        _ = self;
+        _ = roc_host;
+    }
+
+    /// Increment Roc-owned payloads.
+    pub fn incref(self: @This(), amount: isize) void {
+        _ = self;
+        _ = amount;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(HostWindow_set_clipboard_textResult) != 1) @compileError("HostWindow_set_clipboard_textResult size mismatch");
+        if (@alignOf(HostWindow_set_clipboard_textResult) != 1) @compileError("HostWindow_set_clipboard_textResult alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(HostWindow_set_clipboard_textResult) != 1) @compileError("HostWindow_set_clipboard_textResult size mismatch");
+        if (@alignOf(HostWindow_set_clipboard_textResult) != 1) @compileError("HostWindow_set_clipboard_textResult alignment mismatch");
     }
 }
 
@@ -9261,7 +9241,7 @@ pub const HostTilemap_load_tmxResultTag = enum(u8) {
 
 /// Payload union for Try.
 pub const HostTilemap_load_tmxResultPayload = extern union {
-    err: NotFoundOrParseFailedOrReadFailedOrUnsupported,
+    err: NotFoundOrParseFailedOrPermissionDeniedOrReadFailedOrUnsupported,
     ok: __AnonStruct_831cf812524287ed,
 };
 
@@ -9269,8 +9249,8 @@ pub const HostTilemap_load_tmxResultPayload = extern union {
 pub const HostTilemap_load_tmxResult = if (@sizeOf(usize) == 4) extern struct {
     payload: [128]u8 align(8),
     tag: HostTilemap_load_tmxResultTag,
-    pub fn payload_err(self: *const @This()) NotFoundOrParseFailedOrReadFailedOrUnsupported {
-        const ptr: *const NotFoundOrParseFailedOrReadFailedOrUnsupported = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_err(self: *const @This()) NotFoundOrParseFailedOrPermissionDeniedOrReadFailedOrUnsupported {
+        const ptr: *const NotFoundOrParseFailedOrPermissionDeniedOrReadFailedOrUnsupported = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     pub fn payload_ok(self: *const @This()) __AnonStruct_831cf812524287ed {
@@ -9289,7 +9269,7 @@ pub const HostTilemap_load_tmxResult = if (@sizeOf(usize) == 4) extern struct {
 } else extern struct {
     payload: HostTilemap_load_tmxResultPayload,
     tag: HostTilemap_load_tmxResultTag,
-    pub fn payload_err(self: *const @This()) NotFoundOrParseFailedOrReadFailedOrUnsupported {
+    pub fn payload_err(self: *const @This()) NotFoundOrParseFailedOrPermissionDeniedOrReadFailedOrUnsupported {
         return self.payload.err;
     }
     pub fn payload_ok(self: *const @This()) __AnonStruct_831cf812524287ed {
@@ -9319,12 +9299,13 @@ comptime {
     }
 }
 
-/// Tag union: NotFoundOrParseFailedOrReadFailedOrUnsupported
-pub const NotFoundOrParseFailedOrReadFailedOrUnsupported = enum(u8) {
+/// Tag union: NotFoundOrParseFailedOrPermissionDeniedOrReadFailedOrUnsupported
+pub const NotFoundOrParseFailedOrPermissionDeniedOrReadFailedOrUnsupported = enum(u8) {
     not_found = 0,
     parse_failed = 1,
-    read_failed = 2,
-    unsupported = 3,
+    permission_denied = 2,
+    read_failed = 3,
+    unsupported = 4,
     /// Recursively decrement Roc-owned payloads.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         _ = self;
@@ -9340,12 +9321,12 @@ pub const NotFoundOrParseFailedOrReadFailedOrUnsupported = enum(u8) {
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(NotFoundOrParseFailedOrReadFailedOrUnsupported) != 1) @compileError("NotFoundOrParseFailedOrReadFailedOrUnsupported size mismatch");
-        if (@alignOf(NotFoundOrParseFailedOrReadFailedOrUnsupported) != 1) @compileError("NotFoundOrParseFailedOrReadFailedOrUnsupported alignment mismatch");
+        if (@sizeOf(NotFoundOrParseFailedOrPermissionDeniedOrReadFailedOrUnsupported) != 1) @compileError("NotFoundOrParseFailedOrPermissionDeniedOrReadFailedOrUnsupported size mismatch");
+        if (@alignOf(NotFoundOrParseFailedOrPermissionDeniedOrReadFailedOrUnsupported) != 1) @compileError("NotFoundOrParseFailedOrPermissionDeniedOrReadFailedOrUnsupported alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(NotFoundOrParseFailedOrReadFailedOrUnsupported) != 1) @compileError("NotFoundOrParseFailedOrReadFailedOrUnsupported size mismatch");
-        if (@alignOf(NotFoundOrParseFailedOrReadFailedOrUnsupported) != 1) @compileError("NotFoundOrParseFailedOrReadFailedOrUnsupported alignment mismatch");
+        if (@sizeOf(NotFoundOrParseFailedOrPermissionDeniedOrReadFailedOrUnsupported) != 1) @compileError("NotFoundOrParseFailedOrPermissionDeniedOrReadFailedOrUnsupported size mismatch");
+        if (@alignOf(NotFoundOrParseFailedOrPermissionDeniedOrReadFailedOrUnsupported) != 1) @compileError("NotFoundOrParseFailedOrPermissionDeniedOrReadFailedOrUnsupported alignment mismatch");
     }
 }
 
@@ -9357,7 +9338,7 @@ pub const HostSqlite_openResultTag = enum(u8) {
 
 /// Payload union for Try.
 pub const HostSqlite_openResultPayload = extern union {
-    err: SqliteErrOrTooManyConnections,
+    err: PermissionDeniedOrSqliteErrOrTooManyConnections,
     ok: *u64,
 };
 
@@ -9365,8 +9346,8 @@ pub const HostSqlite_openResultPayload = extern union {
 pub const HostSqlite_openResult = if (@sizeOf(usize) == 4) extern struct {
     payload: [32]u8 align(8),
     tag: HostSqlite_openResultTag,
-    pub fn payload_err(self: *const @This()) SqliteErrOrTooManyConnections {
-        const ptr: *const SqliteErrOrTooManyConnections = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_err(self: *const @This()) PermissionDeniedOrSqliteErrOrTooManyConnections {
+        const ptr: *const PermissionDeniedOrSqliteErrOrTooManyConnections = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     pub fn payload_ok(self: *const @This()) *u64 {
@@ -9385,7 +9366,7 @@ pub const HostSqlite_openResult = if (@sizeOf(usize) == 4) extern struct {
 } else extern struct {
     payload: HostSqlite_openResultPayload,
     tag: HostSqlite_openResultTag,
-    pub fn payload_err(self: *const @This()) SqliteErrOrTooManyConnections {
+    pub fn payload_err(self: *const @This()) PermissionDeniedOrSqliteErrOrTooManyConnections {
         return self.payload.err;
     }
     pub fn payload_ok(self: *const @This()) *u64 {
@@ -9415,62 +9396,64 @@ comptime {
     }
 }
 
-/// Tag discriminant for SqliteErrOrTooManyConnections.
-pub const SqliteErrOrTooManyConnectionsTag = enum(u8) {
-    SqliteErr = 0,
-    TooManyConnections = 1,
+/// Tag discriminant for PermissionDeniedOrSqliteErrOrTooManyConnections.
+pub const PermissionDeniedOrSqliteErrOrTooManyConnectionsTag = enum(u8) {
+    PermissionDenied = 0,
+    SqliteErr = 1,
+    TooManyConnections = 2,
 };
 
-/// Payload union for SqliteErrOrTooManyConnections.
-pub const SqliteErrOrTooManyConnectionsPayload = extern union {
+/// Payload union for PermissionDeniedOrSqliteErrOrTooManyConnections.
+pub const PermissionDeniedOrSqliteErrOrTooManyConnectionsPayload = extern union {
+    permission_denied: [0]u8,
     sqlite_err: __AnonStruct_22cf486058afc711,
     too_many_connections: [0]u8,
 };
 
-/// Tag union: SqliteErrOrTooManyConnections
-pub const SqliteErrOrTooManyConnections = if (@sizeOf(usize) == 4) extern struct {
+/// Tag union: PermissionDeniedOrSqliteErrOrTooManyConnections
+pub const PermissionDeniedOrSqliteErrOrTooManyConnections = if (@sizeOf(usize) == 4) extern struct {
     payload: [24]u8 align(8),
-    tag: SqliteErrOrTooManyConnectionsTag,
+    tag: PermissionDeniedOrSqliteErrOrTooManyConnectionsTag,
     pub fn payload_sqlite_err(self: *const @This()) __AnonStruct_22cf486058afc711 {
         const ptr: *const __AnonStruct_22cf486058afc711 = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     /// Recursively decrement Roc-owned payloads.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
-        decrefSqliteErrOrTooManyConnections(self, roc_host);
+        decrefPermissionDeniedOrSqliteErrOrTooManyConnections(self, roc_host);
     }
 
     /// Increment Roc-owned payloads.
     pub fn incref(self: @This(), amount: isize) void {
-        increfSqliteErrOrTooManyConnections(self, amount);
+        increfPermissionDeniedOrSqliteErrOrTooManyConnections(self, amount);
     }
 } else extern struct {
-    payload: SqliteErrOrTooManyConnectionsPayload,
-    tag: SqliteErrOrTooManyConnectionsTag,
+    payload: PermissionDeniedOrSqliteErrOrTooManyConnectionsPayload,
+    tag: PermissionDeniedOrSqliteErrOrTooManyConnectionsTag,
     pub fn payload_sqlite_err(self: *const @This()) __AnonStruct_22cf486058afc711 {
         return self.payload.sqlite_err;
     }
     /// Recursively decrement Roc-owned payloads.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
-        decrefSqliteErrOrTooManyConnections(self, roc_host);
+        decrefPermissionDeniedOrSqliteErrOrTooManyConnections(self, roc_host);
     }
 
     /// Increment Roc-owned payloads.
     pub fn incref(self: @This(), amount: isize) void {
-        increfSqliteErrOrTooManyConnections(self, amount);
+        increfPermissionDeniedOrSqliteErrOrTooManyConnections(self, amount);
     }
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(SqliteErrOrTooManyConnections) != 40) @compileError("SqliteErrOrTooManyConnections size mismatch");
-        if (@alignOf(SqliteErrOrTooManyConnections) != 8) @compileError("SqliteErrOrTooManyConnections alignment mismatch");
-        if (@offsetOf(SqliteErrOrTooManyConnections, "tag") != 32) @compileError("SqliteErrOrTooManyConnections tag offset mismatch");
+        if (@sizeOf(PermissionDeniedOrSqliteErrOrTooManyConnections) != 40) @compileError("PermissionDeniedOrSqliteErrOrTooManyConnections size mismatch");
+        if (@alignOf(PermissionDeniedOrSqliteErrOrTooManyConnections) != 8) @compileError("PermissionDeniedOrSqliteErrOrTooManyConnections alignment mismatch");
+        if (@offsetOf(PermissionDeniedOrSqliteErrOrTooManyConnections, "tag") != 32) @compileError("PermissionDeniedOrSqliteErrOrTooManyConnections tag offset mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(SqliteErrOrTooManyConnections) != 32) @compileError("SqliteErrOrTooManyConnections size mismatch");
-        if (@alignOf(SqliteErrOrTooManyConnections) != 8) @compileError("SqliteErrOrTooManyConnections alignment mismatch");
-        if (@offsetOf(SqliteErrOrTooManyConnections, "tag") != 24) @compileError("SqliteErrOrTooManyConnections tag offset mismatch");
+        if (@sizeOf(PermissionDeniedOrSqliteErrOrTooManyConnections) != 32) @compileError("PermissionDeniedOrSqliteErrOrTooManyConnections size mismatch");
+        if (@alignOf(PermissionDeniedOrSqliteErrOrTooManyConnections) != 8) @compileError("PermissionDeniedOrSqliteErrOrTooManyConnections alignment mismatch");
+        if (@offsetOf(PermissionDeniedOrSqliteErrOrTooManyConnections, "tag") != 24) @compileError("PermissionDeniedOrSqliteErrOrTooManyConnections tag offset mismatch");
     }
 }
 
@@ -9882,7 +9865,7 @@ pub const HostCapture_start_recordingResultTag = enum(u8) {
 
 /// Payload union for Try.
 pub const HostCapture_start_recordingResultPayload = extern union {
-    err: AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed,
+    err: AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrUnsupportedFormatOrWriteFailed,
     ok: [0]u8,
 };
 
@@ -9890,8 +9873,8 @@ pub const HostCapture_start_recordingResultPayload = extern union {
 pub const HostCapture_start_recordingResult = if (@sizeOf(usize) == 4) extern struct {
     payload: [1]u8 align(1),
     tag: HostCapture_start_recordingResultTag,
-    pub fn payload_err(self: *const @This()) AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed {
-        const ptr: *const AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_err(self: *const @This()) AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrUnsupportedFormatOrWriteFailed {
+        const ptr: *const AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrUnsupportedFormatOrWriteFailed = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     /// Recursively decrement Roc-owned payloads.
@@ -9906,7 +9889,7 @@ pub const HostCapture_start_recordingResult = if (@sizeOf(usize) == 4) extern st
 } else extern struct {
     payload: HostCapture_start_recordingResultPayload,
     tag: HostCapture_start_recordingResultTag,
-    pub fn payload_err(self: *const @This()) AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed {
+    pub fn payload_err(self: *const @This()) AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrUnsupportedFormatOrWriteFailed {
         return self.payload.err;
     }
     /// Recursively decrement Roc-owned payloads.
@@ -9933,15 +9916,16 @@ comptime {
     }
 }
 
-/// Tag union: AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed
-pub const AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed = enum(u8) {
+/// Tag union: AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrUnsupportedFormatOrWriteFailed
+pub const AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrUnsupportedFormatOrWriteFailed = enum(u8) {
     already_recording = 0,
     busy = 1,
     path_escapes_output_dir = 2,
     path_invalid = 3,
-    unavailable = 4,
-    unsupported_format = 5,
-    write_failed = 6,
+    permission_denied = 4,
+    unavailable = 5,
+    unsupported_format = 6,
+    write_failed = 7,
     /// Recursively decrement Roc-owned payloads.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         _ = self;
@@ -9957,12 +9941,12 @@ pub const AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailable
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed) != 1) @compileError("AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed size mismatch");
-        if (@alignOf(AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed) != 1) @compileError("AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed alignment mismatch");
+        if (@sizeOf(AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrUnsupportedFormatOrWriteFailed) != 1) @compileError("AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrUnsupportedFormatOrWriteFailed size mismatch");
+        if (@alignOf(AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrUnsupportedFormatOrWriteFailed) != 1) @compileError("AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrUnsupportedFormatOrWriteFailed alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed) != 1) @compileError("AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed size mismatch");
-        if (@alignOf(AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed) != 1) @compileError("AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed alignment mismatch");
+        if (@sizeOf(AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrUnsupportedFormatOrWriteFailed) != 1) @compileError("AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrUnsupportedFormatOrWriteFailed size mismatch");
+        if (@alignOf(AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrUnsupportedFormatOrWriteFailed) != 1) @compileError("AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrUnsupportedFormatOrWriteFailed alignment mismatch");
     }
 }
 
@@ -9974,7 +9958,7 @@ pub const HostCapture_stop_recordingResultTag = enum(u8) {
 
 /// Payload union for Try.
 pub const HostCapture_stop_recordingResultPayload = extern union {
-    err: BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable,
+    err: BudgetExceededOrBusyOrNotRecordingOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailable,
     ok: __AnonStruct_5c978c17ba0c990a,
 };
 
@@ -9982,8 +9966,8 @@ pub const HostCapture_stop_recordingResultPayload = extern union {
 pub const HostCapture_stop_recordingResult = if (@sizeOf(usize) == 4) extern struct {
     payload: [16]u8 align(8),
     tag: HostCapture_stop_recordingResultTag,
-    pub fn payload_err(self: *const @This()) BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable {
-        const ptr: *const BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_err(self: *const @This()) BudgetExceededOrBusyOrNotRecordingOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailable {
+        const ptr: *const BudgetExceededOrBusyOrNotRecordingOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailable = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     pub fn payload_ok(self: *const @This()) __AnonStruct_5c978c17ba0c990a {
@@ -10002,7 +9986,7 @@ pub const HostCapture_stop_recordingResult = if (@sizeOf(usize) == 4) extern str
 } else extern struct {
     payload: HostCapture_stop_recordingResultPayload,
     tag: HostCapture_stop_recordingResultTag,
-    pub fn payload_err(self: *const @This()) BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable {
+    pub fn payload_err(self: *const @This()) BudgetExceededOrBusyOrNotRecordingOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailable {
         return self.payload.err;
     }
     pub fn payload_ok(self: *const @This()) __AnonStruct_5c978c17ba0c990a {
@@ -10032,14 +10016,15 @@ comptime {
     }
 }
 
-/// Tag union: BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable
-pub const BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable = enum(u8) {
+/// Tag union: BudgetExceededOrBusyOrNotRecordingOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailable
+pub const BudgetExceededOrBusyOrNotRecordingOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailable = enum(u8) {
     budget_exceeded = 0,
     busy = 1,
     not_recording = 2,
-    readback_failed = 3,
-    target_unavailable = 4,
-    unavailable = 5,
+    permission_denied = 3,
+    readback_failed = 4,
+    target_unavailable = 5,
+    unavailable = 6,
     /// Recursively decrement Roc-owned payloads.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         _ = self;
@@ -10055,12 +10040,12 @@ pub const BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableO
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable) != 1) @compileError("BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable size mismatch");
-        if (@alignOf(BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable) != 1) @compileError("BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable alignment mismatch");
+        if (@sizeOf(BudgetExceededOrBusyOrNotRecordingOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailable) != 1) @compileError("BudgetExceededOrBusyOrNotRecordingOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailable size mismatch");
+        if (@alignOf(BudgetExceededOrBusyOrNotRecordingOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailable) != 1) @compileError("BudgetExceededOrBusyOrNotRecordingOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailable alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable) != 1) @compileError("BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable size mismatch");
-        if (@alignOf(BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable) != 1) @compileError("BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable alignment mismatch");
+        if (@sizeOf(BudgetExceededOrBusyOrNotRecordingOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailable) != 1) @compileError("BudgetExceededOrBusyOrNotRecordingOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailable size mismatch");
+        if (@alignOf(BudgetExceededOrBusyOrNotRecordingOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailable) != 1) @compileError("BudgetExceededOrBusyOrNotRecordingOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailable alignment mismatch");
     }
 }
 
@@ -10072,7 +10057,7 @@ pub const HostCapture_screenshotResultTag = enum(u8) {
 
 /// Payload union for Try.
 pub const HostCapture_screenshotResultPayload = extern union {
-    err: AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed,
+    err: AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrWriteFailed,
     ok: [0]u8,
 };
 
@@ -10080,8 +10065,8 @@ pub const HostCapture_screenshotResultPayload = extern union {
 pub const HostCapture_screenshotResult = if (@sizeOf(usize) == 4) extern struct {
     payload: [1]u8 align(1),
     tag: HostCapture_screenshotResultTag,
-    pub fn payload_err(self: *const @This()) AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed {
-        const ptr: *const AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_err(self: *const @This()) AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrWriteFailed {
+        const ptr: *const AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrWriteFailed = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     /// Recursively decrement Roc-owned payloads.
@@ -10096,7 +10081,7 @@ pub const HostCapture_screenshotResult = if (@sizeOf(usize) == 4) extern struct 
 } else extern struct {
     payload: HostCapture_screenshotResultPayload,
     tag: HostCapture_screenshotResultTag,
-    pub fn payload_err(self: *const @This()) AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed {
+    pub fn payload_err(self: *const @This()) AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrWriteFailed {
         return self.payload.err;
     }
     /// Recursively decrement Roc-owned payloads.
@@ -10123,14 +10108,15 @@ comptime {
     }
 }
 
-/// Tag union: AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed
-pub const AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed = enum(u8) {
+/// Tag union: AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrWriteFailed
+pub const AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrWriteFailed = enum(u8) {
     already_pending = 0,
     busy = 1,
     path_escapes_output_dir = 2,
     path_invalid = 3,
-    unavailable = 4,
-    write_failed = 5,
+    permission_denied = 4,
+    unavailable = 5,
+    write_failed = 6,
     /// Recursively decrement Roc-owned payloads.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         _ = self;
@@ -10146,12 +10132,12 @@ pub const AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOr
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed) != 1) @compileError("AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed size mismatch");
-        if (@alignOf(AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed) != 1) @compileError("AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed alignment mismatch");
+        if (@sizeOf(AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrWriteFailed) != 1) @compileError("AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrWriteFailed size mismatch");
+        if (@alignOf(AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrWriteFailed) != 1) @compileError("AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrWriteFailed alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed) != 1) @compileError("AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed size mismatch");
-        if (@alignOf(AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed) != 1) @compileError("AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed alignment mismatch");
+        if (@sizeOf(AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrWriteFailed) != 1) @compileError("AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrWriteFailed size mismatch");
+        if (@alignOf(AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrWriteFailed) != 1) @compileError("AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrWriteFailed alignment mismatch");
     }
 }
 
@@ -10163,7 +10149,7 @@ pub const HostCapture_screenshot_textureResultTag = enum(u8) {
 
 /// Payload union for Try.
 pub const HostCapture_screenshot_textureResultPayload = extern union {
-    err: BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed,
+    err: BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed,
     ok: [0]u8,
 };
 
@@ -10171,8 +10157,8 @@ pub const HostCapture_screenshot_textureResultPayload = extern union {
 pub const HostCapture_screenshot_textureResult = if (@sizeOf(usize) == 4) extern struct {
     payload: [1]u8 align(1),
     tag: HostCapture_screenshot_textureResultTag,
-    pub fn payload_err(self: *const @This()) BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed {
-        const ptr: *const BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_err(self: *const @This()) BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed {
+        const ptr: *const BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     /// Recursively decrement Roc-owned payloads.
@@ -10187,7 +10173,7 @@ pub const HostCapture_screenshot_textureResult = if (@sizeOf(usize) == 4) extern
 } else extern struct {
     payload: HostCapture_screenshot_textureResultPayload,
     tag: HostCapture_screenshot_textureResultTag,
-    pub fn payload_err(self: *const @This()) BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed {
+    pub fn payload_err(self: *const @This()) BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed {
         return self.payload.err;
     }
     /// Recursively decrement Roc-owned payloads.
@@ -10214,17 +10200,18 @@ comptime {
     }
 }
 
-/// Tag union: BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed
-pub const BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed = enum(u8) {
+/// Tag union: BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed
+pub const BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed = enum(u8) {
     budget_exceeded = 0,
     busy = 1,
     out_of_memory = 2,
     path_escapes_output_dir = 3,
     path_invalid = 4,
-    readback_failed = 5,
-    target_unavailable = 6,
-    unavailable = 7,
-    write_failed = 8,
+    permission_denied = 5,
+    readback_failed = 6,
+    target_unavailable = 7,
+    unavailable = 8,
+    write_failed = 9,
     /// Recursively decrement Roc-owned payloads.
     pub fn decref(self: @This(), roc_host: *RocHost) void {
         _ = self;
@@ -10240,12 +10227,12 @@ pub const BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOr
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed) != 1) @compileError("BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed size mismatch");
-        if (@alignOf(BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed) != 1) @compileError("BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed alignment mismatch");
+        if (@sizeOf(BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed) != 1) @compileError("BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed size mismatch");
+        if (@alignOf(BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed) != 1) @compileError("BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed) != 1) @compileError("BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed size mismatch");
-        if (@alignOf(BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed) != 1) @compileError("BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed alignment mismatch");
+        if (@sizeOf(BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed) != 1) @compileError("BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed size mismatch");
+        if (@alignOf(BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed) != 1) @compileError("BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed alignment mismatch");
     }
 }
 
@@ -10695,68 +10682,12 @@ comptime {
 }
 
 /// Arguments for Host.store_open!
-/// Roc signature: { asset_set : Str, content_hash : Str, content_hash_mode : U8, content_version : U32, location_kind : U8, manifest_required : Bool, root : Str, schema : U32 } => Try(Resource.Handle([StoreResource]), [AssetSetMismatch, ContentHashMismatch, ContentVersionMismatch, InvalidExpectedContentHash, InvalidRootPath, ManifestMalformed, ManifestMissing, ManifestUnreadable, ResourceLimit, RootNotDirectory, RootNotFound, RootUnreadable, SchemaMismatch])
+/// Roc signature: Resource.Authority, { asset_set : Str, content_hash : Str, content_hash_mode : U8, content_version : U32, location_kind : U8, manifest_required : Bool, root : Str, schema : U32 } => Try(Resource.Handle([StoreResource]), [AssetSetMismatch, ContentHashMismatch, ContentVersionMismatch, InvalidExpectedContentHash, InvalidRootPath, ManifestMalformed, ManifestMissing, ManifestUnreadable, PermissionDenied, ResourceLimit, RootNotDirectory, RootNotFound, RootUnreadable, SchemaMismatch])
 /// Refcounted fields are owned by the hosted function.
-pub const HostStore_openArgs = if (@sizeOf(usize) == 4) extern struct {
-    asset_set: RocStr,
-    content_hash: RocStr,
-    root: RocStr,
-    content_version: u32,
-    schema: u32,
-    content_hash_mode: u8,
-    location_kind: u8,
-    manifest_required: bool,
-    /// Recursively decrement Roc-owned fields.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        const value = self;
-        value.asset_set.decref(roc_host);
-        value.content_hash.decref(roc_host);
-        value.root.decref(roc_host);
-    }
-
-    /// Increment Roc-owned fields.
-    pub fn incref(self: @This(), amount: isize) void {
-        const value = self;
-        value.asset_set.incref(amount);
-        value.content_hash.incref(amount);
-        value.root.incref(amount);
-    }
-} else extern struct {
-    asset_set: RocStr,
-    content_hash: RocStr,
-    root: RocStr,
-    content_version: u32,
-    schema: u32,
-    content_hash_mode: u8,
-    location_kind: u8,
-    manifest_required: bool,
-    /// Recursively decrement Roc-owned fields.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        const value = self;
-        value.asset_set.decref(roc_host);
-        value.content_hash.decref(roc_host);
-        value.root.decref(roc_host);
-    }
-
-    /// Increment Roc-owned fields.
-    pub fn incref(self: @This(), amount: isize) void {
-        const value = self;
-        value.asset_set.incref(amount);
-        value.content_hash.incref(amount);
-        value.root.incref(amount);
-    }
+pub const HostStore_openArgs = extern struct {
+    arg0: u64,
+    arg1: __AnonStruct_8f4b2816fd84fce2,
 };
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostStore_openArgs) != 88) @compileError("HostStore_openArgs size mismatch");
-        if (@alignOf(HostStore_openArgs) != 8) @compileError("HostStore_openArgs alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostStore_openArgs) != 48) @compileError("HostStore_openArgs size mismatch");
-        if (@alignOf(HostStore_openArgs) != 4) @compileError("HostStore_openArgs alignment mismatch");
-    }
-}
 
 /// Arguments for Host.texture_load_store!
 /// Roc signature: { path : Str, store : Resource.Handle([StoreResource]) } => Try(Texture, [NotFound, PathInvalid, ReadFailed, ResourceLimit, TextureLoadFailed])
@@ -11183,17 +11114,19 @@ comptime {
 }
 
 /// Arguments for Host.audio_load_sound!
-/// Roc signature: Str => Try(Resource.Handle([SoundResource]), [ResourceLimit, SoundLoadFailed])
+/// Roc signature: Resource.Authority, Str => Try(Resource.Handle([SoundResource]), [PermissionDenied, ResourceLimit, SoundLoadFailed])
 /// Refcounted fields are owned by the hosted function.
 pub const HostAudio_load_soundArgs = extern struct {
-    arg0: RocStr,
+    arg0: u64,
+    arg1: RocStr,
 };
 
 /// Arguments for Host.audio_load_music!
-/// Roc signature: Str => Try(Resource.Handle([MusicResource]), [MusicLoadFailed, ResourceLimit])
+/// Roc signature: Resource.Authority, Str => Try(Resource.Handle([MusicResource]), [MusicLoadFailed, PermissionDenied, ResourceLimit])
 /// Refcounted fields are owned by the hosted function.
 pub const HostAudio_load_musicArgs = extern struct {
-    arg0: RocStr,
+    arg0: u64,
+    arg1: RocStr,
 };
 
 /// Arguments for Host.audio_play_sound!
@@ -11864,6 +11797,13 @@ comptime {
         if (@alignOf(HostDraw_fpsArgs) != 4) @compileError("HostDraw_fpsArgs alignment mismatch");
     }
 }
+
+/// Arguments for Host.text_startup_default_font!
+/// Roc signature: Resource.Authority => Try(Font, [AssetNotFound, AssetPathInvalid, AssetReadFailed, FontLoadFailed, PermissionDenied, ResourceLimit])
+/// Refcounted fields are owned by the hosted function.
+pub const HostText_startup_default_fontArgs = extern struct {
+    arg0: u64,
+};
 
 /// Arguments for Host.draw_line!
 /// Roc signature: { color : Color.Rgba, end : Math.Vec2, start : Math.Vec2, thickness : F32 } => {}
@@ -12732,47 +12672,53 @@ comptime {
 }
 
 /// Arguments for Host.files_read_text!
-/// Roc signature: Str => Try(Str, [Busy, NotFound, NotUtf8, ReadFailed, TooLarge, Unavailable])
+/// Roc signature: Resource.Authority, Str => Try(Str, [Busy, NotFound, NotUtf8, PermissionDenied, ReadFailed, TooLarge, Unavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostFiles_read_textArgs = extern struct {
-    arg0: RocStr,
-};
-
-/// Arguments for Host.files_read_bytes!
-/// Roc signature: Str => Try(List(U8), [Busy, NotFound, ReadFailed, TooLarge, Unavailable])
-/// Refcounted fields are owned by the hosted function.
-pub const HostFiles_read_bytesArgs = extern struct {
-    arg0: RocStr,
-};
-
-/// Arguments for Host.files_list!
-/// Roc signature: Str => Try(List(U8), [Busy, NotADirectory, NotFound, ReadFailed, TooLarge, Unavailable])
-/// Refcounted fields are owned by the hosted function.
-pub const HostFiles_listArgs = extern struct {
-    arg0: RocStr,
-};
-
-/// Arguments for Host.files_metadata!
-/// Roc signature: Str => Try({ kind : U8, modified_nanosecond : U32, modified_seconds : I64, size_bytes : U64 }, [NotFound, PermissionDenied, ReadFailed, Unavailable])
-/// Refcounted fields are owned by the hosted function.
-pub const HostFiles_metadataArgs = extern struct {
-    arg0: RocStr,
-};
-
-/// Arguments for Host.files_write_text!
-/// Roc signature: Str, Str => Try({}, [NoSpace, NotFound, PermissionDenied, Unavailable, WriteFailed])
-/// Refcounted fields are owned by the hosted function.
-pub const HostFiles_write_textArgs = extern struct {
-    arg0: RocStr,
+    arg0: u64,
     arg1: RocStr,
 };
 
+/// Arguments for Host.files_read_bytes!
+/// Roc signature: Resource.Authority, Str => Try(List(U8), [Busy, NotFound, PermissionDenied, ReadFailed, TooLarge, Unavailable])
+/// Refcounted fields are owned by the hosted function.
+pub const HostFiles_read_bytesArgs = extern struct {
+    arg0: u64,
+    arg1: RocStr,
+};
+
+/// Arguments for Host.files_list!
+/// Roc signature: Resource.Authority, Str => Try(List(U8), [Busy, NotADirectory, NotFound, PermissionDenied, ReadFailed, TooLarge, Unavailable])
+/// Refcounted fields are owned by the hosted function.
+pub const HostFiles_listArgs = extern struct {
+    arg0: u64,
+    arg1: RocStr,
+};
+
+/// Arguments for Host.files_metadata!
+/// Roc signature: Resource.Authority, Str => Try({ kind : U8, modified_nanosecond : U32, modified_seconds : I64, size_bytes : U64 }, [NotFound, PermissionDenied, ReadFailed, Unavailable])
+/// Refcounted fields are owned by the hosted function.
+pub const HostFiles_metadataArgs = extern struct {
+    arg0: u64,
+    arg1: RocStr,
+};
+
+/// Arguments for Host.files_write_text!
+/// Roc signature: Resource.Authority, Str, Str => Try({}, [NoSpace, NotFound, PermissionDenied, Unavailable, WriteFailed])
+/// Refcounted fields are owned by the hosted function.
+pub const HostFiles_write_textArgs = extern struct {
+    arg0: u64,
+    arg1: RocStr,
+    arg2: RocStr,
+};
+
 /// Arguments for Host.files_write_bytes!
-/// Roc signature: Str, List(U8) => Try({}, [NoSpace, NotFound, PermissionDenied, Unavailable, WriteFailed])
+/// Roc signature: Resource.Authority, Str, List(U8) => Try({}, [NoSpace, NotFound, PermissionDenied, Unavailable, WriteFailed])
 /// Refcounted fields are owned by the hosted function.
 pub const HostFiles_write_bytesArgs = extern struct {
-    arg0: RocStr,
-    arg1: RocListWith(u8, false),
+    arg0: u64,
+    arg1: RocStr,
+    arg2: RocListWith(u8, false),
 };
 
 /// Arguments for Host.capture_set_virtual_mouse!
@@ -12885,119 +12831,35 @@ pub const HostCapture_set_virtual_textArgs = extern struct {
 };
 
 /// Arguments for Host.capture_start_recording!
-/// Roc signature: { cursor : U8, every_nth : U32, format : U8, fps : I32, max_frames : U64, path : Str, quality : U8, scale_denominator : U32, scale_numerator : U32, timing : U8 } => Try({}, [AlreadyRecording, Busy, PathEscapesOutputDir, PathInvalid, Unavailable, UnsupportedFormat, WriteFailed])
+/// Roc signature: Resource.Authority, { cursor : U8, every_nth : U32, format : U8, fps : I32, max_frames : U64, path : Str, quality : U8, scale_denominator : U32, scale_numerator : U32, timing : U8 } => Try({}, [AlreadyRecording, Busy, PathEscapesOutputDir, PathInvalid, PermissionDenied, Unavailable, UnsupportedFormat, WriteFailed])
 /// Refcounted fields are owned by the hosted function.
-pub const HostCapture_start_recordingArgs = if (@sizeOf(usize) == 4) extern struct {
-    max_frames: u64,
-    path: RocStr,
-    every_nth: u32,
-    fps: i32,
-    scale_denominator: u32,
-    scale_numerator: u32,
-    cursor: u8,
-    format: u8,
-    quality: u8,
-    timing: u8,
-    /// Recursively decrement Roc-owned fields.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        const value = self;
-        value.path.decref(roc_host);
-    }
-
-    /// Increment Roc-owned fields.
-    pub fn incref(self: @This(), amount: isize) void {
-        const value = self;
-        value.path.incref(amount);
-    }
-} else extern struct {
-    max_frames: u64,
-    path: RocStr,
-    every_nth: u32,
-    fps: i32,
-    scale_denominator: u32,
-    scale_numerator: u32,
-    cursor: u8,
-    format: u8,
-    quality: u8,
-    timing: u8,
-    /// Recursively decrement Roc-owned fields.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        const value = self;
-        value.path.decref(roc_host);
-    }
-
-    /// Increment Roc-owned fields.
-    pub fn incref(self: @This(), amount: isize) void {
-        const value = self;
-        value.path.incref(amount);
-    }
+pub const HostCapture_start_recordingArgs = extern struct {
+    arg0: u64,
+    arg1: __AnonStruct_96bd4e483c462501,
 };
 
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostCapture_start_recordingArgs) != 56) @compileError("HostCapture_start_recordingArgs size mismatch");
-        if (@alignOf(HostCapture_start_recordingArgs) != 8) @compileError("HostCapture_start_recordingArgs alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostCapture_start_recordingArgs) != 40) @compileError("HostCapture_start_recordingArgs size mismatch");
-        if (@alignOf(HostCapture_start_recordingArgs) != 8) @compileError("HostCapture_start_recordingArgs alignment mismatch");
-    }
-}
+/// Arguments for Host.capture_stop_recording!
+/// Roc signature: Resource.Authority => Try({ bytes : U64, frames : U64 }, [BudgetExceeded, Busy, NotRecording, PermissionDenied, ReadbackFailed, TargetUnavailable, Unavailable])
+/// Refcounted fields are owned by the hosted function.
+pub const HostCapture_stop_recordingArgs = extern struct {
+    arg0: u64,
+};
 
 /// Arguments for Host.capture_screenshot!
-/// Roc signature: Str => Try({}, [AlreadyPending, Busy, PathEscapesOutputDir, PathInvalid, Unavailable, WriteFailed])
+/// Roc signature: Resource.Authority, Str => Try({}, [AlreadyPending, Busy, PathEscapesOutputDir, PathInvalid, PermissionDenied, Unavailable, WriteFailed])
 /// Refcounted fields are owned by the hosted function.
 pub const HostCapture_screenshotArgs = extern struct {
-    arg0: RocStr,
+    arg0: u64,
+    arg1: RocStr,
 };
 
 /// Arguments for Host.capture_screenshot_texture!
-/// Roc signature: { path : Str, target : Texture } => Try({}, [BudgetExceeded, Busy, OutOfMemory, PathEscapesOutputDir, PathInvalid, ReadbackFailed, TargetUnavailable, Unavailable, WriteFailed])
+/// Roc signature: Resource.Authority, { path : Str, target : Texture } => Try({}, [BudgetExceeded, Busy, OutOfMemory, PathEscapesOutputDir, PathInvalid, PermissionDenied, ReadbackFailed, TargetUnavailable, Unavailable, WriteFailed])
 /// Refcounted fields are owned by the hosted function.
-pub const HostCapture_screenshot_textureArgs = if (@sizeOf(usize) == 4) extern struct {
-    path: RocStr,
-    target: Texture,
-    /// Recursively decrement Roc-owned fields.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        const value = self;
-        value.path.decref(roc_host);
-        value.target.decref(roc_host);
-    }
-
-    /// Increment Roc-owned fields.
-    pub fn incref(self: @This(), amount: isize) void {
-        const value = self;
-        value.path.incref(amount);
-        value.target.incref(amount);
-    }
-} else extern struct {
-    path: RocStr,
-    target: Texture,
-    /// Recursively decrement Roc-owned fields.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        const value = self;
-        value.path.decref(roc_host);
-        value.target.decref(roc_host);
-    }
-
-    /// Increment Roc-owned fields.
-    pub fn incref(self: @This(), amount: isize) void {
-        const value = self;
-        value.path.incref(amount);
-        value.target.incref(amount);
-    }
+pub const HostCapture_screenshot_textureArgs = extern struct {
+    arg0: u64,
+    arg1: __AnonStruct_aa2779af0bb79965,
 };
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostCapture_screenshot_textureArgs) != 40) @compileError("HostCapture_screenshot_textureArgs size mismatch");
-        if (@alignOf(HostCapture_screenshot_textureArgs) != 8) @compileError("HostCapture_screenshot_textureArgs alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostCapture_screenshot_textureArgs) != 24) @compileError("HostCapture_screenshot_textureArgs size mismatch");
-        if (@alignOf(HostCapture_screenshot_textureArgs) != 4) @compileError("HostCapture_screenshot_textureArgs alignment mismatch");
-    }
-}
 
 /// Arguments for Host.capture_pixel_at!
 /// Roc signature: { source : { screen : Bool, target : Texture }, x : I32, y : I32 } => Try({ a : U8, b : U8, g : U8, r : U8 }, [Busy, ReadbackFailed, RegionOutOfBounds, TargetUnavailable, Unavailable])
@@ -13103,17 +12965,11 @@ pub const HostApp_exitArgs = extern struct {
 };
 
 /// Arguments for Host.app_read_env!
-/// Roc signature: Str => Try(Str, [NotFound])
+/// Roc signature: Resource.Authority, Str => Try(Str, [NotFound, PermissionDenied])
 /// Refcounted fields are owned by the hosted function.
 pub const HostApp_read_envArgs = extern struct {
-    arg0: RocStr,
-};
-
-/// Arguments for Host.app_read_text!
-/// Roc signature: Str => Try(Str, [NotFound, ReadFailed])
-/// Refcounted fields are owned by the hosted function.
-pub const HostApp_read_textArgs = extern struct {
-    arg0: RocStr,
+    arg0: u64,
+    arg1: RocStr,
 };
 
 /// Arguments for Host.random_i32!
@@ -13131,11 +12987,19 @@ pub const HostKeys_set_exit_keyArgs = extern struct {
     arg0: i32,
 };
 
+/// Arguments for Host.window_read_clipboard!
+/// Roc signature: Resource.Authority => Try(Str, [Busy, PermissionDenied, TooLarge, Unavailable])
+/// Refcounted fields are owned by the hosted function.
+pub const HostWindow_read_clipboardArgs = extern struct {
+    arg0: u64,
+};
+
 /// Arguments for Host.window_set_clipboard_text!
-/// Roc signature: Str => {}
+/// Roc signature: Resource.Authority, Str => Try({}, [PermissionDenied])
 /// Refcounted fields are owned by the hosted function.
 pub const HostWindow_set_clipboard_textArgs = extern struct {
-    arg0: RocStr,
+    arg0: u64,
+    arg1: RocStr,
 };
 
 /// Arguments for Host.window_suggest_size!
@@ -13325,10 +13189,11 @@ pub const HostTask_spawnArgs = extern struct {
 };
 
 /// Arguments for Host.tilemap_load_tmx!
-/// Roc signature: Str => Try({ gids : List(U64), height : U64, layers : List({ gid_count : U64, gid_start : U64, height : U64, name : Str, opacity : F32, property_count : U64, property_start : U64, visible : Bool, width : U64 }), map_property_count : U64, map_property_start : U64, objects : List({ height : F32, id : U64, kind : U8, name : Str, point_count : U64, point_start : U64, property_count : U64, property_start : U64, rotation : F32, type_name : Str, width : F32, x : F32, y : F32 }), points : List({ x : F32, y : F32 }), properties : List({ bool_value : Bool, integer : I64, kind : U8, name : Str, number : F32, text : Str }), tile_height : F32, tile_properties : List({ gid : U64, property_count : U64, property_start : U64 }), tile_width : F32, tilesets : List({ columns : U64, first_gid : U64, image_height : F32, image_source : Str, image_width : F32, name : Str, property_count : U64, property_start : U64, tile_count : U64, tile_height : F32, tile_width : F32 }), width : U64 }, [NotFound, ParseFailed, ReadFailed, Unsupported])
+/// Roc signature: Resource.Authority, Str => Try({ gids : List(U64), height : U64, layers : List({ gid_count : U64, gid_start : U64, height : U64, name : Str, opacity : F32, property_count : U64, property_start : U64, visible : Bool, width : U64 }), map_property_count : U64, map_property_start : U64, objects : List({ height : F32, id : U64, kind : U8, name : Str, point_count : U64, point_start : U64, property_count : U64, property_start : U64, rotation : F32, type_name : Str, width : F32, x : F32, y : F32 }), points : List({ x : F32, y : F32 }), properties : List({ bool_value : Bool, integer : I64, kind : U8, name : Str, number : F32, text : Str }), tile_height : F32, tile_properties : List({ gid : U64, property_count : U64, property_start : U64 }), tile_width : F32, tilesets : List({ columns : U64, first_gid : U64, image_height : F32, image_source : Str, image_width : F32, name : Str, property_count : U64, property_start : U64, tile_count : U64, tile_height : F32, tile_width : F32 }), width : U64 }, [NotFound, ParseFailed, PermissionDenied, ReadFailed, Unsupported])
 /// Refcounted fields are owned by the hosted function.
 pub const HostTilemap_load_tmxArgs = extern struct {
-    arg0: RocStr,
+    arg0: u64,
+    arg1: RocStr,
 };
 
 /// Arguments for Host.tilemap_draw!
@@ -13998,138 +13863,47 @@ comptime {
 }
 
 /// Arguments for Host.http_send!
-/// Roc signature: { body : List(U8), headers : List({ name : Str, value : Str }), max_response_bytes : U64, method : U8, method_ext : Str, timeout_ms : U64, uri : Str } => Try({ body : List(U8), headers : List({ name : Str, value : Str }), status : U16 }, [MalformedResponse, NetworkError, Other(Str), Timeout])
+/// Roc signature: Resource.Authority, { body : List(U8), headers : List({ name : Str, value : Str }), max_response_bytes : U64, method : U8, method_ext : Str, timeout_ms : U64, uri : Str } => Try({ body : List(U8), headers : List({ name : Str, value : Str }), status : U16 }, [MalformedResponse, NetworkError, Other(Str), PermissionDenied, Timeout])
 /// Refcounted fields are owned by the hosted function.
-pub const HostHttp_sendArgs = if (@sizeOf(usize) == 4) extern struct {
-    max_response_bytes: u64,
-    timeout_ms: u64,
-    body: RocListWith(u8, false),
-    headers: RocList(__AnonStruct_82a96c5d55d63488),
-    method_ext: RocStr,
-    uri: RocStr,
-    method: u8,
-    /// Recursively decrement Roc-owned fields.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        const value = self;
-        value.body.decref(roc_host);
-        decrefListOf__AnonStruct_82a96c5d55d63488(value.headers, roc_host);
-        value.method_ext.decref(roc_host);
-        value.uri.decref(roc_host);
-    }
-
-    /// Increment Roc-owned fields.
-    pub fn incref(self: @This(), amount: isize) void {
-        const value = self;
-        value.body.incref(amount);
-        value.headers.incref(amount);
-        value.method_ext.incref(amount);
-        value.uri.incref(amount);
-    }
-} else extern struct {
-    max_response_bytes: u64,
-    timeout_ms: u64,
-    body: RocListWith(u8, false),
-    headers: RocList(__AnonStruct_82a96c5d55d63488),
-    method_ext: RocStr,
-    uri: RocStr,
-    method: u8,
-    /// Recursively decrement Roc-owned fields.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        const value = self;
-        value.body.decref(roc_host);
-        decrefListOf__AnonStruct_82a96c5d55d63488(value.headers, roc_host);
-        value.method_ext.decref(roc_host);
-        value.uri.decref(roc_host);
-    }
-
-    /// Increment Roc-owned fields.
-    pub fn incref(self: @This(), amount: isize) void {
-        const value = self;
-        value.body.incref(amount);
-        value.headers.incref(amount);
-        value.method_ext.incref(amount);
-        value.uri.incref(amount);
-    }
+pub const HostHttp_sendArgs = extern struct {
+    arg0: u64,
+    arg1: __AnonStruct_85380e02323174c5,
 };
 
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostHttp_sendArgs) != 120) @compileError("HostHttp_sendArgs size mismatch");
-        if (@alignOf(HostHttp_sendArgs) != 8) @compileError("HostHttp_sendArgs alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostHttp_sendArgs) != 72) @compileError("HostHttp_sendArgs size mismatch");
-        if (@alignOf(HostHttp_sendArgs) != 8) @compileError("HostHttp_sendArgs alignment mismatch");
-    }
-}
-
 /// Arguments for Host.stdio_write_text!
-/// Roc signature: U8, Str => Try({}, [BufferFull, TooLarge, Unavailable])
+/// Roc signature: Resource.Authority, U8, Str => Try({}, [BufferFull, PermissionDenied, TooLarge, Unavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostStdio_write_textArgs = extern struct {
-    arg0: u8,
-    arg1: RocStr,
+    arg0: u64,
+    arg1: u8,
+    arg2: RocStr,
 };
 
 /// Arguments for Host.stdio_write_line!
-/// Roc signature: U8, Str => Try({}, [BufferFull, TooLarge, Unavailable])
+/// Roc signature: Resource.Authority, U8, Str => Try({}, [BufferFull, PermissionDenied, TooLarge, Unavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostStdio_write_lineArgs = extern struct {
-    arg0: u8,
-    arg1: RocStr,
+    arg0: u64,
+    arg1: u8,
+    arg2: RocStr,
 };
 
 /// Arguments for Host.stdio_write_bytes!
-/// Roc signature: U8, List(U8) => Try({}, [BufferFull, TooLarge, Unavailable])
+/// Roc signature: Resource.Authority, U8, List(U8) => Try({}, [BufferFull, PermissionDenied, TooLarge, Unavailable])
 /// Refcounted fields are owned by the hosted function.
 pub const HostStdio_write_bytesArgs = extern struct {
-    arg0: u8,
-    arg1: RocListWith(u8, false),
+    arg0: u64,
+    arg1: u8,
+    arg2: RocListWith(u8, false),
 };
 
 /// Arguments for Host.udp_bind!
-/// Roc signature: { ip : Str, port : U16 } => Try({ handle : Resource.Handle([UdpSocketResource]), ip : U32, port : U16 }, [AddressInUse, AddressUnavailable, InvalidAddress, PermissionDenied, ResourceLimit, Unavailable])
+/// Roc signature: Resource.Authority, { ip : Str, port : U16 } => Try({ handle : Resource.Handle([UdpSocketResource]), ip : U32, port : U16 }, [AddressInUse, AddressUnavailable, InvalidAddress, PermissionDenied, ResourceLimit, Unavailable])
 /// Refcounted fields are owned by the hosted function.
-pub const HostUdp_bindArgs = if (@sizeOf(usize) == 4) extern struct {
-    ip: RocStr,
-    port: u16,
-    /// Recursively decrement Roc-owned fields.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        const value = self;
-        value.ip.decref(roc_host);
-    }
-
-    /// Increment Roc-owned fields.
-    pub fn incref(self: @This(), amount: isize) void {
-        const value = self;
-        value.ip.incref(amount);
-    }
-} else extern struct {
-    ip: RocStr,
-    port: u16,
-    /// Recursively decrement Roc-owned fields.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        const value = self;
-        value.ip.decref(roc_host);
-    }
-
-    /// Increment Roc-owned fields.
-    pub fn incref(self: @This(), amount: isize) void {
-        const value = self;
-        value.ip.incref(amount);
-    }
+pub const HostUdp_bindArgs = extern struct {
+    arg0: u64,
+    arg1: __AnonStruct_63b1422749dba501,
 };
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostUdp_bindArgs) != 32) @compileError("HostUdp_bindArgs size mismatch");
-        if (@alignOf(HostUdp_bindArgs) != 8) @compileError("HostUdp_bindArgs alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostUdp_bindArgs) != 16) @compileError("HostUdp_bindArgs size mismatch");
-        if (@alignOf(HostUdp_bindArgs) != 4) @compileError("HostUdp_bindArgs alignment mismatch");
-    }
-}
 
 /// Arguments for Host.udp_send!
 /// Roc signature: { bytes : List(U8), ip : Str, port : U16, socket : Resource.Handle([UdpSocketResource]) } => Try({}, [InvalidAddress, NoRoute, PermissionDenied, SendFailed, TooLarge, Unavailable, WouldBlock])
@@ -14234,13 +14008,14 @@ comptime {
 }
 
 /// Arguments for Host.sqlite_open!
-/// Roc signature: Str, U8, U64, U64 => Try(Resource.Handle([SqliteDbResource]), [SqliteErr({ code : I64, message : Str }), TooManyConnections])
+/// Roc signature: Resource.Authority, Str, U8, U64, U64 => Try(Resource.Handle([SqliteDbResource]), [PermissionDenied, SqliteErr({ code : I64, message : Str }), TooManyConnections])
 /// Refcounted fields are owned by the hosted function.
 pub const HostSqlite_openArgs = extern struct {
-    arg0: RocStr,
-    arg1: u8,
-    arg2: u64,
+    arg0: u64,
+    arg1: RocStr,
+    arg2: u8,
     arg3: u64,
+    arg4: u64,
 };
 
 /// Arguments for Host.sqlite_close!
@@ -14284,72 +14059,12 @@ pub const HostSqlite_exec_scriptArgs = extern struct {
 };
 
 /// Arguments for Host.cmd_run!
-/// Roc signature: { args : List(Str), clear_envs : Bool, envs : List({ name : Str, value : Str }), program : Str, stderr_limit_bytes : U64, stdout_limit_bytes : U64, timeout_ms : U64, working_dir : Str } => Try({ exit_code : I64, stderr : List(U8), stdout : List(U8) }, [Busy, CommandNotFound, PermissionDenied, SpawnFailed, StderrLimitExceeded, StdoutLimitExceeded, Timeout({ exit_code : I64, stderr : List(U8), stdout : List(U8) }), Unavailable])
+/// Roc signature: Resource.Authority, { args : List(Str), clear_envs : Bool, envs : List({ name : Str, value : Str }), program : Str, stderr_limit_bytes : U64, stdout_limit_bytes : U64, timeout_ms : U64, working_dir : Str } => Try({ exit_code : I64, stderr : List(U8), stdout : List(U8) }, [Busy, CommandNotFound, PermissionDenied, SpawnFailed, StderrLimitExceeded, StdoutLimitExceeded, Timeout({ exit_code : I64, stderr : List(U8), stdout : List(U8) }), Unavailable])
 /// Refcounted fields are owned by the hosted function.
-pub const HostCmd_runArgs = if (@sizeOf(usize) == 4) extern struct {
-    stderr_limit_bytes: u64,
-    stdout_limit_bytes: u64,
-    timeout_ms: u64,
-    args: RocList(RocStr),
-    envs: RocList(__AnonStruct_82a96c5d55d63488),
-    program: RocStr,
-    working_dir: RocStr,
-    clear_envs: bool,
-    /// Recursively decrement Roc-owned fields.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        const value = self;
-        decrefListOfStr(value.args, roc_host);
-        decrefListOf__AnonStruct_82a96c5d55d63488(value.envs, roc_host);
-        value.program.decref(roc_host);
-        value.working_dir.decref(roc_host);
-    }
-
-    /// Increment Roc-owned fields.
-    pub fn incref(self: @This(), amount: isize) void {
-        const value = self;
-        value.args.incref(amount);
-        value.envs.incref(amount);
-        value.program.incref(amount);
-        value.working_dir.incref(amount);
-    }
-} else extern struct {
-    stderr_limit_bytes: u64,
-    stdout_limit_bytes: u64,
-    timeout_ms: u64,
-    args: RocList(RocStr),
-    envs: RocList(__AnonStruct_82a96c5d55d63488),
-    program: RocStr,
-    working_dir: RocStr,
-    clear_envs: bool,
-    /// Recursively decrement Roc-owned fields.
-    pub fn decref(self: @This(), roc_host: *RocHost) void {
-        const value = self;
-        decrefListOfStr(value.args, roc_host);
-        decrefListOf__AnonStruct_82a96c5d55d63488(value.envs, roc_host);
-        value.program.decref(roc_host);
-        value.working_dir.decref(roc_host);
-    }
-
-    /// Increment Roc-owned fields.
-    pub fn incref(self: @This(), amount: isize) void {
-        const value = self;
-        value.args.incref(amount);
-        value.envs.incref(amount);
-        value.program.incref(amount);
-        value.working_dir.incref(amount);
-    }
+pub const HostCmd_runArgs = extern struct {
+    arg0: u64,
+    arg1: __AnonStruct_3fe396bc5ba0c31c,
 };
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(HostCmd_runArgs) != 128) @compileError("HostCmd_runArgs size mismatch");
-        if (@alignOf(HostCmd_runArgs) != 8) @compileError("HostCmd_runArgs alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(HostCmd_runArgs) != 80) @compileError("HostCmd_runArgs size mismatch");
-        if (@alignOf(HostCmd_runArgs) != 8) @compileError("HostCmd_runArgs alignment mismatch");
-    }
-}
 
 /// Arguments for Host.trace_mark!
 /// Roc signature: Str => {}
@@ -14392,8 +14107,8 @@ pub const HostTrace_sample_f64Args = extern struct {
 
 // Platform Type Aliases
 
-pub const HostStore_openArg0 = __AnonStruct_8f4b2816fd84fce2;
-pub const HostStore_openErr = AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch;
+pub const HostStore_openArg1 = __AnonStruct_8f4b2816fd84fce2;
+pub const HostStore_openErr = AssetSetMismatchOrContentHashMismatchOrContentVersionMismatchOrInvalidExpectedContentHashOrInvalidRootPathOrManifestMalformedOrManifestMissingOrManifestUnreadableOrPermissionDeniedOrResourceLimitOrRootNotDirectoryOrRootNotFoundOrRootUnreadableOrSchemaMismatch;
 pub const HostTexture_load_storeArg0 = __AnonStruct_e6634fb4c190c214;
 pub const HostTexture_load_storeErr = NotFoundOrPathInvalidOrReadFailedOrResourceLimitOrTextureLoadFailed;
 pub const HostTexture_load_storeOk = Texture;
@@ -14422,8 +14137,8 @@ pub const HostAudio_gen_soundResult = HostAudio_gen_toneResult;
 pub const HostAudio_gen_soundResultPayload = HostAudio_gen_toneResultPayload;
 pub const HostAudio_gen_soundResultTag = HostAudio_gen_toneResultTag;
 pub const HostAudio_gen_soundErr = ResourceLimitOrSoundGenerationFailed;
-pub const HostAudio_load_soundErr = ResourceLimitOrSoundLoadFailed;
-pub const HostAudio_load_musicErr = MusicLoadFailedOrResourceLimit;
+pub const HostAudio_load_soundErr = PermissionDeniedOrResourceLimitOrSoundLoadFailed;
+pub const HostAudio_load_musicErr = MusicLoadFailedOrPermissionDeniedOrResourceLimit;
 pub const HostDraw_begin_scissorArg0 = __AnonStruct_5d393593a1f032cb;
 pub const HostDraw_begin_scissorErr = ScopeLimitOrScopeUnavailable;
 pub const HostDraw_circle_gradientArg0 = __AnonStruct_f8a458371716c148;
@@ -14436,7 +14151,7 @@ pub const HostDraw_draw_texture_quadArg0 = __AnonStruct_81a2561bb748cfff;
 pub const HostDraw_fpsArg0 = __AnonStruct_477f59604acc661e;
 pub const FontMetrics = __AnonStruct_2bfb89334ad27c35;
 pub const FontMetricsGlyphs = __AnonStruct_a31979034eec4b2e;
-pub const HostText_startup_default_fontErr = AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrResourceLimit;
+pub const HostText_startup_default_fontErr = AssetNotFoundOrAssetPathInvalidOrAssetReadFailedOrFontLoadFailedOrPermissionDeniedOrResourceLimit;
 pub const HostText_startup_default_fontOk = Font;
 pub const HostDraw_frame_size = __AnonStruct_473ae8de77ee164b;
 pub const HostDraw_lineArg0 = __AnonStruct_a3fdb7fbf4ae00b8;
@@ -14463,9 +14178,9 @@ pub const HostDraw_rounded_rectangleArg0 = __AnonStruct_2b98c437f1796b13;
 pub const HostDraw_textArg0 = __AnonStruct_a794ed9ee3bc5d8d;
 pub const HostDraw_triangle_linesArg0 = __AnonStruct_563f890a3b4ea7a0;
 pub const HostDraw_triangleArg0 = __AnonStruct_d48cb861dff2afaa;
-pub const HostFiles_read_textErr = BusyOrNotFoundOrNotUtf8OrReadFailedOrTooLargeOrUnavailable;
-pub const HostFiles_read_bytesErr = BusyOrNotFoundOrReadFailedOrTooLargeOrUnavailable;
-pub const HostFiles_listErr = BusyOrNotADirectoryOrNotFoundOrReadFailedOrTooLargeOrUnavailable;
+pub const HostFiles_read_textErr = BusyOrNotFoundOrNotUtf8OrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable;
+pub const HostFiles_read_bytesErr = BusyOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable;
+pub const HostFiles_listErr = BusyOrNotADirectoryOrNotFoundOrPermissionDeniedOrReadFailedOrTooLargeOrUnavailable;
 pub const HostFiles_metadataErr = NotFoundOrPermissionDeniedOrReadFailedOrUnavailable;
 pub const HostFiles_metadataOk = __AnonStruct_a1f5c33e74b3920b;
 pub const HostFiles_write_textErr = NoSpaceOrNotFoundOrPermissionDeniedOrUnavailableOrWriteFailed;
@@ -14475,13 +14190,13 @@ pub const HostFiles_write_bytesResultTag = HostFiles_write_textResultTag;
 pub const HostFiles_write_bytesErr = NoSpaceOrNotFoundOrPermissionDeniedOrUnavailableOrWriteFailed;
 pub const HostCapture_set_virtual_mouseArg0 = __AnonStruct_e20342da83229f51;
 pub const HostCapture_set_virtual_keysArg0 = __AnonStruct_c3425bb1e3730c6e;
-pub const HostCapture_start_recordingArg0 = __AnonStruct_96bd4e483c462501;
-pub const HostCapture_start_recordingErr = AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrUnsupportedFormatOrWriteFailed;
-pub const HostCapture_stop_recordingErr = BudgetExceededOrBusyOrNotRecordingOrReadbackFailedOrTargetUnavailableOrUnavailable;
+pub const HostCapture_start_recordingArg1 = __AnonStruct_96bd4e483c462501;
+pub const HostCapture_start_recordingErr = AlreadyRecordingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrUnsupportedFormatOrWriteFailed;
+pub const HostCapture_stop_recordingErr = BudgetExceededOrBusyOrNotRecordingOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailable;
 pub const HostCapture_stop_recordingOk = __AnonStruct_5c978c17ba0c990a;
-pub const HostCapture_screenshotErr = AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrUnavailableOrWriteFailed;
-pub const HostCapture_screenshot_textureArg0 = __AnonStruct_aa2779af0bb79965;
-pub const HostCapture_screenshot_textureErr = BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed;
+pub const HostCapture_screenshotErr = AlreadyPendingOrBusyOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrUnavailableOrWriteFailed;
+pub const HostCapture_screenshot_textureArg1 = __AnonStruct_aa2779af0bb79965;
+pub const HostCapture_screenshot_textureErr = BudgetExceededOrBusyOrOutOfMemoryOrPathEscapesOutputDirOrPathInvalidOrPermissionDeniedOrReadbackFailedOrTargetUnavailableOrUnavailableOrWriteFailed;
 pub const HostCapture_pixel_atArg0 = __AnonStruct_30827bd86e7a53b3;
 pub const HostCapture_pixel_atArg0Source = __AnonStruct_29524f9bb2f9574c;
 pub const HostCapture_pixel_atErr = BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable;
@@ -14489,14 +14204,14 @@ pub const HostCapture_pixel_atOk = __AnonStruct_bda5c9dc6cabe78e;
 pub const HostCapture_read_regionArg0 = __AnonStruct_7ea2de5aa3c18166;
 pub const HostCapture_read_regionArg0Source = __AnonStruct_29524f9bb2f9574c;
 pub const HostCapture_read_regionErr = BusyOrReadbackFailedOrRegionOutOfBoundsOrTargetUnavailableOrUnavailable;
-pub const HostApp_read_textErr = NotFoundOrReadFailed;
-pub const HostWindow_read_clipboardErr = BusyOrTooLargeOrUnavailable;
+pub const HostApp_read_envErr = NotFoundOrPermissionDenied;
+pub const HostWindow_read_clipboardErr = BusyOrPermissionDeniedOrTooLargeOrUnavailable;
 pub const HostWindow_suggest_sizeArg0 = __AnonStruct_bc8fa73ca49a5ac0;
 pub const HostWindow_suggest_min_sizeArg0 = __AnonStruct_bc8fa73ca49a5ac0;
 pub const HostWindow_scale_dpi = __AnonStruct_2818a50bdccefb1e;
 pub const HostWindow_monitors = __AnonStruct_dae0ce24e748c0cf;
 pub const HostWindow_suggest_positionArg0 = __AnonStruct_3560e04f2553d83d;
-pub const HostTilemap_load_tmxErr = NotFoundOrParseFailedOrReadFailedOrUnsupported;
+pub const HostTilemap_load_tmxErr = NotFoundOrParseFailedOrPermissionDeniedOrReadFailedOrUnsupported;
 pub const HostTilemap_load_tmxOk = __AnonStruct_831cf812524287ed;
 pub const HostTilemap_load_tmxOkLayers = __AnonStruct_1299823ae1663c65;
 pub const HostTilemap_load_tmxOkObjects = __AnonStruct_109c1082e72f7bad;
@@ -14545,24 +14260,24 @@ pub const HostShader_set_vec3Arg0Value = __AnonStruct_1c1c4c2ebf90bdba;
 pub const HostShader_set_vec4Arg0 = __AnonStruct_70e8e55530300f02;
 pub const HostShader_set_vec4Arg0Uniform = __AnonStruct_5977b9984ceff2ca;
 pub const HostShader_set_vec4Arg0Value = __AnonStruct_8ea1de206d7d534d;
-pub const HostHttp_sendArg0 = __AnonStruct_85380e02323174c5;
-pub const HostHttp_sendArg0Headers = __AnonStruct_82a96c5d55d63488;
-pub const HostHttp_sendErr = MalformedResponseOrNetworkErrorOrOtherOrTimeout;
-pub const HostHttp_sendErrPayload = MalformedResponseOrNetworkErrorOrOtherOrTimeoutPayload;
-pub const HostHttp_sendErrTag = MalformedResponseOrNetworkErrorOrOtherOrTimeoutTag;
+pub const HostHttp_sendArg1 = __AnonStruct_85380e02323174c5;
+pub const HostHttp_sendArg1Headers = __AnonStruct_82a96c5d55d63488;
+pub const HostHttp_sendErr = MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout;
+pub const HostHttp_sendErrPayload = MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeoutPayload;
+pub const HostHttp_sendErrTag = MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeoutTag;
 pub const HostHttp_sendOk = __AnonStruct_a14cd3b7d5755441;
 pub const HostHttp_sendOkHeaders = __AnonStruct_82a96c5d55d63488;
 pub const HostTime_now = __AnonStruct_bbf5049c4fa71893;
-pub const HostStdio_write_textErr = BufferFullOrTooLargeOrUnavailable;
+pub const HostStdio_write_textErr = BufferFullOrPermissionDeniedOrTooLargeOrUnavailable;
 pub const HostStdio_write_lineResult = HostStdio_write_textResult;
 pub const HostStdio_write_lineResultPayload = HostStdio_write_textResultPayload;
 pub const HostStdio_write_lineResultTag = HostStdio_write_textResultTag;
-pub const HostStdio_write_lineErr = BufferFullOrTooLargeOrUnavailable;
+pub const HostStdio_write_lineErr = BufferFullOrPermissionDeniedOrTooLargeOrUnavailable;
 pub const HostStdio_write_bytesResult = HostStdio_write_textResult;
 pub const HostStdio_write_bytesResultPayload = HostStdio_write_textResultPayload;
 pub const HostStdio_write_bytesResultTag = HostStdio_write_textResultTag;
-pub const HostStdio_write_bytesErr = BufferFullOrTooLargeOrUnavailable;
-pub const HostUdp_bindArg0 = __AnonStruct_63b1422749dba501;
+pub const HostStdio_write_bytesErr = BufferFullOrPermissionDeniedOrTooLargeOrUnavailable;
+pub const HostUdp_bindArg1 = __AnonStruct_63b1422749dba501;
 pub const HostUdp_bindErr = AddressInUseOrAddressUnavailableOrInvalidAddressOrPermissionDeniedOrResourceLimitOrUnavailable;
 pub const HostUdp_bindOk = __AnonStruct_ec1e23856e0d8ecf;
 pub const HostUdp_sendArg0 = __AnonStruct_686570ce13fde405;
@@ -14571,11 +14286,11 @@ pub const HostUdp_receiveArg0 = __AnonStruct_3d573c3bcb10a375;
 pub const HostUdp_receiveErr = AlreadyReceivingOrReceiveFailedOrTimeoutOrUnavailable;
 pub const HostUdp_receiveOk = __AnonStruct_1772298ecb801858;
 pub const HostUdp_receiveOkSlices = __AnonStruct_4dd3180405b3f44f;
-pub const HostSqlite_openErr = SqliteErrOrTooManyConnections;
-pub const HostSqlite_openErrPayload = SqliteErrOrTooManyConnectionsPayload;
-pub const HostSqlite_openErrTag = SqliteErrOrTooManyConnectionsTag;
+pub const HostSqlite_openErr = PermissionDeniedOrSqliteErrOrTooManyConnections;
+pub const HostSqlite_openErrPayload = PermissionDeniedOrSqliteErrOrTooManyConnectionsPayload;
+pub const HostSqlite_openErrTag = PermissionDeniedOrSqliteErrOrTooManyConnectionsTag;
 pub const HostSqlite_openErrSqliteErr = __AnonStruct_22cf486058afc711;
-pub const SqliteErrOrTooManyConnectionsSqliteErr = __AnonStruct_22cf486058afc711;
+pub const PermissionDeniedOrSqliteErrOrTooManyConnectionsSqliteErr = __AnonStruct_22cf486058afc711;
 pub const HostSqlite_closeErr = __AnonStruct_22cf486058afc711;
 pub const SqliteErr = __AnonStruct_22cf486058afc711;
 pub const SqliteErrSqliteErr = __AnonStruct_22cf486058afc711;
@@ -14606,8 +14321,8 @@ pub const HostSqlite_exec_scriptResult = HostSqlite_closeResult;
 pub const HostSqlite_exec_scriptResultPayload = HostSqlite_closeResultPayload;
 pub const HostSqlite_exec_scriptResultTag = HostSqlite_closeResultTag;
 pub const HostSqlite_exec_scriptErr = __AnonStruct_22cf486058afc711;
-pub const HostCmd_runArg0 = __AnonStruct_3fe396bc5ba0c31c;
-pub const HostCmd_runArg0Envs = __AnonStruct_82a96c5d55d63488;
+pub const HostCmd_runArg1 = __AnonStruct_3fe396bc5ba0c31c;
+pub const HostCmd_runArg1Envs = __AnonStruct_82a96c5d55d63488;
 pub const HostCmd_runErr = BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailable;
 pub const HostCmd_runErrPayload = BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailablePayload;
 pub const HostCmd_runErrTag = BusyOrCommandNotFoundOrPermissionDeniedOrSpawnFailedOrStderrLimitExceededOrStdoutLimitExceededOrTimeoutOrUnavailableTag;
@@ -15459,30 +15174,32 @@ pub const HostHttp_sendResultRelease = struct {
     }
 };
 
-fn decrefMalformedResponseOrNetworkErrorOrOtherOrTimeout(value: MalformedResponseOrNetworkErrorOrOtherOrTimeout, roc_host: *RocHost) void {
+fn decrefMalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout(value: MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout, roc_host: *RocHost) void {
     switch (value.tag) {
         .MalformedResponse => {},
         .NetworkError => {},
         .Other => {
             value.payload_other().decref(roc_host);
         },
+        .PermissionDenied => {},
         .Timeout => {},
     }
 }
 
-fn increfMalformedResponseOrNetworkErrorOrOtherOrTimeout(value: MalformedResponseOrNetworkErrorOrOtherOrTimeout, amount: isize) void {
+fn increfMalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout(value: MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout, amount: isize) void {
     switch (value.tag) {
         .MalformedResponse => {},
         .NetworkError => {},
         .Other => {
             value.payload_other().incref(amount);
         },
+        .PermissionDenied => {},
         .Timeout => {},
     }
 }
 
-pub const MalformedResponseOrNetworkErrorOrOtherOrTimeoutRelease = struct {
-    pub fn release(value: MalformedResponseOrNetworkErrorOrOtherOrTimeout, roc_host: *RocHost) void {
+pub const MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeoutRelease = struct {
+    pub fn release(value: MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -15723,30 +15440,6 @@ pub const __AnonStruct_3d573c3bcb10a375Release = struct {
 
 fn decrefHostApp_read_envResult(value: HostApp_read_envResult, roc_host: *RocHost) void {
     switch (value.tag) {
-        .Err => {},
-        .Ok => {
-            value.payload_ok().decref(roc_host);
-        },
-    }
-}
-
-fn increfHostApp_read_envResult(value: HostApp_read_envResult, amount: isize) void {
-    switch (value.tag) {
-        .Err => {},
-        .Ok => {
-            value.payload_ok().incref(amount);
-        },
-    }
-}
-
-pub const HostApp_read_envResultRelease = struct {
-    pub fn release(value: HostApp_read_envResult, roc_host: *RocHost) void {
-        value.decref(roc_host);
-    }
-};
-
-fn decrefHostApp_read_textResult(value: HostApp_read_textResult, roc_host: *RocHost) void {
-    switch (value.tag) {
         .Err => {
             value.payload_err().decref(roc_host);
         },
@@ -15756,7 +15449,7 @@ fn decrefHostApp_read_textResult(value: HostApp_read_textResult, roc_host: *RocH
     }
 }
 
-fn increfHostApp_read_textResult(value: HostApp_read_textResult, amount: isize) void {
+fn increfHostApp_read_envResult(value: HostApp_read_envResult, amount: isize) void {
     switch (value.tag) {
         .Err => {
             value.payload_err().incref(amount);
@@ -15767,8 +15460,8 @@ fn increfHostApp_read_textResult(value: HostApp_read_textResult, amount: isize) 
     }
 }
 
-pub const HostApp_read_textResultRelease = struct {
-    pub fn release(value: HostApp_read_textResult, roc_host: *RocHost) void {
+pub const HostApp_read_envResultRelease = struct {
+    pub fn release(value: HostApp_read_envResult, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -15797,6 +15490,28 @@ fn increfHostWindow_read_clipboardResult(value: HostWindow_read_clipboardResult,
 
 pub const HostWindow_read_clipboardResultRelease = struct {
     pub fn release(value: HostWindow_read_clipboardResult, roc_host: *RocHost) void {
+        value.decref(roc_host);
+    }
+};
+
+fn decrefHostWindow_set_clipboard_textResult(value: HostWindow_set_clipboard_textResult, roc_host: *RocHost) void {
+    _ = roc_host;
+    switch (value.tag) {
+        .Err => {},
+        .Ok => {},
+    }
+}
+
+fn increfHostWindow_set_clipboard_textResult(value: HostWindow_set_clipboard_textResult, amount: isize) void {
+    _ = amount;
+    switch (value.tag) {
+        .Err => {},
+        .Ok => {},
+    }
+}
+
+pub const HostWindow_set_clipboard_textResultRelease = struct {
+    pub fn release(value: HostWindow_set_clipboard_textResult, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -15951,8 +15666,9 @@ pub const HostSqlite_openResultRelease = struct {
     }
 };
 
-fn decrefSqliteErrOrTooManyConnections(value: SqliteErrOrTooManyConnections, roc_host: *RocHost) void {
+fn decrefPermissionDeniedOrSqliteErrOrTooManyConnections(value: PermissionDeniedOrSqliteErrOrTooManyConnections, roc_host: *RocHost) void {
     switch (value.tag) {
+        .PermissionDenied => {},
         .SqliteErr => {
             value.payload_sqlite_err().decref(roc_host);
         },
@@ -15960,8 +15676,9 @@ fn decrefSqliteErrOrTooManyConnections(value: SqliteErrOrTooManyConnections, roc
     }
 }
 
-fn increfSqliteErrOrTooManyConnections(value: SqliteErrOrTooManyConnections, amount: isize) void {
+fn increfPermissionDeniedOrSqliteErrOrTooManyConnections(value: PermissionDeniedOrSqliteErrOrTooManyConnections, amount: isize) void {
     switch (value.tag) {
+        .PermissionDenied => {},
         .SqliteErr => {
             value.payload_sqlite_err().incref(amount);
         },
@@ -15969,8 +15686,8 @@ fn increfSqliteErrOrTooManyConnections(value: SqliteErrOrTooManyConnections, amo
     }
 }
 
-pub const SqliteErrOrTooManyConnectionsRelease = struct {
-    pub fn release(value: SqliteErrOrTooManyConnections, roc_host: *RocHost) void {
+pub const PermissionDeniedOrSqliteErrOrTooManyConnectionsRelease = struct {
+    pub fn release(value: PermissionDeniedOrSqliteErrOrTooManyConnections, roc_host: *RocHost) void {
         value.decref(roc_host);
     }
 };
@@ -16800,7 +16517,7 @@ fn rocReleasePolicy(comptime T: type) type {
     if (T == HostFiles_read_bytesResult) return HostFiles_read_bytesResultRelease;
     if (T == HostFiles_listResult) return HostFiles_listResultRelease;
     if (T == HostHttp_sendResult) return HostHttp_sendResultRelease;
-    if (T == MalformedResponseOrNetworkErrorOrOtherOrTimeout) return MalformedResponseOrNetworkErrorOrOtherOrTimeoutRelease;
+    if (T == MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeout) return MalformedResponseOrNetworkErrorOrOtherOrPermissionDeniedOrTimeoutRelease;
     if (T == __AnonStruct_a14cd3b7d5755441) return __AnonStruct_a14cd3b7d5755441Release;
     if (T == RocList(__AnonStruct_82a96c5d55d63488)) return RocListRelease(RocList(__AnonStruct_82a96c5d55d63488), __AnonStruct_82a96c5d55d63488Release);
     if (T == __AnonStruct_82a96c5d55d63488) return __AnonStruct_82a96c5d55d63488Release;
@@ -16819,7 +16536,6 @@ fn rocReleasePolicy(comptime T: type) type {
     if (T == RocListWith(__AnonStruct_4dd3180405b3f44f, false)) return RocListSpineRelease(RocListWith(__AnonStruct_4dd3180405b3f44f, false));
     if (T == __AnonStruct_3d573c3bcb10a375) return __AnonStruct_3d573c3bcb10a375Release;
     if (T == HostApp_read_envResult) return HostApp_read_envResultRelease;
-    if (T == HostApp_read_textResult) return HostApp_read_textResultRelease;
     if (T == HostWindow_read_clipboardResult) return HostWindow_read_clipboardResultRelease;
     if (T == RocList(__AnonStruct_dae0ce24e748c0cf)) return RocListRelease(RocList(__AnonStruct_dae0ce24e748c0cf), __AnonStruct_dae0ce24e748c0cfRelease);
     if (T == __AnonStruct_dae0ce24e748c0cf) return __AnonStruct_dae0ce24e748c0cfRelease;
@@ -16841,7 +16557,7 @@ fn rocReleasePolicy(comptime T: type) type {
     if (T == RocList(__AnonStruct_9f9f7e660a5e922b)) return RocListRelease(RocList(__AnonStruct_9f9f7e660a5e922b), __AnonStruct_9f9f7e660a5e922bRelease);
     if (T == __AnonStruct_9f9f7e660a5e922b) return __AnonStruct_9f9f7e660a5e922bRelease;
     if (T == HostSqlite_openResult) return HostSqlite_openResultRelease;
-    if (T == SqliteErrOrTooManyConnections) return SqliteErrOrTooManyConnectionsRelease;
+    if (T == PermissionDeniedOrSqliteErrOrTooManyConnections) return PermissionDeniedOrSqliteErrOrTooManyConnectionsRelease;
     if (T == __AnonStruct_22cf486058afc711) return __AnonStruct_22cf486058afc711Release;
     if (T == HostSqlite_closeResult) return HostSqlite_closeResultRelease;
     if (T == HostSqlite_prepareResult) return HostSqlite_prepareResultRelease;
@@ -16902,12 +16618,12 @@ pub extern fn roc_crashed(bytes: [*]const u8, len: usize) callconv(.c) void;
 // Refcounted arguments are owned by the hosted function.
 
 /// Hosted symbol for Host.store_open!
-/// Roc signature: { asset_set : Str, content_hash : Str, content_hash_mode : U8, content_version : U32, location_kind : U8, manifest_required : Bool, root : Str, schema : U32 } => Try(Resource.Handle([StoreResource]), [AssetSetMismatch, ContentHashMismatch, ContentVersionMismatch, InvalidExpectedContentHash, InvalidRootPath, ManifestMalformed, ManifestMissing, ManifestUnreadable, ResourceLimit, RootNotDirectory, RootNotFound, RootUnreadable, SchemaMismatch])
+/// Roc signature: Resource.Authority, { asset_set : Str, content_hash : Str, content_hash_mode : U8, content_version : U32, location_kind : U8, manifest_required : Bool, root : Str, schema : U32 } => Try(Resource.Handle([StoreResource]), [AssetSetMismatch, ContentHashMismatch, ContentVersionMismatch, InvalidExpectedContentHash, InvalidRootPath, ManifestMalformed, ManifestMissing, ManifestUnreadable, PermissionDenied, ResourceLimit, RootNotDirectory, RootNotFound, RootUnreadable, SchemaMismatch])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg0.decref(roc_host);
+///     arg1.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_store_open_raw(arg0: HostStore_openArgs) callconv(.c) HostStore_openResult;
+pub extern fn roc_store_open_raw(arg0: u64, arg1: __AnonStruct_8f4b2816fd84fce2) callconv(.c) HostStore_openResult;
 
 /// Hosted symbol for Host.texture_load_store!
 /// Roc signature: { path : Str, store : Resource.Handle([StoreResource]) } => Try(Texture, [NotFound, PathInvalid, ReadFailed, ResourceLimit, TextureLoadFailed])
@@ -16974,20 +16690,20 @@ pub extern fn roc_audio_gen_tone_raw(arg0: HostAudio_gen_toneArgs) callconv(.c) 
 pub extern fn roc_audio_gen_sound_raw(arg0: HostAudio_gen_soundArgs) callconv(.c) HostAudio_gen_toneResult;
 
 /// Hosted symbol for Host.audio_load_sound!
-/// Roc signature: Str => Try(Resource.Handle([SoundResource]), [ResourceLimit, SoundLoadFailed])
+/// Roc signature: Resource.Authority, Str => Try(Resource.Handle([SoundResource]), [PermissionDenied, ResourceLimit, SoundLoadFailed])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg0.decref(roc_host);
+///     arg1.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_audio_load_sound_raw(arg0: RocStr) callconv(.c) HostAudio_load_soundResult;
+pub extern fn roc_audio_load_sound_raw(arg0: u64, arg1: RocStr) callconv(.c) HostAudio_load_soundResult;
 
 /// Hosted symbol for Host.audio_load_music!
-/// Roc signature: Str => Try(Resource.Handle([MusicResource]), [MusicLoadFailed, ResourceLimit])
+/// Roc signature: Resource.Authority, Str => Try(Resource.Handle([MusicResource]), [MusicLoadFailed, PermissionDenied, ResourceLimit])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg0.decref(roc_host);
+///     arg1.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_audio_load_music_raw(arg0: RocStr) callconv(.c) HostAudio_load_musicResult;
+pub extern fn roc_audio_load_music_raw(arg0: u64, arg1: RocStr) callconv(.c) HostAudio_load_musicResult;
 
 /// Hosted symbol for Host.audio_play_sound!
 /// Roc signature: Resource.Handle([SoundResource]) => {}
@@ -17191,9 +16907,9 @@ pub extern fn roc_draw_fps(arg0: HostDraw_fpsArgs) callconv(.c) void;
 pub extern fn roc_text_default_font_raw() callconv(.c) Font;
 
 /// Hosted symbol for Host.text_startup_default_font!
-/// Roc signature: {} => Try(Font, [AssetNotFound, AssetPathInvalid, AssetReadFailed, FontLoadFailed, ResourceLimit])
+/// Roc signature: Resource.Authority => Try(Font, [AssetNotFound, AssetPathInvalid, AssetReadFailed, FontLoadFailed, PermissionDenied, ResourceLimit])
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_text_startup_default_font_raw() callconv(.c) HostText_startup_default_fontResult;
+pub extern fn roc_text_startup_default_font_raw(arg0: u64) callconv(.c) HostText_startup_default_fontResult;
 
 /// Hosted symbol for Host.draw_frame_size!
 /// Roc signature: {} => { height : F32, width : F32 }
@@ -17288,51 +17004,51 @@ pub extern fn roc_draw_triangle_lines_raw(arg0: HostDraw_triangle_linesArgs) cal
 pub extern fn roc_draw_triangle_raw(arg0: HostDraw_triangleArgs) callconv(.c) void;
 
 /// Hosted symbol for Host.files_read_text!
-/// Roc signature: Str => Try(Str, [Busy, NotFound, NotUtf8, ReadFailed, TooLarge, Unavailable])
+/// Roc signature: Resource.Authority, Str => Try(Str, [Busy, NotFound, NotUtf8, PermissionDenied, ReadFailed, TooLarge, Unavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg0.decref(roc_host);
+///     arg1.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_files_read_text(arg0: RocStr) callconv(.c) HostFiles_read_textResult;
+pub extern fn roc_files_read_text(arg0: u64, arg1: RocStr) callconv(.c) HostFiles_read_textResult;
 
 /// Hosted symbol for Host.files_read_bytes!
-/// Roc signature: Str => Try(List(U8), [Busy, NotFound, ReadFailed, TooLarge, Unavailable])
+/// Roc signature: Resource.Authority, Str => Try(List(U8), [Busy, NotFound, PermissionDenied, ReadFailed, TooLarge, Unavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg0.decref(roc_host);
+///     arg1.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_files_read_bytes(arg0: RocStr) callconv(.c) HostFiles_read_bytesResult;
+pub extern fn roc_files_read_bytes(arg0: u64, arg1: RocStr) callconv(.c) HostFiles_read_bytesResult;
 
 /// Hosted symbol for Host.files_list!
-/// Roc signature: Str => Try(List(U8), [Busy, NotADirectory, NotFound, ReadFailed, TooLarge, Unavailable])
+/// Roc signature: Resource.Authority, Str => Try(List(U8), [Busy, NotADirectory, NotFound, PermissionDenied, ReadFailed, TooLarge, Unavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg0.decref(roc_host);
+///     arg1.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_files_list(arg0: RocStr) callconv(.c) HostFiles_listResult;
+pub extern fn roc_files_list(arg0: u64, arg1: RocStr) callconv(.c) HostFiles_listResult;
 
 /// Hosted symbol for Host.files_metadata!
-/// Roc signature: Str => Try({ kind : U8, modified_nanosecond : U32, modified_seconds : I64, size_bytes : U64 }, [NotFound, PermissionDenied, ReadFailed, Unavailable])
+/// Roc signature: Resource.Authority, Str => Try({ kind : U8, modified_nanosecond : U32, modified_seconds : I64, size_bytes : U64 }, [NotFound, PermissionDenied, ReadFailed, Unavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg0.decref(roc_host);
-pub extern fn roc_files_metadata(arg0: RocStr) callconv(.c) HostFiles_metadataResult;
+///     arg1.decref(roc_host);
+pub extern fn roc_files_metadata(arg0: u64, arg1: RocStr) callconv(.c) HostFiles_metadataResult;
 
 /// Hosted symbol for Host.files_write_text!
-/// Roc signature: Str, Str => Try({}, [NoSpace, NotFound, PermissionDenied, Unavailable, WriteFailed])
+/// Roc signature: Resource.Authority, Str, Str => Try({}, [NoSpace, NotFound, PermissionDenied, Unavailable, WriteFailed])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg0.decref(roc_host);
 ///     arg1.decref(roc_host);
-pub extern fn roc_files_write_text(arg0: RocStr, arg1: RocStr) callconv(.c) HostFiles_write_textResult;
+///     arg2.decref(roc_host);
+pub extern fn roc_files_write_text(arg0: u64, arg1: RocStr, arg2: RocStr) callconv(.c) HostFiles_write_textResult;
 
 /// Hosted symbol for Host.files_write_bytes!
-/// Roc signature: Str, List(U8) => Try({}, [NoSpace, NotFound, PermissionDenied, Unavailable, WriteFailed])
+/// Roc signature: Resource.Authority, Str, List(U8) => Try({}, [NoSpace, NotFound, PermissionDenied, Unavailable, WriteFailed])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg0.decref(roc_host);
 ///     arg1.decref(roc_host);
-pub extern fn roc_files_write_bytes(arg0: RocStr, arg1: RocListWith(u8, false)) callconv(.c) HostFiles_write_textResult;
+///     arg2.decref(roc_host);
+pub extern fn roc_files_write_bytes(arg0: u64, arg1: RocStr, arg2: RocListWith(u8, false)) callconv(.c) HostFiles_write_textResult;
 
 /// Hosted symbol for Host.capture_set_virtual_mouse!
 /// Roc signature: { active : Bool, left : Bool, middle : Bool, right : Bool, wheel : F32, x : F32, y : F32 } => {}
@@ -17353,29 +17069,29 @@ pub extern fn roc_capture_set_virtual_keys(arg0: HostCapture_set_virtual_keysArg
 pub extern fn roc_capture_set_virtual_text(arg0: RocListWith(u32, false)) callconv(.c) void;
 
 /// Hosted symbol for Host.capture_start_recording!
-/// Roc signature: { cursor : U8, every_nth : U32, format : U8, fps : I32, max_frames : U64, path : Str, quality : U8, scale_denominator : U32, scale_numerator : U32, timing : U8 } => Try({}, [AlreadyRecording, Busy, PathEscapesOutputDir, PathInvalid, Unavailable, UnsupportedFormat, WriteFailed])
+/// Roc signature: Resource.Authority, { cursor : U8, every_nth : U32, format : U8, fps : I32, max_frames : U64, path : Str, quality : U8, scale_denominator : U32, scale_numerator : U32, timing : U8 } => Try({}, [AlreadyRecording, Busy, PathEscapesOutputDir, PathInvalid, PermissionDenied, Unavailable, UnsupportedFormat, WriteFailed])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg0.decref(roc_host);
-pub extern fn roc_capture_start_recording(arg0: HostCapture_start_recordingArgs) callconv(.c) HostCapture_start_recordingResult;
+///     arg1.decref(roc_host);
+pub extern fn roc_capture_start_recording(arg0: u64, arg1: __AnonStruct_96bd4e483c462501) callconv(.c) HostCapture_start_recordingResult;
 
 /// Hosted symbol for Host.capture_stop_recording!
-/// Roc signature: {} => Try({ bytes : U64, frames : U64 }, [BudgetExceeded, Busy, NotRecording, ReadbackFailed, TargetUnavailable, Unavailable])
-pub extern fn roc_capture_stop_recording() callconv(.c) HostCapture_stop_recordingResult;
+/// Roc signature: Resource.Authority => Try({ bytes : U64, frames : U64 }, [BudgetExceeded, Busy, NotRecording, PermissionDenied, ReadbackFailed, TargetUnavailable, Unavailable])
+pub extern fn roc_capture_stop_recording(arg0: u64) callconv(.c) HostCapture_stop_recordingResult;
 
 /// Hosted symbol for Host.capture_screenshot!
-/// Roc signature: Str => Try({}, [AlreadyPending, Busy, PathEscapesOutputDir, PathInvalid, Unavailable, WriteFailed])
+/// Roc signature: Resource.Authority, Str => Try({}, [AlreadyPending, Busy, PathEscapesOutputDir, PathInvalid, PermissionDenied, Unavailable, WriteFailed])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg0.decref(roc_host);
-pub extern fn roc_capture_screenshot(arg0: RocStr) callconv(.c) HostCapture_screenshotResult;
+///     arg1.decref(roc_host);
+pub extern fn roc_capture_screenshot(arg0: u64, arg1: RocStr) callconv(.c) HostCapture_screenshotResult;
 
 /// Hosted symbol for Host.capture_screenshot_texture!
-/// Roc signature: { path : Str, target : Texture } => Try({}, [BudgetExceeded, Busy, OutOfMemory, PathEscapesOutputDir, PathInvalid, ReadbackFailed, TargetUnavailable, Unavailable, WriteFailed])
+/// Roc signature: Resource.Authority, { path : Str, target : Texture } => Try({}, [BudgetExceeded, Busy, OutOfMemory, PathEscapesOutputDir, PathInvalid, PermissionDenied, ReadbackFailed, TargetUnavailable, Unavailable, WriteFailed])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg0.decref(roc_host);
-pub extern fn roc_capture_screenshot_texture(arg0: HostCapture_screenshot_textureArgs) callconv(.c) HostCapture_screenshot_textureResult;
+///     arg1.decref(roc_host);
+pub extern fn roc_capture_screenshot_texture(arg0: u64, arg1: __AnonStruct_aa2779af0bb79965) callconv(.c) HostCapture_screenshot_textureResult;
 
 /// Hosted symbol for Host.capture_pixel_at!
 /// Roc signature: { source : { screen : Bool, target : Texture }, x : I32, y : I32 } => Try({ a : U8, b : U8, g : U8, r : U8 }, [Busy, ReadbackFailed, RegionOutOfBounds, TargetUnavailable, Unavailable])
@@ -17402,20 +17118,12 @@ pub extern fn roc_app_exit(arg0: i32) callconv(.c) void;
 pub extern fn roc_app_args() callconv(.c) RocList(RocStr);
 
 /// Hosted symbol for Host.app_read_env!
-/// Roc signature: Str => Try(Str, [NotFound])
+/// Roc signature: Resource.Authority, Str => Try(Str, [NotFound, PermissionDenied])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg0.decref(roc_host);
+///     arg1.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_app_read_env(arg0: RocStr) callconv(.c) HostApp_read_envResult;
-
-/// Hosted symbol for Host.app_read_text!
-/// Roc signature: Str => Try(Str, [NotFound, ReadFailed])
-/// Owned arguments. Release each exactly once before returning, unless it is
-/// moved into storage or into the result:
-///     arg0.decref(roc_host);
-/// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_app_read_text_raw(arg0: RocStr) callconv(.c) HostApp_read_textResult;
+pub extern fn roc_app_read_env(arg0: u64, arg1: RocStr) callconv(.c) HostApp_read_envResult;
 
 /// Hosted symbol for Host.random_entropy!
 /// Roc signature: {} => U64
@@ -17430,16 +17138,16 @@ pub extern fn roc_random_i32(arg0: i32, arg1: i32) callconv(.c) i32;
 pub extern fn roc_keys_set_exit_key(arg0: i32) callconv(.c) void;
 
 /// Hosted symbol for Host.window_read_clipboard!
-/// Roc signature: {} => Try(Str, [Busy, TooLarge, Unavailable])
+/// Roc signature: Resource.Authority => Try(Str, [Busy, PermissionDenied, TooLarge, Unavailable])
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_window_read_clipboard() callconv(.c) HostWindow_read_clipboardResult;
+pub extern fn roc_window_read_clipboard(arg0: u64) callconv(.c) HostWindow_read_clipboardResult;
 
 /// Hosted symbol for Host.window_set_clipboard_text!
-/// Roc signature: Str => {}
+/// Roc signature: Resource.Authority, Str => Try({}, [PermissionDenied])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg0.decref(roc_host);
-pub extern fn roc_window_set_clipboard_text(arg0: RocStr) callconv(.c) void;
+///     arg1.decref(roc_host);
+pub extern fn roc_window_set_clipboard_text(arg0: u64, arg1: RocStr) callconv(.c) HostWindow_set_clipboard_textResult;
 
 /// Hosted symbol for Host.window_suggest_size!
 /// Roc signature: { height : I32, width : I32 } => Try({}, [NotSupported])
@@ -17490,12 +17198,12 @@ pub extern fn roc_task_sleep(arg0: u64) callconv(.c) void;
 pub extern fn roc_task_spawn(arg0: RocErasedCallable) callconv(.c) void;
 
 /// Hosted symbol for Host.tilemap_load_tmx!
-/// Roc signature: Str => Try({ gids : List(U64), height : U64, layers : List({ gid_count : U64, gid_start : U64, height : U64, name : Str, opacity : F32, property_count : U64, property_start : U64, visible : Bool, width : U64 }), map_property_count : U64, map_property_start : U64, objects : List({ height : F32, id : U64, kind : U8, name : Str, point_count : U64, point_start : U64, property_count : U64, property_start : U64, rotation : F32, type_name : Str, width : F32, x : F32, y : F32 }), points : List({ x : F32, y : F32 }), properties : List({ bool_value : Bool, integer : I64, kind : U8, name : Str, number : F32, text : Str }), tile_height : F32, tile_properties : List({ gid : U64, property_count : U64, property_start : U64 }), tile_width : F32, tilesets : List({ columns : U64, first_gid : U64, image_height : F32, image_source : Str, image_width : F32, name : Str, property_count : U64, property_start : U64, tile_count : U64, tile_height : F32, tile_width : F32 }), width : U64 }, [NotFound, ParseFailed, ReadFailed, Unsupported])
+/// Roc signature: Resource.Authority, Str => Try({ gids : List(U64), height : U64, layers : List({ gid_count : U64, gid_start : U64, height : U64, name : Str, opacity : F32, property_count : U64, property_start : U64, visible : Bool, width : U64 }), map_property_count : U64, map_property_start : U64, objects : List({ height : F32, id : U64, kind : U8, name : Str, point_count : U64, point_start : U64, property_count : U64, property_start : U64, rotation : F32, type_name : Str, width : F32, x : F32, y : F32 }), points : List({ x : F32, y : F32 }), properties : List({ bool_value : Bool, integer : I64, kind : U8, name : Str, number : F32, text : Str }), tile_height : F32, tile_properties : List({ gid : U64, property_count : U64, property_start : U64 }), tile_width : F32, tilesets : List({ columns : U64, first_gid : U64, image_height : F32, image_source : Str, image_width : F32, name : Str, property_count : U64, property_start : U64, tile_count : U64, tile_height : F32, tile_width : F32 }), width : U64 }, [NotFound, ParseFailed, PermissionDenied, ReadFailed, Unsupported])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg0.decref(roc_host);
+///     arg1.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_tilemap_load_tmx_raw(arg0: RocStr) callconv(.c) HostTilemap_load_tmxResult;
+pub extern fn roc_tilemap_load_tmx_raw(arg0: u64, arg1: RocStr) callconv(.c) HostTilemap_load_tmxResult;
 
 /// Hosted symbol for Host.tilemap_draw!
 /// Roc signature: { culled : Bool, gids : List(U64), layers : List({ gid_count : U64, gid_start : U64, height : U64, role : U8, visible : Bool, width : U64 }), map_tile_height : F32, map_tile_width : F32, max_col : U64, max_row : U64, min_col : U64, min_row : U64, origin_x : F32, origin_y : F32, selector_kind : U8, selector_value : U64, tilesets : List({ columns : U64, first_gid : U64, texture : Texture, tile_height : F32, tile_width : F32 }) } => {}
@@ -17616,45 +17324,45 @@ pub extern fn roc_shader_set_vec3_raw(arg0: HostShader_set_vec3Args) callconv(.c
 pub extern fn roc_shader_set_vec4_raw(arg0: HostShader_set_vec4Args) callconv(.c) void;
 
 /// Hosted symbol for Host.http_send!
-/// Roc signature: { body : List(U8), headers : List({ name : Str, value : Str }), max_response_bytes : U64, method : U8, method_ext : Str, timeout_ms : U64, uri : Str } => Try({ body : List(U8), headers : List({ name : Str, value : Str }), status : U16 }, [MalformedResponse, NetworkError, Other(Str), Timeout])
+/// Roc signature: Resource.Authority, { body : List(U8), headers : List({ name : Str, value : Str }), max_response_bytes : U64, method : U8, method_ext : Str, timeout_ms : U64, uri : Str } => Try({ body : List(U8), headers : List({ name : Str, value : Str }), status : U16 }, [MalformedResponse, NetworkError, Other(Str), PermissionDenied, Timeout])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg0.decref(roc_host);
+///     arg1.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_http_send(arg0: HostHttp_sendArgs) callconv(.c) HostHttp_sendResult;
+pub extern fn roc_http_send(arg0: u64, arg1: __AnonStruct_85380e02323174c5) callconv(.c) HostHttp_sendResult;
 
 /// Hosted symbol for Host.time_now!
 /// Roc signature: {} => { nanosecond : U32, seconds : I64 }
 pub extern fn roc_time_now() callconv(.c) __AnonStruct_bbf5049c4fa71893;
 
 /// Hosted symbol for Host.stdio_write_text!
-/// Roc signature: U8, Str => Try({}, [BufferFull, TooLarge, Unavailable])
+/// Roc signature: Resource.Authority, U8, Str => Try({}, [BufferFull, PermissionDenied, TooLarge, Unavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg1.decref(roc_host);
-pub extern fn roc_stdio_write_text(arg0: u8, arg1: RocStr) callconv(.c) HostStdio_write_textResult;
+///     arg2.decref(roc_host);
+pub extern fn roc_stdio_write_text(arg0: u64, arg1: u8, arg2: RocStr) callconv(.c) HostStdio_write_textResult;
 
 /// Hosted symbol for Host.stdio_write_line!
-/// Roc signature: U8, Str => Try({}, [BufferFull, TooLarge, Unavailable])
+/// Roc signature: Resource.Authority, U8, Str => Try({}, [BufferFull, PermissionDenied, TooLarge, Unavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg1.decref(roc_host);
-pub extern fn roc_stdio_write_line(arg0: u8, arg1: RocStr) callconv(.c) HostStdio_write_textResult;
+///     arg2.decref(roc_host);
+pub extern fn roc_stdio_write_line(arg0: u64, arg1: u8, arg2: RocStr) callconv(.c) HostStdio_write_textResult;
 
 /// Hosted symbol for Host.stdio_write_bytes!
-/// Roc signature: U8, List(U8) => Try({}, [BufferFull, TooLarge, Unavailable])
+/// Roc signature: Resource.Authority, U8, List(U8) => Try({}, [BufferFull, PermissionDenied, TooLarge, Unavailable])
+/// Owned arguments. Release each exactly once before returning, unless it is
+/// moved into storage or into the result:
+///     arg2.decref(roc_host);
+pub extern fn roc_stdio_write_bytes(arg0: u64, arg1: u8, arg2: RocListWith(u8, false)) callconv(.c) HostStdio_write_textResult;
+
+/// Hosted symbol for Host.udp_bind!
+/// Roc signature: Resource.Authority, { ip : Str, port : U16 } => Try({ handle : Resource.Handle([UdpSocketResource]), ip : U32, port : U16 }, [AddressInUse, AddressUnavailable, InvalidAddress, PermissionDenied, ResourceLimit, Unavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
 ///     arg1.decref(roc_host);
-pub extern fn roc_stdio_write_bytes(arg0: u8, arg1: RocListWith(u8, false)) callconv(.c) HostStdio_write_textResult;
-
-/// Hosted symbol for Host.udp_bind!
-/// Roc signature: { ip : Str, port : U16 } => Try({ handle : Resource.Handle([UdpSocketResource]), ip : U32, port : U16 }, [AddressInUse, AddressUnavailable, InvalidAddress, PermissionDenied, ResourceLimit, Unavailable])
-/// Owned arguments. Release each exactly once before returning, unless it is
-/// moved into storage or into the result:
-///     arg0.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_udp_bind(arg0: HostUdp_bindArgs) callconv(.c) HostUdp_bindResult;
+pub extern fn roc_udp_bind(arg0: u64, arg1: __AnonStruct_63b1422749dba501) callconv(.c) HostUdp_bindResult;
 
 /// Hosted symbol for Host.udp_send!
 /// Roc signature: { bytes : List(U8), ip : Str, port : U16, socket : Resource.Handle([UdpSocketResource]) } => Try({}, [InvalidAddress, NoRoute, PermissionDenied, SendFailed, TooLarge, Unavailable, WouldBlock])
@@ -17672,12 +17380,12 @@ pub extern fn roc_udp_send(arg0: HostUdp_sendArgs) callconv(.c) HostUdp_sendResu
 pub extern fn roc_udp_receive(arg0: HostUdp_receiveArgs) callconv(.c) HostUdp_receiveResult;
 
 /// Hosted symbol for Host.sqlite_open!
-/// Roc signature: Str, U8, U64, U64 => Try(Resource.Handle([SqliteDbResource]), [SqliteErr({ code : I64, message : Str }), TooManyConnections])
+/// Roc signature: Resource.Authority, Str, U8, U64, U64 => Try(Resource.Handle([SqliteDbResource]), [PermissionDenied, SqliteErr({ code : I64, message : Str }), TooManyConnections])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg0.decref(roc_host);
+///     arg1.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_sqlite_open(arg0: RocStr, arg1: u8, arg2: u64, arg3: u64) callconv(.c) HostSqlite_openResult;
+pub extern fn roc_sqlite_open(arg0: u64, arg1: RocStr, arg2: u8, arg3: u64, arg4: u64) callconv(.c) HostSqlite_openResult;
 
 /// Hosted symbol for Host.sqlite_close!
 /// Roc signature: Resource.Handle([SqliteDbResource]) => Try({}, [SqliteErr({ code : I64, message : Str })])
@@ -17725,12 +17433,12 @@ pub extern fn roc_sqlite_run_once(arg0: *u64, arg1: RocStr, arg2: RocList(__Anon
 pub extern fn roc_sqlite_exec_script(arg0: *u64, arg1: RocStr) callconv(.c) HostSqlite_closeResult;
 
 /// Hosted symbol for Host.cmd_run!
-/// Roc signature: { args : List(Str), clear_envs : Bool, envs : List({ name : Str, value : Str }), program : Str, stderr_limit_bytes : U64, stdout_limit_bytes : U64, timeout_ms : U64, working_dir : Str } => Try({ exit_code : I64, stderr : List(U8), stdout : List(U8) }, [Busy, CommandNotFound, PermissionDenied, SpawnFailed, StderrLimitExceeded, StdoutLimitExceeded, Timeout({ exit_code : I64, stderr : List(U8), stdout : List(U8) }), Unavailable])
+/// Roc signature: Resource.Authority, { args : List(Str), clear_envs : Bool, envs : List({ name : Str, value : Str }), program : Str, stderr_limit_bytes : U64, stdout_limit_bytes : U64, timeout_ms : U64, working_dir : Str } => Try({ exit_code : I64, stderr : List(U8), stdout : List(U8) }, [Busy, CommandNotFound, PermissionDenied, SpawnFailed, StderrLimitExceeded, StdoutLimitExceeded, Timeout({ exit_code : I64, stderr : List(U8), stdout : List(U8) }), Unavailable])
 /// Owned arguments. Release each exactly once before returning, unless it is
 /// moved into storage or into the result:
-///     arg0.decref(roc_host);
+///     arg1.decref(roc_host);
 /// The result is owned by Roc: return exactly one owned reference.
-pub extern fn roc_cmd_run(arg0: HostCmd_runArgs) callconv(.c) HostCmd_runResult;
+pub extern fn roc_cmd_run(arg0: u64, arg1: __AnonStruct_3fe396bc5ba0c31c) callconv(.c) HostCmd_runResult;
 
 /// Hosted symbol for Host.trace_mark!
 /// Roc signature: Str => {}
@@ -17907,10 +17615,10 @@ pub fn makeRocHost(env: *RocEnv) RocHost {
 pub extern fn app_config_for_host() callconv(.c) __AnonStruct_a868748fcc059834;
 
 /// Entrypoint: init_for_host!
-pub extern fn init_for_host() callconv(.c) Init_for_hostResult;
+pub extern fn init_for_host(arg0: u64) callconv(.c) Init_for_hostResult;
 
 /// Entrypoint: update_for_host!
-pub extern fn update_for_host(arg0: RocBox, arg1: __AnonStruct_cf3def8e4b7f351) callconv(.c) Update_for_hostResult;
+pub extern fn update_for_host(arg0: RocBox, arg1: __AnonStruct_cf3def8e4b7f351, arg2: u64) callconv(.c) Update_for_hostResult;
 
 /// Entrypoint: render_for_host!
 pub extern fn render_for_host(arg0: RocBox) callconv(.c) Render_for_hostResult;

--- a/test/asset_store_compile.roc
+++ b/test/asset_store_compile.roc
@@ -15,8 +15,8 @@ program = { init!, update!, render! }
 init! : App.Init(Model, _)
 init! = App.init(
 	App.default,
-	|_startup| {
-		store = Assets.Store.open!(
+	|io| {
+		store = io.assets().open!(
 			Assets.with_manifest(
 				Assets.beside_executable("assets"),
 				{
@@ -36,8 +36,8 @@ init! = App.init(
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, _input| Ok(model)
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, _input, _io| Ok(model)
 
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])
 render! = |_model, _frame| Ok({})

--- a/test/capabilities/main.roc
+++ b/test/capabilities/main.roc
@@ -1,0 +1,90 @@
+app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-2026-09-07-14d9829" }
+
+import rr.App
+import rr.Assets
+import rr.Cmd
+import rr.Capture
+import rr.Files
+import rr.Task
+
+Model : { allowed : Bool }
+
+Msg : [Checked(Bool)]
+
+program = { init!, update!, render! }
+
+denied : Try(a, [PermissionDenied, ..]) -> Bool
+denied = |result| match result {
+	Err(PermissionDenied) => Bool.True
+	_ => Bool.False
+}
+
+init! : App.Init(Model, [Failed])
+init! = App.init(
+	App.default.with_default_font({ path: "missing.ttf", size: 20 }),
+	|io| {
+		args = io.args!()
+		if args.contains("--probe-crash") {
+			crash "DENIED_OUTPUT_LEAK"
+		}
+		allowed = args.contains("--expect-allowed")
+		if !denied(App.Io.stub.files().write_text!("stub.txt", "must never be written")) {
+			return Err(Failed)
+		}
+		if args.contains("--host-caps-allow-all") {
+			return Err(Failed)
+		}
+		if !allowed {
+			ok = denied(io.default_font!())
+				and denied(io.http().get_utf8!("http://127.0.0.1:1/"))
+					and denied(io.commands().run!(Cmd.new("roc-ray-caps-command-must-not-run")))
+						and denied(io.udp().bind!({ ip: "127.0.0.1", port: 0 }))
+							and denied(io.assets().open!(Assets.working_directory(".")))
+								and denied(io.files().read_text!("missing.txt"))
+									and denied(io.files().write_text!("denied.txt", "must never be written"))
+										and denied(io.env().read!("PATH"))
+											and denied(io.sqlite().open!(":memory:"))
+												and denied(io.audio().load_sound!("missing.wav"))
+													and denied(io.audio().load_music!("missing.ogg"))
+														and denied(io.tilemaps().load_tmx!("missing.tmx"))
+															and denied(io.clipboard().read_text!())
+																and denied(io.clipboard().set_text!("must never reach the clipboard"))
+																	and denied(io.stdout().line!("DENIED_OUTPUT_LEAK"))
+																		and denied(io.stderr().line!("DENIED_OUTPUT_LEAK"))
+																			and denied(io.capture().start!(Capture.default))
+																				and denied(io.capture().stop!())
+			if !ok {
+				return Err(Failed)
+			}
+		}
+		Ok(
+			{ allowed: allowed },
+		)
+	},
+)
+
+check! : Files.Access, Bool => Msg
+check! = |files, allowed| {
+	result = files.write_text!("task.txt", "task authority")
+	if allowed {
+		Checked(result == Ok({}) and files.read_text!("task.txt") == Ok("task authority"))
+	} else {
+		Checked(denied(result))
+	}
+}
+
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, input, io| {
+	if input.time.cycle_count == 0 {
+		files = io.files()
+		Task.spawn!(input, || check!(files, model.allowed))
+	}
+	match List.first(input.messages) {
+		Ok(Checked(Bool.True)) => Err(Exit(0))
+		Ok(Checked(Bool.False)) => Err(Exit(3))
+		Err(_) => if input.time.cycle_count > 120 Err(Exit(4)) else Ok(model)
+	}
+}
+
+render! : Model, _ => Try({}, [Exit(I64), ..])
+render! = |_model, _frame| Ok({})

--- a/test/cli_args/main.roc
+++ b/test/cli_args/main.roc
@@ -21,12 +21,12 @@ config_for_args = |args|
 	}
 
 init! : App.Init(Model, [])
-init! = App.init_for_args(config_for_args, |startup| Ok({ args: App.args!(startup) }))
+init! = App.init_for_args(config_for_args, |io| Ok({ args: io.args!() }))
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, _io| {
 	passed =
 		List.len(model.args) == 3
 			and List.contains(model.args, config_flag)

--- a/test/cmd/main.roc
+++ b/test/cmd/main.roc
@@ -25,7 +25,7 @@ Msg : [Checked(U64)]
 program = { init!, update!, render! }
 
 init! : App.Init(Model, [])
-init! = App.init(App.default.with_title("cmd"), |_startup| Ok({ started_cycle: 0 }))
+init! = App.init(App.default.with_title("cmd"), |_io| Ok({ started_cycle: 0 }))
 
 ## A correct run scores every bit. Any property that does not hold subtracts
 ## its own bit, so the exit code's companion -- the score -- says which one.
@@ -62,13 +62,13 @@ expect score(Bool.False, 4) == 0
 
 ## Run every command and score what came back. Runs on a task, where `run!`
 ## parks rather than blocking.
-check! : () => Msg
-check! = || {
+check! : App.Io => Msg
+check! = |io| {
 	# Which shell this machine has. `/bin/sh` is on every POSIX target and on
 	# none of the Windows ones, so one stat decides it without the platform
 	# having to name the operating system.
 	posix =
-		match Files.metadata!("/bin/sh") {
+		match io.files().metadata!("/bin/sh") {
 			Ok(_) => Bool.True
 			Err(_) => Bool.False
 		}
@@ -82,7 +82,7 @@ check! = || {
 	# on Windows, so this asks whether the text is in the output rather than
 	# whether it is the whole of it.
 	echoed =
-		match Cmd.run!(Cmd.new(shell).with_args(echo_args)) {
+		match io.commands().run!(Cmd.new(shell).with_args(echo_args)) {
 			Ok(output) =>
 				output.exit_code == 0 and Str.contains(Str.from_utf8_lossy(output.stdout), probe_text)
 
@@ -91,17 +91,17 @@ check! = || {
 
 	# A program that is not there is named, rather than reported as a generic
 	# failure or as a child that exited non-zero.
-	missing = Cmd.run!(Cmd.new("roc-ray-definitely-not-a-program")) == Err(CommandNotFound)
+	missing = io.commands().run!(Cmd.new("roc-ray-definitely-not-a-program")) == Err(CommandNotFound)
 
 	# More output than the command allowed is refused outright: no truncated
 	# prefix, and no `Ok`.
 	bounded =
-		Cmd.run!(Cmd.new(shell).with_args(echo_args).with_stdout_limit(2))
+		io.commands().run!(Cmd.new(shell).with_args(echo_args).with_stdout_limit(2))
 			== Err(StdoutLimitExceeded)
 
 	# A non-zero exit status is data. It arrives as `Ok`, carrying the code.
 	exited =
-		match Cmd.run!(Cmd.new(shell).with_args(exit_args)) {
+		match io.commands().run!(Cmd.new(shell).with_args(exit_args)) {
 			Ok(output) => output.exit_code == 3
 			Err(_) => Bool.False
 		}
@@ -109,7 +109,7 @@ check! = || {
 	# The deadline expires and the host kills the child, rather than waiting
 	# out the thirty seconds the command asked for.
 	timed_out =
-		match Cmd.run!(Cmd.new(shell).with_args(sleep_args).with_timeout_ms(timeout_ms)) {
+		match io.commands().run!(Cmd.new(shell).with_args(sleep_args).with_timeout_ms(timeout_ms)) {
 			Err(Timeout(_)) => Bool.True
 			Ok(_) => Bool.False
 			Err(_) => Bool.False
@@ -118,7 +118,7 @@ check! = || {
 	# A working directory that is not there is refused, and is not confused
 	# with the program being missing.
 	no_such_dir =
-		Cmd.run!(Cmd.new(shell).with_args(exit_args).with_working_dir("roc-ray-no-such-dir"))
+		io.commands().run!(Cmd.new(shell).with_args(exit_args).with_working_dir("roc-ray-no-such-dir"))
 			== Err(SpawnFailed)
 
 	Checked(
@@ -131,11 +131,11 @@ check! = || {
 	)
 }
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, input, io| {
 	cycle = input.time.cycle_count
 	if cycle == 0 {
-		Task.spawn!(input, check!)
+		Task.spawn!(input, || check!(io))
 	}
 
 	match List.first(input.messages) {

--- a/test/compile_fail/app_config_module.roc
+++ b/test/compile_fail/app_config_module.roc
@@ -9,12 +9,12 @@ Model : {}
 program = { init!, update!, render! }
 
 init! : App.Init(Model, [])
-init! = App.init(App.default, |_startup| Ok({}))
+init! = App.init(App.default, |io| Ok({}))
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, _input| Ok(model)
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, _input, _io| Ok(model)
 
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])
 render! = |_model, _frame| Ok({})

--- a/test/compile_fail/app_config_to_host.roc
+++ b/test/compile_fail/app_config_to_host.roc
@@ -8,12 +8,12 @@ Model : {}
 program = { init!, update!, render! }
 
 init! : App.Init(Model, [])
-init! = App.init(App.default, |_startup| Ok({}))
+init! = App.init(App.default, |io| Ok({}))
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, _input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, _input, io| {
 	_transport = App.default.to_host()
 	Ok(model)
 }

--- a/test/compile_fail/app_host_config.roc
+++ b/test/compile_fail/app_host_config.roc
@@ -36,12 +36,12 @@ transport = {
 program = { init!, update!, render! }
 
 init! : App.Init(Model, [])
-init! = App.init(App.default, |_startup| Ok({}))
+init! = App.init(App.default, |io| Ok({}))
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, _input| Ok(model)
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, _input, _io| Ok(model)
 
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])
 render! = |_model, _frame| Ok({})

--- a/test/compile_fail/audio_resource_kind_confusion.roc
+++ b/test/compile_fail/audio_resource_kind_confusion.roc
@@ -16,7 +16,7 @@ program = { init!, update!, render! }
 init! : App.Init(Model, [])
 init! = App.init(
 	App.default,
-	|_startup| {
+	|io| {
 		use_sound(Audio.Music.stub)
 		Ok({})
 	},
@@ -27,8 +27,8 @@ use_sound = |_sound| {}
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, _input| Ok(model)
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, _input, _io| Ok(model)
 
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])
 render! = |_model, _frame| Ok({})

--- a/test/compile_fail/file_module_removed.roc
+++ b/test/compile_fail/file_module_removed.roc
@@ -10,12 +10,12 @@ Model : {}
 program = { init!, update!, render! }
 
 init! : App.Init(Model, [])
-init! = App.init(App.default, |_startup| Ok({}))
+init! = App.init(App.default, |io| Ok({}))
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, _input| Ok(model)
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, _input, _io| Ok(model)
 
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])
 render! = |_model, _frame| Ok({})

--- a/test/compile_fail/font_handle_manufacture.roc
+++ b/test/compile_fail/font_handle_manufacture.roc
@@ -19,7 +19,7 @@ program = { init!, update!, render! }
 init! : App.Init(Model, [])
 init! = App.init(
 	App.default,
-	|_startup| {
+	|io| {
 		handle : Box(U64)
 		handle = Box.box(0)
 		Ok({
@@ -30,8 +30,8 @@ init! = App.init(
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, _input| Ok(model)
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, _input, _io| Ok(model)
 
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])
 render! = |_model, _frame| Ok({})

--- a/test/compile_fail/host_module.roc
+++ b/test/compile_fail/host_module.roc
@@ -9,12 +9,12 @@ Model : {}
 program = { init!, update!, render! }
 
 init! : App.Init(Model, [])
-init! = App.init(App.default, |_startup| Ok({}))
+init! = App.init(App.default, |io| Ok({}))
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, _input| Ok(model)
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, _input, _io| Ok(model)
 
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])
 render! = |_model, _frame| Ok({})

--- a/test/compile_fail/http_client_manufacture.roc
+++ b/test/compile_fail/http_client_manufacture.roc
@@ -2,14 +2,16 @@ app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-202
 
 import rr.App
 import rr.Draw
-import rr.Devices
+import rr.Http
 
-Model : { raw : List(Devices.RawEvent) }
+Model : {
+	db : Http.Client,
+}
 
 program = { init!, update!, render! }
 
 init! : App.Init(Model, [])
-init! = App.init(App.default, |io| Ok({ raw: [] }))
+init! = App.init(App.default, |io| Ok({ db: Http.Client.(0) }))
 
 Msg : []
 

--- a/test/compile_fail/input_module_removed.roc
+++ b/test/compile_fail/input_module_removed.roc
@@ -9,12 +9,12 @@ Model : {}
 program = { init!, update!, render! }
 
 init! : App.Init(Model, [])
-init! = App.init(App.default, |_startup| Ok({}))
+init! = App.init(App.default, |io| Ok({}))
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, _input| Ok(model)
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, _input, _io| Ok(model)
 
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])
 render! = |_model, _frame| Ok({})

--- a/test/compile_fail/input_spawn_receiver.roc
+++ b/test/compile_fail/input_spawn_receiver.roc
@@ -12,12 +12,12 @@ Model : {}
 program = { init!, update!, render! }
 
 init! : App.Init(Model, [])
-init! = App.init(App.default, |_startup| Ok({}))
+init! = App.init(App.default, |io| Ok({}))
 
 Msg : [Woke]
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, input, io| {
 	input.spawn!(|| Woke)
 	Ok(model)
 }

--- a/test/compile_fail/io_manufacture.roc
+++ b/test/compile_fail/io_manufacture.roc
@@ -2,14 +2,15 @@ app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-202
 
 import rr.App
 import rr.Draw
-import rr.Devices
 
-Model : { raw : List(Devices.RawEvent) }
+Model : {
+	db : App.Io,
+}
 
 program = { init!, update!, render! }
 
 init! : App.Init(Model, [])
-init! = App.init(App.default, |io| Ok({ raw: [] }))
+init! = App.init(App.default, |io| Ok({ db: App.Io.(0) }))
 
 Msg : []
 

--- a/test/compile_fail/program_module_removed.roc
+++ b/test/compile_fail/program_module_removed.roc
@@ -9,12 +9,12 @@ Model : {}
 program = { init!, update!, render! }
 
 init! : App.Init(Model, [])
-init! = App.init(App.default, |_startup| Ok({}))
+init! = App.init(App.default, |io| Ok({}))
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, _input| Ok(model)
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, _input, _io| Ok(model)
 
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])
 render! = |_model, _frame| Ok({})

--- a/test/compile_fail/resource_handle_kind_confusion.roc
+++ b/test/compile_fail/resource_handle_kind_confusion.roc
@@ -17,7 +17,7 @@ program = { init!, update!, render! }
 init! : App.Init(Model, [])
 init! = App.init(
 	App.default,
-	|_startup| {
+	|io| {
 		use_font_handle(Texture.stub.handle)
 		Ok({})
 	},
@@ -28,8 +28,8 @@ use_font_handle = |_handle| {}
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, _input| Ok(model)
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, _input, _io| Ok(model)
 
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])
 render! = |_model, _frame| Ok({})

--- a/test/compile_fail/resource_module_private.roc
+++ b/test/compile_fail/resource_module_private.roc
@@ -9,12 +9,12 @@ Model : {}
 program = { init!, update!, render! }
 
 init! : App.Init(Model, [])
-init! = App.init(App.default, |_startup| Ok({}))
+init! = App.init(App.default, |io| Ok({}))
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, _input| Ok(model)
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, _input, _io| Ok(model)
 
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])
 render! = |_model, _frame| Ok({})

--- a/test/compile_fail/service_kind_confusion.roc
+++ b/test/compile_fail/service_kind_confusion.roc
@@ -2,14 +2,23 @@ app [Model, program] { rr: platform "../../platform/main.roc", roc: "nightly-202
 
 import rr.App
 import rr.Draw
-import rr.Devices
+import rr.Http
 
-Model : { raw : List(Devices.RawEvent) }
+Model : {
+	db : Http.Client,
+}
 
 program = { init!, update!, render! }
 
 init! : App.Init(Model, [])
-init! = App.init(App.default, |io| Ok({ raw: [] }))
+init! = App.init(
+	App.default,
+	|io| {
+		client : Http.Client
+		client = io.files()
+		Ok({ db: client })
+	},
+)
 
 Msg : []
 

--- a/test/compile_fail/shader_handle_manufacture.roc
+++ b/test/compile_fail/shader_handle_manufacture.roc
@@ -17,7 +17,7 @@ program = { init!, update!, render! }
 init! : App.Init(Model, [])
 init! = App.init(
 	App.default,
-	|_startup| {
+	|io| {
 		handle = Box.box(0)
 		Ok({ shader: Draw.Shader.(handle) })
 	},
@@ -25,8 +25,8 @@ init! = App.init(
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, _input| Ok(model)
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, _input, _io| Ok(model)
 
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])
 render! = |_model, _frame| Ok({})

--- a/test/compile_fail/sound_handle_manufacture.roc
+++ b/test/compile_fail/sound_handle_manufacture.roc
@@ -17,7 +17,7 @@ program = { init!, update!, render! }
 init! : App.Init(Model, [])
 init! = App.init(
 	App.default,
-	|_startup| {
+	|io| {
 		handle = Box.box(0)
 		Ok({ sound: Audio.Sound.(handle) })
 	},
@@ -25,8 +25,8 @@ init! = App.init(
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, _input| Ok(model)
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, _input, _io| Ok(model)
 
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])
 render! = |_model, _frame| Ok({})

--- a/test/compile_fail/sqlite_db_manufacture.roc
+++ b/test/compile_fail/sqlite_db_manufacture.roc
@@ -14,12 +14,12 @@ Model : {
 program = { init!, update!, render! }
 
 init! : App.Init(Model, [])
-init! = App.init(App.default, |_startup| Ok({ db: Sqlite.Db.(Box.box(0)) }))
+init! = App.init(App.default, |io| Ok({ db: Sqlite.Db.(Box.box(0)) }))
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, _input| Ok(model)
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, _input, _io| Ok(model)
 
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])
 render! = |_model, _frame| Ok({})

--- a/test/compile_fail/texture_handle_manufacture.roc
+++ b/test/compile_fail/texture_handle_manufacture.roc
@@ -19,7 +19,7 @@ program = { init!, update!, render! }
 init! : App.Init(Model, [])
 init! = App.init(
 	App.default,
-	|_startup| {
+	|io| {
 		handle : Box(U64)
 		handle = Box.box(0)
 		Ok({ texture: { ..Texture.stub, handle } })
@@ -28,8 +28,8 @@ init! = App.init(
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, _input| Ok(model)
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, _input, _io| Ok(model)
 
 render! : Model, Draw.Frame => Try({}, [Exit(I64), ..])
 render! = |_model, _frame| Ok({})

--- a/test/compile_fail/transition_removed.roc
+++ b/test/compile_fail/transition_removed.roc
@@ -12,12 +12,12 @@ Model : {}
 program = { init!, update!, render! }
 
 init! : App.Init(Model, [])
-init! = App.init(App.default, |_startup| Ok({}))
+init! = App.init(App.default, |io| Ok({}))
 
 Msg : []
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, _input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, _input, io| {
 	_ = App.next(model)
 	Ok(model)
 }

--- a/test/file_write/main.roc
+++ b/test/file_write/main.roc
@@ -21,7 +21,7 @@ Msg : [Checked(U64)]
 program = { init!, update!, render! }
 
 init! : App.Init(Model, [])
-init! = App.init(App.default.with_title("file write"), |_startup| Ok({ checked: Bool.False }))
+init! = App.init(App.default.with_title("file write"), |_io| Ok({ checked: Bool.False }))
 
 ## A correct run scores every bit. Any property that does not hold subtracts
 ## its own bit, so the exit code says which half of the probe went wrong.
@@ -48,29 +48,29 @@ expect score(Bool.False, 4) == 0
 expect 1 + 2 + 4 + 8 + 16 + 32 + 64 == expected_score
 
 ## Write, read back, compare. Runs on a task, where every call parks.
-check! : () => Msg
-check! = || {
-	wrote_text = Files.write_text!("probe_out/text.txt", probe_text) == Ok({})
-	read_text_back = Files.read_text!("probe_out/text.txt") == Ok(probe_text)
+check! : App.Io => Msg
+check! = |io| {
+	wrote_text = io.files().write_text!("probe_out/text.txt", probe_text) == Ok({})
+	read_text_back = io.files().read_text!("probe_out/text.txt") == Ok(probe_text)
 
-	wrote_bytes = Files.write_bytes!("probe_out/blob.bin", probe_bytes) == Ok({})
-	read_bytes_back = Files.read_bytes!("probe_out/blob.bin") == Ok(probe_bytes)
+	wrote_bytes = io.files().write_bytes!("probe_out/blob.bin", probe_bytes) == Ok({})
+	read_bytes_back = io.files().read_bytes!("probe_out/blob.bin") == Ok(probe_bytes)
 
 	# A second write replaces the file rather than appending to it or leaving
 	# the tail of the longer contents in place.
 	replaced =
-		Files.write_bytes!("probe_out/blob.bin", [1, 2, 3]) == Ok({})
-			and Files.read_bytes!("probe_out/blob.bin") == Ok([1, 2, 3])
+		io.files().write_bytes!("probe_out/blob.bin", [1, 2, 3]) == Ok({})
+			and io.files().read_bytes!("probe_out/blob.bin") == Ok([1, 2, 3])
 
 	# Missing parent directories are created, so a first save does not need a
 	# separate step to make its directory.
 	made_parents =
-		Files.write_text!("probe_out/nested/deep/save.json", "{}") == Ok({})
-			and Files.read_text!("probe_out/nested/deep/save.json") == Ok("{}")
+		io.files().write_text!("probe_out/nested/deep/save.json", "{}") == Ok({})
+			and io.files().read_text!("probe_out/nested/deep/save.json") == Ok("{}")
 
 	# A path whose parent is a file cannot be created, and says so with the
 	# named error rather than by pretending to succeed.
-	refused = Files.write_text!("probe_out/text.txt/nope.txt", "x") == Err(NotFound)
+	refused = io.files().write_text!("probe_out/text.txt/nope.txt", "x") == Err(NotFound)
 
 	Checked(
 		score(wrote_text, 1)
@@ -83,10 +83,10 @@ check! = || {
 	)
 }
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, input, io| {
 	if input.time.cycle_count == 0 {
-		Task.spawn!(input, check!)
+		Task.spawn!(input, || check!(io))
 	}
 
 	match List.first(input.messages) {

--- a/test/http_fetch/main.roc
+++ b/test/http_fetch/main.roc
@@ -51,8 +51,8 @@ program = { init!, update!, render! }
 init! : App.Init(Model, [])
 init! = App.init_for_args(
 	|_args| App.default,
-	|startup| {
-		args = App.args!(startup)
+	|io| {
+		args = io.args!()
 		expected_error = flag_value(args, "--http-expect-error", "")
 		Ok({
 			url: flag_value(args, "--http-url", ""),
@@ -92,12 +92,12 @@ flag_number = |args, flag, fallback| {
 	}
 }
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, input, io| {
 	if model.cycle == 0 {
 		url = model.url
 		config = model.config
-		Task.spawn!(input, || fetch!(config, url))
+		Task.spawn!(input, || fetch!(io, config, url))
 	}
 	outcome = List.fold(input.messages, model.outcome, |current, message| judge(current, message, model.expectation))
 	next = { ..model, cycle: model.cycle + 1, outcome }
@@ -115,9 +115,9 @@ update! = |model, input| {
 
 ## The whole exchange, written as if it were synchronous. It is not: the host
 ## parks this coroutine on the socket and the frame loop keeps running.
-fetch! : Http.Config, Str => Msg
-fetch! = |config, url|
-	match Http.send_with!(config, Request.from_method(GET).with_uri(url)) {
+fetch! : App.Io, Http.Config, Str => Msg
+fetch! = |io, config, url|
+	match io.http().send_with!(config, Request.from_method(GET).with_uri(url)) {
 		Ok(response) =>
 			match Str.from_utf8(Response.body(response)) {
 				Ok(text) => Fetched(Response.status(response), text, List.len(Response.headers(response)))
@@ -156,9 +156,10 @@ judge = |current, message, expectation|
 		}
 
 ## Name a send failure without depending on how the platform renders it.
-describe : [InvalidUrl(_), HttpErr([Timeout, NetworkError, MalformedResponse, Other(List(U8))])] -> Str
+describe : [PermissionDenied, InvalidUrl(_), HttpErr([Timeout, NetworkError, MalformedResponse, Other(List(U8))])] -> Str
 describe = |err|
 	match err {
+		PermissionDenied => "HTTP access was not granted"
 		InvalidUrl(_) => "the URL was rejected before any host effect ran"
 		HttpErr(Timeout) => "the request timed out"
 		HttpErr(NetworkError) => "the request failed at the network layer"

--- a/test/model_inplace/main.roc
+++ b/test/model_inplace/main.roc
@@ -57,21 +57,22 @@ point_count = 1_000_000
 
 program = { init!, update!, render! }
 
-init! : App.Init(Model, [])
+init! : App.Init(Model, [PermissionDenied])
 init! = App.init(
 	App.default.with_title("Model allocation probe"),
-	|startup| {
+	|io| {
 		requested =
-			match App.read_env!(startup, "ROC_RAY_MODEL_PATTERN") {
-				Ok(value) => value
-				Err(NotFound) => "set"
+			match io.env().read!("ROC_RAY_MODEL_PATTERN") {
+				Ok(value) => Ok(value)
+				Err(NotFound) => Ok("set")
+				Err(PermissionDenied) => Err(PermissionDenied)
 			}
 
 		Ok({
 			points: List.repeat(0.0, point_count),
 			trail: [],
 			cursor: 0,
-			pattern: parse_pattern(requested),
+			pattern: parse_pattern(requested?),
 		})
 	},
 )
@@ -100,8 +101,8 @@ parse_pattern = |name|
 ##
 ## Every branch uses the ordinary record-update spread an app would write,
 ## except `SetWithoutSpread`, which exists to price the spread itself.
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, _input|
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, _input, _io|
 	match model.pattern {
 		SetInPlace =>
 			Ok({ ..model, points: set_point(model.points, model.cursor), cursor: model.cursor + 1 })

--- a/test/observatory/main.roc
+++ b/test/observatory/main.roc
@@ -13,17 +13,20 @@ Msg : [TaskDone(Str)]
 program = { init!, update!, render! }
 
 init! : App.Init(Model, Msg)
-init! = App.init(App.default.with_title("Observatory probe"), |_startup| {
-	_init_sentinel = Files.write_text!("observatory-init-ran", "init")
-	Trace.mark!("probe init")
-	startup_zone = Trace.begin!("probe startup wait")
-	Task.sleep!(2)
-	Trace.end!(startup_zone)
-	Ok({ cycles: 0 })
-})
+init! = App.init(
+	App.default.with_title("Observatory probe"),
+	|io| {
+		_init_sentinel = io.files().write_text!("observatory-init-ran", "init")
+		Trace.mark!("probe init")
+		startup_zone = Trace.begin!("probe startup wait")
+		Task.sleep!(2)
+		Trace.end!(startup_zone)
+		Ok({ cycles: 0 })
+	},
+)
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, input, _io| {
 	zone = Trace.begin!("probe update")
 	Trace.sample_i64!("probe items", 7, Count)
 	Trace.sample_f64!("load ratio", 0.5, Ratio)
@@ -51,7 +54,12 @@ update! = |model, input| {
 			},
 		)
 	}
-	done = List.any(input.messages, |msg| match msg { TaskDone(_) => Bool.True })
+	done = List.any(
+		input.messages,
+		|msg| match msg {
+			TaskDone(_) => Bool.True
+		},
+	)
 	if input.time.cycle_count >= 2 and done {
 		Err(Exit(0))
 	} else {

--- a/test/observatory_abrupt/main.roc
+++ b/test/observatory_abrupt/main.roc
@@ -6,15 +6,16 @@ import rr.Trace
 ## Long-running headless fixture terminated by the host test to verify that a
 ## real process kill leaves a committed, explicitly unclean SQLite prefix.
 Model : U64
+
 Msg : [Unused]
 
 program = { init!, update!, render! }
 
 init! : App.Init(Model, Msg)
-init! = App.init(App.default.with_title("Observatory abrupt probe"), |_startup| Ok(0))
+init! = App.init(App.default.with_title("Observatory abrupt probe"), |_io| Ok(0))
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, _input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, _input, _io| {
 	Trace.sample_i64!("abrupt cycles", 1, Count)
 	Ok(model + 1)
 }

--- a/test/observatory_perf/main.roc
+++ b/test/observatory_perf/main.roc
@@ -17,12 +17,14 @@ Msg : []
 program = { init!, update!, render! }
 
 init! : App.Init(Model, Msg)
-init! = App.init(App.default.with_title("Observatory performance probe"), |_startup|
-	Ok({ cycle: 0, values: List.repeat(0, 64) }),
+init! = App.init(
+	App.default.with_title("Observatory performance probe"),
+	|_io|
+		Ok({ cycle: 0, values: List.repeat(0, 64) }),
 )
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, _input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, _input, _io| {
 	zone = Trace.begin!("benchmark update")
 	index = model.cycle % List.len(model.values)
 	values = match List.set(model.values, index, model.cycle) {

--- a/test/sqlite/main.roc
+++ b/test/sqlite/main.roc
@@ -23,7 +23,7 @@ Msg : [Checked(U64)]
 program = { init!, update!, render! }
 
 init! : App.Init(Model, [])
-init! = App.init(App.default.with_title("sqlite"), |_startup| Ok({ checked: Bool.False }))
+init! = App.init(App.default.with_title("sqlite"), |_io| Ok({ checked: Bool.False }))
 
 ## A correct run scores every bit. Any property that does not hold subtracts
 ## its own bit, so the exit code says which property went wrong.
@@ -52,17 +52,17 @@ schema : Str
 schema = "CREATE TABLE kinds(i INTEGER NOT NULL, r REAL NOT NULL, s TEXT NOT NULL, b BLOB NOT NULL, n TEXT); CREATE TABLE unique_names(name TEXT NOT NULL UNIQUE);"
 
 ## Write every `Value` kind, read them back, and compare.
-check! : () => Msg
-check! = || {
+check! : App.Io => Msg
+check! = |io| {
 	# Opening a database does not create its parent directory, so make one the
 	# way an app would. A write creates the tree on its way.
-	match Files.write_bytes!("probe_out/.keep", []) {
+	match io.files().write_bytes!("probe_out/.keep", []) {
 		Ok({}) => {}
 		Err(_) => return Checked(0)
 	}
 
 	db =
-		match Sqlite.Db.open!("probe_out/probe.db") {
+		match io.sqlite().open!("probe_out/probe.db") {
 			Ok(opened) => opened
 			Err(_) => return Checked(0)
 		}
@@ -202,10 +202,10 @@ error_paths! = |db| {
 	)
 }
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, input, io| {
 	if !model.checked {
-		Task.spawn!(input, check!)
+		Task.spawn!(input, || check!(io))
 		Ok({ checked: Bool.True })
 	} else {
 		match List.first(input.messages) {

--- a/test/task_cap/main.roc
+++ b/test/task_cap/main.roc
@@ -21,7 +21,7 @@ Msg : [Done(U64)]
 program = { init!, update!, render! }
 
 init! : App.Init(Model, [])
-init! = App.init(App.default.with_title("task cap"), |_startup| Ok({ seen: 0, sum: 0 }))
+init! = App.init(App.default.with_title("task cap"), |_io| Ok({ seen: 0, sum: 0 }))
 
 ## Comfortably past the host's 32 live tasks.
 wanted : U64
@@ -43,8 +43,8 @@ build_ids = |acc, n| if n > wanted acc else build_ids(List.append(acc, n), n + 1
 expect List.len(ids) == wanted
 expect List.fold(ids, 0, |acc, n| acc + n) == expected_sum
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, input, _io| {
 	if input.time.cycle_count == 0 {
 		for id in ids {
 			# Each task parks, so the queue drains over several cycles rather

--- a/test/task_delivery/main.roc
+++ b/test/task_delivery/main.roc
@@ -31,7 +31,7 @@ ChildMsg : [Loaded(Str), Ticked(U64)]
 program = { init!, update!, render! }
 
 init! : App.Init(Model, [])
-init! = App.init(App.default.with_title("task delivery"), |_startup| Ok({ received: 0, count: 0 }))
+init! = App.init(App.default.with_title("task delivery"), |_io| Ok({ received: 0, count: 0 }))
 
 ## What each spawned task is expected to answer, and the distinct power of two
 ## that stands for it. Eight tasks, so a correct run sums to 255 with a count of
@@ -80,8 +80,8 @@ expect score(Child(Ticked(4242))) == 128
 expect score(Child(Ticked(0))) == 0
 expect 1 + 32 + 2 + 4 + 8 + 16 + 64 + 128 == expected_total
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, input, _io| {
 	if input.time.cycle_count == 0 {
 		Task.spawn!(input, || Num(77))
 		Task.spawn!(input, || Text("the quick brown fox"))

--- a/test/udp/main.roc
+++ b/test/udp/main.roc
@@ -92,10 +92,10 @@ program = { init!, update!, render! }
 init! : App.Init(Model, [])
 init! = App.init_for_args(
 	|_args| App.default,
-	|startup| {
-		args = App.args!(startup)
+	|io| {
+		args = io.args!()
 		mode = if List.contains(args, "--udp-expect-timeout") ExpectTimeout else RoundTrip
-		match (Udp.bind!(loopback(0)), Udp.bind!(loopback(0))) {
+		match (io.udp().bind!(loopback(0)), io.udp().bind!(loopback(0))) {
 			(Ok(socket_a), Ok(socket_b)) =>
 				Ok({
 					mode,
@@ -115,8 +115,8 @@ init! = App.init_for_args(
 loopback : U16 -> Udp.Address
 loopback = |port| { ip: "127.0.0.1", port }
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, input, _io| {
 	cycle = input.time.cycle_count
 	started = if model.state == Idle {
 		start!(model, input, cycle)
@@ -270,10 +270,10 @@ reply! = |model, input, local, datagrams, cycle, started| {
 	match List.first(datagrams) {
 		Err(_) => { outcome: FailedWith("a receive answered Ok with no datagrams"), state: model.state }
 		Ok(datagram) =>
-			# The latency assertion, and the reason the start cycle rides along
-			# on `Received` as well as on `ReceiveFailed`. The bytes and the
-			# sender can all be right and the exchange still be several frames
-			# behind where the datagram was ready.
+		# The latency assertion, and the reason the start cycle rides along
+		# on `Received` as well as on `ReceiveFailed`. The bytes and the
+		# sender can all be right and the exchange still be several frames
+		# behind where the datagram was ready.
 			if cycle > started + max_delivery_cycles {
 				{
 					outcome: FailedWith("${U64.to_str(cycle - started)} cycle(s) passed before the batch was delivered"),

--- a/test/virtual_keys/main.roc
+++ b/test/virtual_keys/main.roc
@@ -42,10 +42,10 @@ typed_codepoints = [73, 78, 80, 85, 84, 95, 80, 65, 89, 76, 79, 65, 68, 95, 83, 
 expect Keys.typing(typed) == typed_codepoints
 
 init! : App.Init(Model, [])
-init! = App.init(App.default.with_title("virtual keys"), |_startup| Ok({ outcome: Pending }))
+init! = App.init(App.default.with_title("virtual keys"), |_io| Ok({ outcome: Pending }))
 
-update! : Model, App.Input(Msg) => Try(Model, [Exit(I64), ..])
-update! = |model, program_input| {
+update! : Model, App.Input(Msg), App.Io => Try(Model, [Exit(I64), ..])
+update! = |model, program_input, _io| {
 	input = program_input.devices
 	cycle = program_input.time.cycle_count
 


### PR DESCRIPTION
External host operations were available through ambient module effects. This change supplies `App.Io` to initialization and `update!(model, input, io)`, with receiver calls such as `io.http().send!(request)` and narrow service values that helpers and tasks can retain.

External services now return `PermissionDenied` by default. The launcher flag `--host-caps-allow-all` restores broad access under the existing phase rules and resource limits. This includes files and cwd writes, networking, processes, SQLite, environment, clipboard, stdout/stderr, asset loaders, and capture output. Drawing, input, generated resources, audio playback, clocks, and timers remain available.

Recording starts explicitly through `io.capture()`. Native guards check authority before external work and release transferred arguments on refusal; restricted diagnostics suppress application payloads. Both platform headers, generated ABI, examples, tests, and architecture/API documentation are migrated together. This establishes typed authority boundaries, not OS isolation or per-directory/origin/process confinement.

Validation:

- Full `zig build test` suite passed with the pinned compiler and `ROC_BUILD_OPT=dev`, including all 24 examples, hidden-window runs, service probes, and the Wayland bundle check.
- 313 native tests passed, including denial, lifetime identity, and argument ownership checks.
- Native builds passed for all four supported targets; generated ABI, API documentation, graphical smoke tests, and diff checks passed.
- Permission probes verify default denial, explicit allow-all, task-captured authority, denied test stubs, and suppressed crash payloads.

The optimized `cave_climb` build stalls on both unchanged HEAD and this branch; validation uses the repository's supported dev-backend fallback. Local test runs disabled tag signing only for scratch Git fixtures and excluded Homebrew raylib 5 metadata for the vendored raylib 6 graphical check.
